### PR TITLE
keyring: initial ECDSA support (YubiHSM2 only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,6 +2341,7 @@ dependencies = [
  "pbkdf2",
  "ring",
  "rusb",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tendermint = "0.13"
 thiserror = "1"
 wait-timeout = "0.2"
 x25519-dalek = "0.6"
-yubihsm = { version = "0.33", features = ["setup", "usb"], optional = true }
+yubihsm = { version = "0.33", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
 merlin = "2"
 

--- a/src/commands/yubihsm/keys/list.rs
+++ b/src/commands/yubihsm/keys/list.rs
@@ -1,8 +1,8 @@
 //! List keys inside the YubiHSM2
 
-use crate::{application::app_config, chain, keyring, prelude::*};
+use crate::{application::app_config, chain, keyring, prelude::*, Map};
 use abscissa_core::{Command, Options, Runnable};
-use std::{collections::BTreeMap as Map, path::PathBuf, process};
+use std::{path::PathBuf, process};
 use tendermint::{PublicKey, TendermintKey};
 
 /// The `yubihsm keys list` subcommand

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -34,3 +34,23 @@ pub struct ProviderConfig {
     #[serde(default)]
     pub ledgertm: Vec<LedgerTendermintConfig>,
 }
+
+/// Types of cryptographic keys
+// TODO(tarcieri): move this into a provider-agnostic module
+#[derive(Clone, Debug, Deserialize)]
+pub enum KeyType {
+    /// Account keys
+    #[serde(rename = "account")]
+    Account,
+
+    /// Consensus keys
+    #[serde(rename = "consensus")]
+    Consensus,
+}
+
+impl Default for KeyType {
+    /// Backwards compat for existing configuration files
+    fn default() -> Self {
+        KeyType::Consensus
+    }
+}

--- a/src/config/provider/yubihsm.rs
+++ b/src/config/provider/yubihsm.rs
@@ -1,5 +1,6 @@
 //! Configuration for the `YubiHSM` backend
 
+use super::KeyType;
 use crate::{chain, prelude::*};
 use abscissa_core::secret::{CloneableSecret, DebugSecret, ExposeSecret, Secret};
 use serde::Deserialize;
@@ -117,6 +118,10 @@ pub struct SigningKeyConfig {
 
     /// Signing key ID
     pub key: u16,
+
+    /// Type of key
+    #[serde(default, rename = "type")]
+    pub key_type: KeyType,
 }
 
 /// Default value for `AdapterConfig::Usb { timeout_ms }`

--- a/src/keyring/ecdsa.rs
+++ b/src/keyring/ecdsa.rs
@@ -1,6 +1,6 @@
-//! Ed25519 signing keys
+//! ECDSA keys
 
-pub use signatory::ed25519::{PublicKey, Seed, Signature, PUBLIC_KEY_SIZE};
+pub use signatory::ecdsa::curve::secp256k1::{FixedSignature as Signature, PublicKey};
 
 use crate::{
     error::{Error, ErrorKind::*},
@@ -11,7 +11,7 @@ use signatory::signature;
 use std::sync::Arc;
 use tendermint::TendermintKey;
 
-/// Ed25519 signer
+/// ECDSA signer
 #[derive(Clone)]
 pub struct Signer {
     /// Provider for this signer

--- a/src/keyring/providers/ledgertm.rs
+++ b/src/keyring/providers/ledgertm.rs
@@ -41,7 +41,7 @@ pub fn init(
     );
 
     for chain_id in &ledgertm_configs[0].chain_ids {
-        chain_registry.add_to_keyring(chain_id, signer.clone())?;
+        chain_registry.add_consensus_key(chain_id, signer.clone())?;
     }
 
     Ok(())

--- a/src/keyring/providers/softsign.rs
+++ b/src/keyring/providers/softsign.rs
@@ -105,7 +105,7 @@ pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) ->
     );
 
     for chain_id in &config.chain_ids {
-        chain_registry.add_to_keyring(chain_id, signer.clone())?;
+        chain_registry.add_consensus_key(chain_id, signer.clone())?;
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,6 @@ pub mod session;
 pub mod yubihsm;
 
 pub use crate::application::KmsApplication;
+
+// Map type used within this application
+use std::collections::BTreeMap as Map;

--- a/src/session.rs
+++ b/src/session.rs
@@ -277,7 +277,7 @@ impl Session {
             });
 
         Ok(Response::PublicKey(PubKeyResponse::from(
-            *chain.keyring.default_pubkey()?,
+            *chain.keyring.default_ed25519_pubkey()?,
         )))
     }
 

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -37,7 +37,10 @@ protocol_version = "v0.33" # "legacy" is the default
 [[providers.yubihsm]]
 adapter = { type = "usb" }
 auth = { key = 1, password_file = "/path/to/password" } # or pass raw password as `password`
-keys = [{ chain_ids = ["cosmoshub-1"], key = 1 }]
+keys = [
+    { chain_ids = ["cosmoshub-1"], key = 1 }
+    # { chain_ids = ["cosmoshub-2"], key = 2, type = "account" }
+]
 #serial_number = "0123456789" # identify serial number of a specific YubiHSM to connect to
 #connector_server = { laddr = "tcp://127.0.0.1:12345", cli = { auth_key = 2 } } # run yubihsm-connector compatible server
 


### PR DESCRIPTION
Adds initial support for storing ECDSA keys (i.e. account keys) in per-chain keyrings, initially wired up for the `yubihsm` provider.

There's no code to actually use these keys yet. That will come in follow-up PR(s).