### PR TITLE
v0.8.0-alpha1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+## 0.8.0-alpha1 (2020-06-08)
+
+This release adds initial support for [tendermint v0.33].
+
+- Replace `atomicwrites` dependency with `tempfile` ([#62])
+- Refactor locking; add more debug locking ([#60])
+- Support both the Tendermint legacy and v0.33 secret connection handshake ([#58])
+
+[tendermint v0.33]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v033
+[#62]: https://github.com/iqlusioninc/tmkms/pull/62
+[#60]: https://github.com/iqlusioninc/tmkms/pull/60
+[#58]: https://github.com/iqlusioninc/tmkms/pull/58
+
 ## 0.7.3 (2020-05-12)
 
 - Bump `tendermint` crate to v0.13 ([#36])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.7.3"
+version = "0.8.0-alpha1"
 dependencies = [
  "abscissa_core",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.7.3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.8.0-alpha1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 repository  = "https://github.com/iqlusioninc/tmkms/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(warnings, rust_2018_idioms, missing_docs, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/tmkms/0.7.3")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.8.0-alpha1")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(


### PR DESCRIPTION
This release adds initial support for [tendermint v0.33].

- Replace `atomicwrites` dependency with `tempfile` ([#62])
- Refactor locking; add more debug locking ([#60])
- Support both the Tendermint legacy and v0.33 secret connection handshake ([#58])

[tendermint v0.33]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v033
[#62]: https://github.com/iqlusioninc/tmkms/pull/62
[#60]: https://github.com/iqlusioninc/tmkms/pull/60
[#58]: https://github.com/iqlusioninc/tmkms/pull/58