### PR TITLE
v0.7.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## 0.7.3 (2020-05-12)
+
+- Bump `tendermint` crate to v0.13 ([#36])
+- Bump `signatory` to v0.19 ([#36])
+- Bump `yubihsm` crate to v0.33 ([#36])
+
+[#36]: https://github.com/iqlusioninc/tmkms/pull/36
+
 ## 0.7.2 (2020-03-03)
 
 - Upgrade `hkdf` to v0.8 ([#13])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "abscissa_core",
  "atomicwrites",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.7.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.7.3" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 repository  = "https://github.com/iqlusioninc/tmkms/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(warnings, rust_2018_idioms, missing_docs, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/tmkms/0.7.2")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.7.3")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(
@@ -21,6 +21,7 @@ pub mod keyring;
 pub mod prelude;
 pub mod rpc;
 pub mod session;
+
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;
 


### PR DESCRIPTION
- Bump `tendermint` crate to v0.13 ([#36])
- Bump `signatory` to v0.19 ([#36])
- Bump `yubihsm` crate to v0.33 ([#36])

[#36]: https://github.com/iqlusioninc/tmkms/pull/36