### PR TITLE
Support both the Tendermint legacy and v0.33 secret connection handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 dependencies = [
  "byteorder",
- "hex",
  "keccak",
  "rand_core 0.5.1",
  "zeroize 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 dependencies = [
  "byteorder",
+ "hex",
  "keccak",
  "rand_core 0.5.1",
  "zeroize 1.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,6 +1027,18 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "merlin"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.5.1",
+ "zeroize 1.1.0",
+]
 
 [[package]]
 name = "mio"
@@ -1967,6 +1985,7 @@ dependencies = [
  "hkd32",
  "hkdf",
  "hmac",
+ "merlin",
  "once_cell",
  "prost-amino",
  "prost-amino-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ wait-timeout = "0.2"
 x25519-dalek = "0.6"
 yubihsm = { version = "0.32", features = ["setup", "usb"], optional = true }
 zeroize = "1"
-merlin = "2.0.0"
+merlin = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ wait-timeout = "0.2"
 x25519-dalek = "0.6"
 yubihsm = { version = "0.32", features = ["setup", "usb"], optional = true }
 zeroize = "1"
+merlin = "2.0.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -5,7 +5,7 @@ use crate::{
     keyring::SecretKeyEncoding,
     prelude::*,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use signatory::{
     ed25519,
     encoding::{Decode, Encode},
@@ -37,8 +37,20 @@ pub struct ValidatorConfig {
     pub max_height: Option<tendermint::block::Height>,
 
     /// Use Tendermint v0.33 handshake
-    #[serde(default = "handshake_default")]
-    pub v0_33_handshake: bool,
+    #[serde(default = "protocol_default")]
+    pub protocol_version: TendermintVersion,
+}
+
+/// Tendermint secure connection protocol version
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub enum TendermintVersion {
+    /// Legacy V1 SecretConnection Handshake
+    #[serde(rename = "legacy")]
+    Legacy,
+
+    /// Tendermint v0.33+ SecretConnection Handshake
+    #[serde(rename = "v0.33")]
+    V0_33,
 }
 
 impl ValidatorConfig {
@@ -81,6 +93,6 @@ fn reconnect_default() -> bool {
 }
 
 /// Default value for the `ValidatorConfig` reconnect field
-fn handshake_default() -> bool {
-    false
+fn protocol_default() -> TendermintVersion {
+    TendermintVersion::Legacy
 }

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -35,6 +35,10 @@ pub struct ValidatorConfig {
 
     /// Height at which to stop signing
     pub max_height: Option<tendermint::block::Height>,
+
+    /// Use Tendermint v0.33 handshake
+    #[serde(default = "handshake_default")]
+    pub v0_33_handshake: bool,
 }
 
 impl ValidatorConfig {
@@ -74,4 +78,9 @@ impl ValidatorConfig {
 /// Default value for the `ValidatorConfig` reconnect field
 fn reconnect_default() -> bool {
     true
+}
+
+/// Default value for the `ValidatorConfig` reconnect field
+fn handshake_default() -> bool {
+    false
 }

--- a/src/connection/secret_connection.rs
+++ b/src/connection/secret_connection.rs
@@ -136,7 +136,7 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
             ed25519::Signature::from_bytes(remote_signature).map_err(|_| ErrorKind::CryptoError)?;
 
         Ed25519Verifier::from(&remote_pubkey)
-            .verify(&kdf.challenge, &remote_sig)
+            .verify(&sc_mac, &remote_sig)
             .map_err(|_| ErrorKind::CryptoError)?;
 
         // We've authorized.

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -21,6 +21,7 @@ pub fn open_secret_connection(
     secret_key: &ed25519::Seed,
     peer_id: &Option<node::Id>,
     timeout: Option<u16>,
+    v0_33_handshake: bool,
 ) -> Result<SecretConnection<TcpStream>, Error> {
     let signer = Ed25519Signer::from(secret_key);
     let public_key = PublicKey::from(signer.public_key().map_err(|_| Error::from(InvalidKey))?);
@@ -33,7 +34,7 @@ pub fn open_secret_connection(
     socket.set_read_timeout(Some(timeout))?;
     socket.set_write_timeout(Some(timeout))?;
 
-    let connection = SecretConnection::new(socket, &public_key, &signer)?;
+    let connection = SecretConnection::new(socket, &public_key, &signer, v0_33_handshake)?;
     let actual_peer_id = connection.remote_pubkey().peer_id();
 
     // TODO(tarcieri): move this into `SecretConnection::new`

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     chain::{self, state::StateErrorKind},
-    config::ValidatorConfig,
+    config::{TendermintVersion, ValidatorConfig},
     connection::{tcp, unix::UnixConnection, Connection},
     error::{Error, ErrorKind::*},
     prelude::*,
@@ -39,13 +39,18 @@ impl Session {
                 debug!("{}: Connecting to {}...", &config.chain_id, &config.addr);
 
                 let seed = config.load_secret_key()?;
+                let v0_33_handshake = match config.protocol_version {
+                    TendermintVersion::V0_33 => true,
+                    TendermintVersion::Legacy => false,
+                };
+
                 let conn = tcp::open_secret_connection(
                     host,
                     *port,
                     &seed,
                     peer_id,
                     config.timeout,
-                    config.v0_33_handshake,
+                    v0_33_handshake,
                 )?;
 
                 info!(

--- a/src/session.rs
+++ b/src/session.rs
@@ -39,8 +39,14 @@ impl Session {
                 debug!("{}: Connecting to {}...", &config.chain_id, &config.addr);
 
                 let seed = config.load_secret_key()?;
-                let conn =
-                    tcp::open_secret_connection(host, *port, &seed, peer_id, config.timeout)?;
+                let conn = tcp::open_secret_connection(
+                    host,
+                    *port,
+                    &seed,
+                    peer_id,
+                    config.timeout,
+                    config.v0_33_handshake,
+                )?;
 
                 info!(
                     "[{}@{}] connected to validator successfully",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -201,7 +201,9 @@ impl KmsProcess {
                 let socket_cp = sock.try_clone().unwrap();
                 let public_key = secret_connection::PublicKey::from(signer.public_key().unwrap());
 
-                KmsConnection::Tcp(SecretConnection::new(socket_cp, &public_key, &signer).unwrap())
+                KmsConnection::Tcp(
+                    SecretConnection::new(socket_cp, &public_key, &signer, false).unwrap(),
+                )
             }
 
             KmsSocket::UNIX(ref sock) => {

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -29,7 +29,7 @@ chain_id = "cosmoshub-1"
 reconnect = true # true is the default
 secret_key = "path/to/secret_connection.key"
 # max_height = "500000"
-v0_33_handshake = false # false is the default
+protocol_version = "v0.33" # "legacy" is the default
 
 ## Signing provider configuration
 

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -29,6 +29,7 @@ chain_id = "cosmoshub-1"
 reconnect = true # true is the default
 secret_key = "path/to/secret_connection.key"
 # max_height = "500000"
+v0_33_handshake = false # false is the default
 
 ## Signing provider configuration
 


### PR DESCRIPTION
This pull requests adds support for both the Tendermint legacy secret connection handshake that has a malleability vulnerability and the Tendermint v0.33 handshake that uses a transcript hash to defeat malleability.