### PR TITLE
v0.7.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## 0.7.2 (2020-03-03)
+
+- Upgrade `hkdf` to v0.8 ([#13])
+- Move repository to `iqlusioninc/tmkms` ([#10])
+- Upgrade `yubihsm` to v0.32 ([#6])
+
+[#13]: https://github.com/iqlusioninc/tmkms/pull/13
+[#10]: https://github.com/iqlusioninc/tmkms/pull/10
+[#6]: https://github.com/iqlusioninc/tmkms/pull/6
+
 ## 0.7.1 (2020-01-23)
 
 - Remove explicit dependency on the `log` crate

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "abscissa_core",
  "atomicwrites",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.7.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.7.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
-repository  = "https://github.com/iqlusion/tmkms/"
+repository  = "https://github.com/iqlusioninc/tmkms/"
 readme      = "README.md"
 categories  = ["cryptography"]
 keywords    = ["cosmos", "ed25519", "kms", "key-management", "yubihsm"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(warnings, rust_2018_idioms, missing_docs, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/tmkms/0.7.1")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.7.2")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(


### PR DESCRIPTION
- Upgrade `hkdf` to v0.8 ([#13])
- Move repository to `iqlusioninc/tmkms` ([#10])
- Upgrade `yubihsm` to v0.32 ([#6])

[#13]: https://github.com/iqlusioninc/tmkms/pull/13
[#10]: https://github.com/iqlusioninc/tmkms/pull/10
[#6]: https://github.com/iqlusioninc/tmkms/pull/6