### PR TITLE
Refactor locking; add more debug locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.5.1",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]

--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -179,10 +179,21 @@ impl State {
 
     /// Sync the current state to disk
     fn sync_to_disk(&self) -> io::Result<()> {
+        debug!(
+            "writing new consensus state to {}: {:?}",
+            self.state_file_path.display(),
+            &self.consensus_state
+        );
+
         let json = serde_json::to_string(&self.consensus_state)?;
 
         AtomicFile::new(&self.state_file_path, OverwriteBehavior::AllowOverwrite)
             .write(|f| f.write_all(json.as_bytes()))?;
+
+        debug!(
+            "successfully wrote new consensus state to {}",
+            self.state_file_path.display(),
+        );
 
         Ok(())
     }


### PR DESCRIPTION
This is an attempt to help address #37.

Based on `strace` logging it appears at least one of the instances of this bug occurred during a lock acquisition happening immediately after persisting the chain state. The system call sequence looked something like this:

```
close(12)   = 0
rmdir("/.../.atomicwrite.InysUcmuRax7") = 0
futex(0x..., FUTEX_WAIT_PRIVATE, 2, NULL
```

Unfortunately this isn't a whole lot to go on, but makes it appear as if it's hanging trying to acquire a lock immediately after persisting the consensus state to disk.

This commit does a couple things to try to narrow down what is happening:

1. Ensures that an exclusive lock to the chain state isn't held while the signing operation is being performed (i.e. while communicating with the HSM). If we were able to update the consensus state, that means the signing operation is authorized, and we no longer need to hold the lock. In the event the signing operation fails, the validator will miss the block in question, but with no risk of double-signing.
2. Adds a significant amount of additional debug logging, particularly around things like lock acquisition and writing to disk. While this commit is unlikely to fix #37 in and of itself, the additional debug logging should be helpful in isolating the problem.