### PR TITLE
Support for secret connection to tendermint v0.33.x.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1063,18 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "merlin"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.5.1",
+ "zeroize",
+]
 
 [[package]]
 name = "mio"
@@ -1162,6 +1180,16 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "orion"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2dd0d645e94ec75aacc27460cb68438263342f4e4e1aeaf7af67847687e7a8"
+dependencies = [
+ "subtle 2.2.2",
+ "zeroize",
+]
 
 [[package]]
 name = "owning_ref"
@@ -1965,7 +1993,9 @@ dependencies = [
  "hkd32",
  "hkdf",
  "hmac",
+ "merlin",
  "once_cell",
+ "orion",
  "prost-amino",
  "prost-amino-derive",
  "rand 0.7.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,16 +1182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
-name = "orion"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2dd0d645e94ec75aacc27460cb68438263342f4e4e1aeaf7af67847687e7a8"
-dependencies = [
- "subtle 2.2.2",
- "zeroize",
-]
-
-[[package]]
 name = "owning_ref"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,7 +1985,6 @@ dependencies = [
  "hmac",
  "merlin",
  "once_cell",
- "orion",
  "prost-amino",
  "prost-amino-derive",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ gumdrop = "0.7"
 hkd32 = { version = "0.3", default-features = false, features = ["mnemonic"] }
 hkdf = "0.8"
 hmac = "0.7"
+merlin = "2.0.0"
 once_cell = "1.3"
+orion = { version = "0.15.1", default-features = false }
 prost-amino = "0.5"
 prost-amino-derive = "0.5"
 rand = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ hkdf = "0.8"
 hmac = "0.7"
 merlin = "2.0.0"
 once_cell = "1.3"
-orion = { version = "0.15.1", default-features = false }
 prost-amino = "0.5"
 prost-amino-derive = "0.5"
 rand = "0.7"

--- a/src/connection/secret_connection/kdf.rs
+++ b/src/connection/secret_connection/kdf.rs
@@ -12,21 +12,18 @@ pub struct Kdf {
 
     /// Sender's secret
     pub send_secret: [u8; 32],
-
-    /// Challenge to be signed by peer
-    pub challenge: [u8; 32],
 }
 
 impl Kdf {
-    /// Returns recv secret, send secret, challenge as 32 byte arrays
-    pub fn derive_secrets_and_challenge(shared_secret: &[u8; 32], loc_is_lo: bool) -> Self {
+    /// Returns recv secret, send secret as 32 byte arrays
+    pub fn derive_secrets(shared_secret: &[u8; 32], loc_is_lo: bool) -> Self {
         let mut key_material = [0u8; 96];
 
         Hkdf::<Sha256>::new(None, shared_secret)
             .expand(HKDF_INFO, &mut key_material)
             .unwrap();
 
-        let [mut recv_secret, mut send_secret, mut challenge] = [[0u8; 32]; 3];
+        let [mut recv_secret, mut send_secret] = [[0u8; 32]; 2];
 
         if loc_is_lo {
             recv_secret.copy_from_slice(&key_material[0..32]);
@@ -36,13 +33,11 @@ impl Kdf {
             recv_secret.copy_from_slice(&key_material[32..64]);
         }
 
-        challenge.copy_from_slice(&key_material[64..96]);
         key_material.as_mut().zeroize();
 
         Kdf {
             recv_secret,
             send_secret,
-            challenge,
         }
     }
 }
@@ -51,6 +46,5 @@ impl Drop for Kdf {
     fn drop(&mut self) {
         self.recv_secret.zeroize();
         self.send_secret.zeroize();
-        self.challenge.zeroize();
     }
 }


### PR DESCRIPTION
Support for tendermint v0.33.x to resolve a cryptographic error that was a problem with #24 .

- Cause
  - The way to p2p handshake when updating from tendermint v0.32.x to v0.33.x has been changed.
  - The transcript was introduced in handshake.
- Correspond
  - Introduce to transcript using Merlin