### PR TITLE
Transaction Signer

### DIFF
--- a/.github/workflows/tmkms.yml
+++ b/.github/workflows/tmkms.yml
@@ -1,11 +1,15 @@
 # Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
 
+name: tmkms
+
 on:
   pull_request: {}
   push:
     branches: develop
 
-name: Rust
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   check:
@@ -81,42 +85,11 @@ jobs:
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install libudev-dev
 
-      - name: Run cargo build --features=yubihsm
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
-        with:
-          command: build
-          args: --features=yubihsm --release
-
-      - name: Run cargo build --features=yubihsm-server
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
-        with:
-          command: build
-          args: --features=yubihsm-server --release
-
-      - name: Run cargo build --features=ledgertm
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
-        with:
-          command: build
-          args: --features=ledgertm --release
-
-      # NOTE: softsign backend alone is tested via the test harness job
-      - name: Run cargo build --features=yubihsm-server,ledgertm,softsign
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
-        with:
-          command: build
-          args: --features=yubihsm-server,ledgertm,softsign --release
+      - run: cargo build --no-default-features --features softsign --release
+      - run: cargo build --features=yubihsm --release
+      - run: cargo build --features=yubihsm-server --release
+      - run: cargo build --features=ledgertm --release
+      - run: cargo build --features=yubihsm-server,ledgertm,softsign --release
 
   test:
     name: Test Suite
@@ -159,9 +132,6 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
         with:
           command: test
           args: --all-features -- --test-threads 1
@@ -202,8 +172,6 @@ jobs:
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
-        env:
-          CARGO_INCREMENTAL: 0
         with:
           version: 0.11.0
           args: --all-features -- --test-threads 1
@@ -252,9 +220,6 @@ jobs:
 
       - name: Run cargo build
         uses: actions-rs/cargo@v1
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
         with:
           command: build
           args: --features=softsign --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,8 +38,18 @@ dependencies = [
  "ident_case",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "synstructure",
+]
+
+[[package]]
+name = "abscissa_tokio"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7d1a5aa670b07be20e9457b491e78022d8421d4a39939f8b01a6a16ea85dc"
+dependencies = [
+ "abscissa_core",
+ "tokio",
 ]
 
 [[package]]
@@ -53,48 +63,48 @@ dependencies = [
 
 [[package]]
 name = "adler32"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
+checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
 name = "aead"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e6f2cedd00d6e1d33954c9e4181094b61d87e7e751e5aaed1c249df5ba71ba"
+checksum = "3672ba0d12aaf256aabcdab516ebed87b5cec4b602316d7a3035fac9b7a9567b"
 dependencies = [
- "generic-array 0.14.1",
+ "generic-array 0.14.2",
 ]
 
 [[package]]
 name = "aes"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
  "aes-soft",
  "aesni",
- "block-cipher-trait",
+ "block-cipher",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "opaque-debug",
 ]
 
@@ -105,6 +115,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "anomaly"
+version = "0.2.0"
+source = "git+https://github.com/iqlusioninc/crates.git?branch=develop#77f658ef41911bf6ea6b030b8a9f91039c04351e"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -145,7 +163,21 @@ checksum = "89cb5d814ab2a47fd66d3266e9efccb53ca4c740b7451043b8ffcf9a6208f3f8"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "182617e5bbfe7001b6f2317883506f239c77313171620a04cc11292704d3e171"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -167,16 +199,23 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "bit-set"
@@ -212,21 +251,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
+name = "block-buffer"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
+checksum = "dbcf92448676f82bb7a334c58bbce8b0d43580fb5362a9d608b18879d12a3d31"
 dependencies = [
- "generic-array 0.12.3",
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.14.2",
+]
+
+[[package]]
+name = "block-cipher"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+dependencies = [
+ "generic-array 0.14.2",
 ]
 
 [[package]]
 name = "block-modes"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"
+checksum = "538b66bc25a51ce985544067a9c3e17d426447f468c495dd6cb00040e5953692"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "block-padding",
 ]
 
@@ -288,7 +339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
 dependencies = [
  "stream-cipher",
- "zeroize",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -301,7 +352,7 @@ dependencies = [
  "chacha20",
  "poly1305",
  "stream-cipher",
- "zeroize",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -318,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "chunked_transfer"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b89647f09b9f4c838cb622799b2843e4e13bff64661dab9a0362bb92985addd"
+checksum = "1d29eb15132782371f71da8f947dba48b3717bdb6fa771b9b434d645e40a7193"
 
 [[package]]
 name = "clear_on_drop"
@@ -333,11 +384,11 @@ dependencies = [
 
 [[package]]
 name = "cmac"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4a435124bcc292eba031f1f725d7abacdaf13cbf9f935450e8c45aa9e96cad"
+checksum = "d9f8f8ba8b9640e29213f152015694e78208e601adf91c72b698460633b15715"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "crypto-mac",
  "dbl",
 ]
@@ -364,12 +415,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.12.3",
- "subtle 1.0.0",
+ "generic-array 0.14.2",
+ "subtle",
 ]
 
 [[package]]
@@ -382,7 +433,7 @@ dependencies = [
  "clear_on_drop",
  "digest 0.8.1",
  "rand_core 0.3.1",
- "subtle 2.2.3",
+ "subtle",
 ]
 
 [[package]]
@@ -394,8 +445,8 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "rand_core 0.5.1",
- "subtle 2.2.3",
- "zeroize",
+ "subtle",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -419,7 +470,7 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "strsim",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -430,16 +481,16 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
 name = "dbl"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dc203b75decc900220c4d9838e738d08413e663c26826ba92b669bed1d0795"
+checksum = "2735145c3b9ba15f2d7a3ae8cdafcbc8c98a7bef7f62afe9d08bd99fbf7130de"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.14.2",
 ]
 
 [[package]]
@@ -461,17 +512,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.5.0"
+name = "digest"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7aaf89875554fab12c9d0855d694803a8820b73bfb89cdc96546b6bcab69e4"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.2",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a184c3e1b6bc72ac8de04ef553a238d57067cb3c9e5e9783578bdc2bb3c3283"
 dependencies = [
  "elliptic-curve",
- "generic-array 0.12.3",
  "k256",
  "p256",
  "p384",
- "sha2",
+ "sha2 0.9.0",
  "signature",
 ]
 
@@ -494,7 +553,7 @@ dependencies = [
  "curve25519-dalek 1.2.3",
  "failure",
  "rand_core 0.3.1",
- "sha2",
+ "sha2 0.8.2",
 ]
 
 [[package]]
@@ -505,14 +564,14 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f69be7d1feb7a7a04f158aaf32c7deaa7604e9bd58145525e536438c4e5096"
+checksum = "2298f66754d859f4c099b0e645cfd258d2dfdfd1bac9496fd514d603ff6a5c6b"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.14.2",
  "getrandom",
- "subtle 2.2.3",
- "zeroize",
+ "subtle",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -533,7 +592,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "synstructure",
 ]
 
@@ -634,7 +693,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -701,11 +760,12 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
+checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
 dependencies = [
  "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -742,7 +802,7 @@ checksum = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -772,9 +832,9 @@ checksum = "60bf12c625ed5e96f81609ae4377c34e9fa3e4d1fada392404322daeace511ab"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
+checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
 dependencies = [
  "libc",
 ]
@@ -800,35 +860,35 @@ dependencies = [
 
 [[package]]
 name = "hkd32"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec8449a5d1c7ea34a75bc45e91097d2768dfb056f37fa55a465f3c3ba7c0721"
+checksum = "0124735b175a890d1fb749bad117f2d6474ea5c20dfdfdc3a93ab8c10c192d36"
 dependencies = [
  "getrandom",
  "hmac",
  "lazy_static",
- "sha2",
- "zeroize",
+ "sha2 0.9.0",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hkdf"
-version = "0.8.0"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
+checksum = "e551da9a76291df932270bc2b100d0571588eaa9ef77af7bceee80dba9ace3ad"
 dependencies = [
- "digest 0.8.1",
+ "digest 0.9.0",
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+checksum = "b87b580bd66811cc2324a27f3587de707cacf7525b96dca8122f7493e6cce0da"
 dependencies = [
  "crypto-mac",
- "digest 0.8.1",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -909,6 +969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "input_buffer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
@@ -943,11 +1012,12 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afa79ea8238df7a342756fbf971d4e3ba16f389eaaf730658f3e3f58cf47da4"
+checksum = "c34f5cb67f9625a99c159fc0776e75d2e37f988cdf31c115e9c25225e61d858c"
 dependencies = [
  "elliptic-curve",
+ "subtle",
 ]
 
 [[package]]
@@ -1065,7 +1135,16 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.5.1",
- "zeroize",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
 ]
 
 [[package]]
@@ -1125,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1135,18 +1214,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
@@ -1171,29 +1250,28 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812a058a5afc96a52a8ab6e250325d025254ff030ff737dc5b62576e4e604c42"
+checksum = "a425ecb71515663b2735fd1e65bb638fd134c5ad23857eb197c2f157784476cf"
 dependencies = [
  "elliptic-curve",
 ]
 
 [[package]]
 name = "p384"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aee0d9bdeedaea6cdd47f9281a9f8e1037d3037088b70e2af13c64ce65608ec"
+checksum = "9ae962014118ae1621d13f011e14902223013b1b4151922c3a682a233a967ddb"
 dependencies = [
  "elliptic-curve",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
+checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
 dependencies = [
- "byteorder",
  "crypto-mac",
 ]
 
@@ -1205,22 +1283,22 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75373ff9037d112bb19bc61333a06a159eaeb217660dcfbea7d88e1db823919"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b4b44893d3c370407a1d6a5cfde7c41ae0478e31c516c85f67eb3adc51be6d"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -1264,9 +1342,9 @@ checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afe1bd463b9e9ed51d0e0f0b50b6b146aec855c56fd182bb242388710a9b6de"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -1307,7 +1385,7 @@ dependencies = [
  "itertools",
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "sha2",
+ "sha2 0.8.2",
  "syn 0.14.9",
 ]
 
@@ -1427,9 +1505,9 @@ checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi 0.3.8",
 ]
@@ -1450,12 +1528,12 @@ dependencies = [
 
 [[package]]
 name = "ripemd160"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
+checksum = "7037e00ff78e861f53edd08ea4c4351fbf9b357145fdb791bc2f9a2236a33b45"
 dependencies = [
- "block-buffer",
- "digest 0.8.1",
+ "block-buffer 0.8.0",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -1477,13 +1555,23 @@ dependencies = [
 
 [[package]]
 name = "rusb"
-version = "0.5.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10caa3e5fc7ad1879a679bf16d3304ea10614b8f2f1a1386be4ec942d44062a"
+checksum = "884a9ee2c66cdb5ca6c5243ea91cdbba9865506792c3d175d1ad8de8bb0ea64a"
 dependencies = [
  "bit-set",
  "libc",
  "libusb1-sys",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b5f52edf35045e96b07aa29822bf4ce8495295fd5610270f85ab1f26df7ba5"
+dependencies = [
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1523,7 +1611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9182278ed645df3477a9c27bfee0621c621aa16f6972635f7f795dae3d81070f"
 dependencies = [
  "serde",
- "zeroize",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1544,33 +1632,65 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.111"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.111"
+name = "serde_bytes"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.54"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4c1f6427dbc29329c6288e9e748b8b8e0ea42a0aab733e887fa72c22e965d"
+checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1579,17 +1699,29 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.1.15"
+name = "sha2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6"
+checksum = "72377440080fd008550fe9b441e854e43318db116f90181eef92e9ae9aedab48"
+dependencies = [
+ "block-buffer 0.8.0",
+ "digest 0.9.0",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1607,49 +1739,46 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac23ba234e306afe0d90b1cc809e329622f49a89328aeebe3a6c37a8f8b8a3"
+checksum = "7c20cbcf205bedce2ce5944ab41dd2e10b1dcee2831a0a2a071806761ed6eaba"
 dependencies = [
  "ecdsa",
  "ed25519",
  "getrandom",
- "sha2",
+ "sha2 0.9.0",
  "signature",
- "subtle-encoding",
- "zeroize",
+ "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "signatory-dalek"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4425bf9e35922750008db1353d22b164711a2d5353a6b72dcc79353e33c80b72"
+checksum = "6e3c0e542d70d6d29c3bc3cba306c41679a6f52e42418fd4c9fc4ef9aa37d85e"
 dependencies = [
- "digest 0.8.1",
  "ed25519-dalek",
- "sha2",
  "signatory",
 ]
 
 [[package]]
 name = "signatory-ledger-tm"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df30705b6f2ceded2070548a97cc99e21a07d6ab4a66d8c42ce1d1e15a6284b9"
+checksum = "4c29411cdc6a0068363eb142f0fda7d4173e61473846a02f17ce8e8abf6b36ff"
 dependencies = [
  "byteorder",
  "ledger",
- "matches",
  "signatory",
  "thiserror",
 ]
 
 [[package]]
 name = "signatory-secp256k1"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08548248a4b10eb37a1976f2e821f6220ce3efea3cda17321c1f0d564216ba"
+checksum = "02a50b18b66b81b859f8ee57b0e85658e1777fe2683ac37b7e756380f0a28f6e"
 dependencies = [
  "secp256k1",
  "signatory",
@@ -1658,11 +1787,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685e1c5b65c6cc6fd0eb9ba63c6cfb8431f7f9c7e078c626f23f50e13fa378d7"
+checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
 dependencies = [
- "digest 0.8.1",
+ "digest 0.9.0",
  "signature_derive",
 ]
 
@@ -1674,7 +1803,7 @@ checksum = "b0656c180103507cca4b82519908e813225b2f6b90b2bd59ee119f46155ae872"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "synstructure",
 ]
 
@@ -1692,12 +1821,6 @@ checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 dependencies = [
  "maybe-uninit",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "socket2"
@@ -1724,12 +1847,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
+name = "stdtx"
+version = "0.1.0"
+source = "git+https://github.com/iqlusioninc/crates.git?branch=develop#77f658ef41911bf6ea6b030b8a9f91039c04351e"
+dependencies = [
+ "anomaly 0.2.0 (git+https://github.com/iqlusioninc/crates.git?branch=develop)",
+ "ecdsa",
+ "prost-amino",
+ "prost-amino-derive",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2 0.9.0",
+ "subtle-encoding 0.5.1 (git+https://github.com/iqlusioninc/crates.git?branch=develop)",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "stream-cipher"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f8ed9974042b8c3672ff3030a69fcc03b74c47c3d1ecb7755e8a3626011e88"
 dependencies = [
- "generic-array 0.14.1",
+ "generic-array 0.14.2",
 ]
 
 [[package]]
@@ -1740,12 +1881,6 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-
-[[package]]
-name = "subtle"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
@@ -1753,10 +1888,18 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 [[package]]
 name = "subtle-encoding"
 version = "0.5.1"
+source = "git+https://github.com/iqlusioninc/crates.git?branch=develop#77f658ef41911bf6ea6b030b8a9f91039c04351e"
+dependencies = [
+ "zeroize 1.1.0 (git+https://github.com/iqlusioninc/crates.git?branch=develop)",
+]
+
+[[package]]
+name = "subtle-encoding"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
- "zeroize",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1772,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -1789,7 +1932,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "unicode-xid 0.2.0",
 ]
 
@@ -1810,9 +1953,9 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tar"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c058ad0bd6ccb84faa24cc44d4fc99bee8a5d7ba9ff33aa4d993122d1aeeac2"
+checksum = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
 dependencies = [
  "filetime",
  "libc",
@@ -1837,34 +1980,51 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c4e34977942ecf2e9f57beee3e34231667a6f5363358cc9e4fbd2ce4bf6bad"
+source = "git+https://github.com/informalsystems/tendermint-rs#e2335c40b1c5e1f7d47ee28ae5f9cc679730b7a2"
 dependencies = [
- "anomaly",
+ "anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
  "bytes",
  "chrono",
  "futures",
- "getrandom",
- "http",
- "hyper",
  "once_cell",
  "prost-amino",
  "prost-amino-derive",
  "ripemd160",
  "serde",
+ "serde_bytes",
  "serde_json",
- "sha2",
+ "serde_repr",
+ "sha2 0.9.0",
  "signatory",
  "signatory-dalek",
  "signatory-secp256k1",
- "subtle 2.2.3",
- "subtle-encoding",
+ "subtle",
+ "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tai64",
  "thiserror",
  "toml",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.1.0"
+source = "git+https://github.com/informalsystems/tendermint-rs#e2335c40b1c5e1f7d47ee28ae5f9cc679730b7a2"
+dependencies = [
+ "async-tungstenite",
+ "bytes",
+ "futures",
+ "getrandom",
+ "http",
+ "hyper",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "tendermint",
+ "thiserror",
+ "tokio",
  "uuid",
- "zeroize",
 ]
 
 [[package]]
@@ -1878,22 +2038,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -1929,10 +2089,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+
+[[package]]
 name = "tmkms"
 version = "0.8.0-alpha1"
 dependencies = [
  "abscissa_core",
+ "abscissa_tokio",
  "bytes",
  "chacha20poly1305",
  "chrono",
@@ -1940,7 +2107,8 @@ dependencies = [
  "gumdrop",
  "hkd32",
  "hkdf",
- "hmac",
+ "hyper",
+ "k256",
  "merlin",
  "once_cell",
  "prost-amino",
@@ -1949,20 +2117,22 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.0",
  "signatory",
  "signatory-dalek",
  "signatory-ledger-tm",
  "signatory-secp256k1",
- "subtle 2.2.3",
- "subtle-encoding",
+ "stdtx",
+ "subtle",
+ "subtle-encoding 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "tendermint",
+ "tendermint-rpc",
  "thiserror",
  "wait-timeout",
  "x25519-dalek",
  "yubihsm",
- "zeroize",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1980,6 +2150,18 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "slab",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2030,7 +2212,7 @@ checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -2065,7 +2247,7 @@ dependencies = [
  "matchers",
  "owning_ref",
  "regex",
- "smallvec 0.6.13",
+ "smallvec",
  "tracing-core",
  "tracing-log",
 ]
@@ -2075,6 +2257,25 @@ name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+
+[[package]]
+name = "tungstenite"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "input_buffer",
+ "log",
+ "rand",
+ "sha-1",
+ "url",
+ "utf-8",
+]
 
 [[package]]
 name = "typenum"
@@ -2093,11 +2294,11 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
 dependencies = [
- "smallvec 1.4.0",
+ "tinyvec",
 ]
 
 [[package]]
@@ -2118,8 +2319,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.14.1",
- "subtle 2.2.3",
+ "generic-array 0.14.2",
+ "subtle",
 ]
 
 [[package]]
@@ -2140,6 +2341,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+
+[[package]]
 name = "uuid"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,9 +2357,15 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d1e41d56121e07f1e223db0a4def204e45c85425f6a16d462fd07c8d10d74c"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "void"
@@ -2206,7 +2419,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "wasm-bindgen-shared",
 ]
 
@@ -2228,7 +2441,7 @@ checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2310,7 +2523,7 @@ checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
  "curve25519-dalek 2.1.0",
  "rand_core 0.5.1",
- "zeroize",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2325,11 +2538,10 @@ dependencies = [
 [[package]]
 name = "yubihsm"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d457388954f4a8c83b245d6ad6007956a1108aea207f9c40e4bc789dfe71aee"
+source = "git+https://github.com/iqlusioninc/yubihsm.rs.git?branch=develop#d1cade201c516eed35eb91858a9962e17e3a9576"
 dependencies = [
  "aes",
- "anomaly",
+ "anomaly 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags",
  "block-modes",
  "chrono",
@@ -2344,15 +2556,20 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.0",
  "signatory",
  "signature",
- "subtle 2.2.3",
+ "subtle",
  "thiserror",
  "tiny_http",
  "uuid",
- "zeroize",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.1.0"
+source = "git+https://github.com/iqlusioninc/crates.git?branch=develop#77f658ef41911bf6ea6b030b8a9f91039c04351e"
 
 [[package]]
 name = "zeroize"
@@ -2371,6 +2588,6 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
- "syn 1.0.30",
+ "syn 1.0.31",
  "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,16 @@ edition     = "2018"
 
 [dependencies]
 abscissa_core = "0.5"
+abscissa_tokio = "0.5"
 bytes = "0.5"
 chacha20poly1305 = "0.5"
 chrono = "0.4"
 getrandom = "0.1"
 gumdrop = "0.7"
-hkd32 = { version = "0.3", default-features = false, features = ["mnemonic"] }
-hkdf = "0.8"
-hmac = "0.7"
+hkd32 = { version = "0.4", default-features = false, features = ["mnemonic"] }
+hkdf = "0.9.0-alpha.0"
+hyper = { version = "0.13", optional = true }
+k256 = "0.3"
 once_cell = "1.3"
 prost-amino = "0.5"
 prost-amino-derive = "0.5"
@@ -27,15 +29,17 @@ rand = "0.7"
 rpassword = { version = "4", optional = true }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
-sha2 = "0.8"
-signatory = { version = "0.19", features = ["ecdsa", "ed25519", "encoding"] }
-signatory-dalek = "0.19"
-signatory-secp256k1 = "0.19"
-signatory-ledger-tm = { version = "0.19", optional = true }
+sha2 = "0.9"
+signatory = { version = "0.20", features = ["ecdsa", "ed25519", "encoding"] }
+signatory-dalek = "0.20"
+signatory-secp256k1 = "0.20"
+signatory-ledger-tm = { version = "0.20", optional = true }
+stdtx = { version = "0.1", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
 tendermint = "0.13"
+tendermint-rpc = { version = "0.1.0", optional = true }
 thiserror = "1"
 wait-timeout = "0.2"
 x25519-dalek = "0.6"
@@ -51,9 +55,10 @@ version = "0.5"
 features = ["testing"]
 
 [features]
-default = []
-softsign = []
+default = ["tx_signer"]
 ledgertm = ["signatory-ledger-tm"]
+softsign = []
+tx_signer = ["hyper", "stdtx", "tendermint-rpc"]
 yubihsm-mock = ["yubihsm/mockhsm"]
 yubihsm-server = ["yubihsm/http-server", "rpassword"]
 
@@ -63,3 +68,9 @@ overflow-checks = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[patch.crates-io]
+stdtx = { git = "https://github.com/iqlusioninc/crates.git", branch = "develop" }
+tendermint = { git = "https://github.com/informalsystems/tendermint-rs" }
+tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs" }
+yubihsm = { git = "https://github.com/iqlusioninc/yubihsm.rs.git", branch = "develop" }

--- a/src/application.rs
+++ b/src/application.rs
@@ -78,7 +78,12 @@ impl Application for KmsApplication {
     /// beyond the default ones provided by the framework, this is the place
     /// to do so.
     fn register_components(&mut self, command: &Self::Cmd) -> Result<(), FrameworkError> {
-        let components = self.framework_components(command)?;
+        #[allow(unused_mut)]
+        let mut components = self.framework_components(command)?;
+
+        #[cfg(feature = "tx_signer")]
+        components.push(Box::new(abscissa_tokio::TokioComponent::new()?));
+
         self.state.components.register(components)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,9 +2,15 @@
 
 pub mod chain;
 pub mod provider;
+#[cfg(feature = "tx_signer")]
+pub mod tx_signer;
 pub mod validator;
 
 pub use self::validator::*;
+
+#[cfg(feature = "tx_signer")]
+pub use self::tx_signer::TxSignerConfig;
+
 use self::{chain::ChainConfig, provider::ProviderConfig};
 use serde::Deserialize;
 
@@ -22,10 +28,15 @@ pub struct KmsConfig {
     #[serde(default)]
     pub chain: Vec<ChainConfig>,
 
+    /// Cryptographic signature provider configuration
+    pub providers: ProviderConfig,
+
     /// Addresses of validator nodes
     #[serde(default)]
     pub validator: Vec<ValidatorConfig>,
 
-    /// Cryptographic signature provider configuration
-    pub providers: ProviderConfig,
+    /// Transaction signer config (for e.g. oracles)
+    #[cfg(feature = "tx_signer")]
+    #[serde(default)]
+    pub tx_signer: Vec<TxSignerConfig>,
 }

--- a/src/config/tx_signer.rs
+++ b/src/config/tx_signer.rs
@@ -1,0 +1,76 @@
+//! Transaction signer configuration
+
+use hyper::http::Uri;
+use serde::{de, Deserialize};
+use std::path::PathBuf;
+use stdtx::{Address, TypeName};
+use tendermint::{chain, net};
+
+/// Transaction signer (`[tx_signer]`) configuration
+#[derive(Clone, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct TxSignerConfig {
+    /// Chain ID of the Tendermint network this validator is part of
+    pub chain_id: chain::Id,
+
+    /// Path to a `StdTx` transaction schema definition (TOML).
+    ///
+    /// See example TERRA_SCHEMA at <https://docs.rs/stdtx#usage>
+    pub schema: PathBuf,
+
+    /// Account number corresponding to the provided public key
+    pub account_number: u64,
+
+    /// Account address associated with the intended signing key and account
+    /// number.
+    ///
+    /// This must match one of the keys in the keyring!
+    pub account_address: Address,
+
+    /// Access control list (ACL) for what transactions can be signed
+    pub acl: TxAcl,
+
+    /// Service to connect to which provides transactions to be signed
+    pub source: TxSource,
+
+    /// Tendermint RPC host where transactions should be submitted once signed
+    pub rpc_addr: net::Address,
+
+    /// JSON file where the current sequence number is persisted
+    pub seq_file: PathBuf,
+}
+
+/// Transaction Access Control Lists
+#[derive(Clone, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct TxAcl {
+    /// Transaction message types
+    #[serde(default)]
+    pub msg_type: Vec<TypeName>,
+}
+
+/// Transaction source configuration
+#[derive(Clone, Deserialize, Debug)]
+#[serde(tag = "protocol")]
+pub enum TxSource {
+    /// Request transactions to be signed from the given JSON/HTTP(S) endpoint
+    #[serde(rename = "jsonrpc")]
+    JsonRpc {
+        /// Interval at which to poll the server (in seconds)
+        poll_secs: u64,
+
+        /// URI to request from the JSONRPC server
+        #[serde(deserialize_with = "deserialize_uri")]
+        uri: Uri,
+    },
+}
+
+/// Parse a [`Uri`] from the configuration
+fn deserialize_uri<'de, D>(deserializer: D) -> Result<Uri, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    String::deserialize(deserializer)?
+        .parse()
+        .map_err(de::Error::custom)
+}

--- a/src/keyring/format.rs
+++ b/src/keyring/format.rs
@@ -1,6 +1,7 @@
 //! Chain-specific key configuration
 
 use serde::Deserialize;
+use subtle_encoding::bech32;
 use tendermint::TendermintKey;
 
 /// Options for how keys for this chain are represented
@@ -30,7 +31,9 @@ impl Format {
                 account_key_prefix,
                 consensus_key_prefix,
             } => match public_key {
-                TendermintKey::AccountKey(pk) => pk.to_bech32(account_key_prefix),
+                TendermintKey::AccountKey(pk) => {
+                    bech32::encode(account_key_prefix, tendermint::account::Id::from(pk))
+                }
                 TendermintKey::ConsensusKey(pk) => pk.to_bech32(consensus_key_prefix),
             },
             Format::Hex => public_key.to_hex(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! Tendermint Key Management System
 
-#![forbid(unsafe_code)]
-#![deny(warnings, rust_2018_idioms, missing_docs, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/tmkms/0.8.0-alpha1")]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(
@@ -21,6 +21,9 @@ pub mod keyring;
 pub mod prelude;
 pub mod rpc;
 pub mod session;
+
+#[cfg(feature = "tx_signer")]
+pub mod tx_signer;
 
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -44,8 +44,8 @@ pub trait TendermintRequest: SignableMsg {
 
 fn compute_prefix(name: &str) -> Vec<u8> {
     let mut sh = Sha256::default();
-    sh.input(name.as_bytes());
-    let output = sh.result();
+    sh.update(name.as_bytes());
+    let output = sh.finalize();
 
     let prefix_bytes: Vec<u8> = output
         .iter()

--- a/src/session.rs
+++ b/src/session.rs
@@ -146,7 +146,7 @@ impl Session {
         self.check_max_height(&mut request)?;
 
         debug!(
-            "[{}@{}] acquiring chain registry (for signing)",
+            "[{}@{}] acquiring chain registry",
             &self.config.chain_id, &self.config.addr
         );
 

--- a/src/tx_signer.rs
+++ b/src/tx_signer.rs
@@ -1,0 +1,231 @@
+//! Transaction signer.
+//!
+//! Connects to a remote service to obtain transactions to sign, and if they
+//! meet a prescribed policy, signs them.
+
+pub mod jsonrpc;
+pub mod request;
+pub mod sequence_file;
+
+pub use request::TxSigningRequest;
+
+use crate::{
+    chain,
+    config::tx_signer::{TxAcl, TxSignerConfig, TxSource},
+    error::{Error, ErrorKind},
+    prelude::*,
+};
+use abscissa_tokio::tokio;
+use sequence_file::SequenceFile;
+use std::{collections::BTreeSet as Set, process, time::Duration};
+use stdtx::{StdSignature, StdTx};
+
+/// Frequency at which to retry after failures
+pub const RETRY_DELAY: Duration = Duration::from_secs(5);
+
+/// Transaction signer
+pub struct TxSigner {
+    /// Chain ID of the Tendermint network this validator is part of
+    chain_id: tendermint::chain::Id,
+
+    /// Transaction builder
+    tx_builder: stdtx::Builder,
+
+    /// Access Control List for authorized transaaction types to sign
+    acl: TxAcl,
+
+    /// Account address
+    address: stdtx::Address,
+
+    /// Transaction source (JSONRPC)
+    // TODO(tarcieri): gRPC
+    source: jsonrpc::Client,
+
+    /// Tendermint RPC client
+    // TODO(tarcieri): use RPC client
+    #[allow(dead_code)]
+    tendermint_rpc: tendermint_rpc::Client,
+
+    /// Sequence file
+    seq_file: SequenceFile,
+}
+
+impl TxSigner {
+    /// Create a new transaction signer
+    pub fn new(config: &TxSignerConfig) -> Result<Self, Error> {
+        let schema = stdtx::Schema::load_toml(&config.schema).unwrap_or_else(|e| {
+            status_err!(
+                "couldn't read TX schema from `{}`: {}",
+                config.schema.display(),
+                e
+            );
+            process::exit(1);
+        });
+
+        let tx_builder =
+            stdtx::Builder::new(schema, config.chain_id.to_string(), config.account_number);
+
+        let source = match &config.source {
+            TxSource::JsonRpc { uri, poll_secs } => {
+                jsonrpc::Client::new(uri.clone(), Duration::from_secs(*poll_secs))
+            }
+        };
+
+        let tendermint_rpc = tendermint_rpc::Client::new(config.rpc_addr.clone());
+
+        let seq_file = SequenceFile::open(&config.seq_file)?;
+
+        Ok(Self {
+            chain_id: config.chain_id,
+            tx_builder,
+            acl: config.acl.clone(),
+            address: config.account_address,
+            source,
+            tendermint_rpc,
+            seq_file,
+        })
+    }
+
+    /// Run the transaction signer
+    pub async fn run(&mut self) {
+        let mut poll_interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + self.source.poll_interval(),
+            self.source.poll_interval(),
+        );
+
+        loop {
+            // Request batch of transactions from source
+            let tx_reqs = match self.source.request().await {
+                Ok(req) => req,
+                Err(e) => {
+                    error!("couldn't fetch TXes from `{}`: {}", self.source.uri(), e);
+                    tokio::time::delay_for(RETRY_DELAY).await;
+                    continue;
+                }
+            };
+
+            // Process batch of transactions
+            for req in tx_reqs.into_iter() {
+                // Sign transaction
+                let signed_tx = match self.sign_tx(req) {
+                    Ok(tx) => tx,
+                    Err(e) => {
+                        error!("[{}] error signing transaction: {}", &self.chain_id, e);
+                        continue;
+                    }
+                };
+
+                // Broadcast transaction to Tendermint P2P network via RPC
+                if let Err(e) = self.broadcast_tx(signed_tx).await {
+                    error!("[{}] {}", &self.chain_id, e);
+                    continue;
+                }
+
+                // Increment value in state file
+                if let Err(e) = self.seq_file.increment() {
+                    status_err!("couldn't persist sequence file: {}", e);
+                }
+            }
+
+            poll_interval.tick().await;
+        }
+    }
+
+    /// Sign the given transaction signing request
+    pub fn sign_tx(&self, req: TxSigningRequest) -> Result<StdTx, Error> {
+        if self.chain_id.as_str() != req.chain_id {
+            fail!(
+                ErrorKind::ChainIdError,
+                "expected `{}`, got `{}`",
+                self.chain_id,
+                req.chain_id
+            );
+        }
+
+        // TODO(tarcieri): check fee
+        // if req.fee != ...
+
+        let mut msgs = vec![];
+        let mut msg_types = Set::new();
+
+        for msg_value in req.msgs {
+            let msg = stdtx::Msg::from_json_value(self.tx_builder.schema(), msg_value)?;
+            msg_types.insert(msg.type_name().clone());
+            msgs.push(msg);
+        }
+
+        // Ensure message types are authorized in the ACL
+        for msg_type in &msg_types {
+            if !self.acl.msg_type.contains(&msg_type) {
+                fail!(
+                    ErrorKind::AccessError,
+                    "unauthorized request to sign `{}` message",
+                    msg_type
+                );
+            }
+        }
+
+        let sign_msg = self.tx_builder.create_sign_msg(
+            self.seq_file.sequence(),
+            &req.fee,
+            &req.memo,
+            msgs.as_slice(),
+        );
+
+        debug!("[{}] acquiring chain registry", &self.chain_id);
+
+        let registry = chain::REGISTRY.get();
+
+        debug!(
+            "[{}] acquiring read-only shared lock on chain",
+            &self.chain_id
+        );
+
+        let chain = registry.get_chain(&self.chain_id).unwrap_or_else(|| {
+            panic!("chain '{}' missing from registry!", &self.chain_id);
+        });
+
+        debug!("[{}] performing signature", &self.chain_id);
+
+        let account_id = tendermint::account::Id::new(self.address.0);
+
+        let signature =
+            StdSignature::from(chain.keyring.sign_ecdsa(account_id, sign_msg.as_bytes())?);
+
+        let msg_type_info = msg_types
+            .iter()
+            .map(|ty| ty.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        info!(
+            "[{}] signed `{}` TX with {}",
+            self.chain_id,
+            msg_type_info,
+            self.address
+                .to_bech32(self.tx_builder.schema().acc_prefix())
+        );
+
+        Ok(StdTx::new(&msgs, req.fee, vec![signature], req.memo))
+    }
+
+    /// Broadcast signed transaction to the Tendermint P2P network via RPC
+    pub async fn broadcast_tx(&mut self, tx: StdTx) -> Result<(), Error> {
+        let amino_tx = tendermint::abci::Transaction::new(
+            tx.to_amino_bytes(self.tx_builder.schema().namespace()),
+        );
+
+        let response = self.tendermint_rpc.broadcast_tx_sync(amino_tx).await?;
+
+        if response.code.is_ok() {
+            info!("[{}] broadcast TX: {:?}", self.chain_id, response);
+            Ok(())
+        } else {
+            fail!(
+                ErrorKind::TendermintError,
+                "error broadcasting TX: {:?}",
+                response
+            );
+        }
+    }
+}

--- a/src/tx_signer/jsonrpc.rs
+++ b/src/tx_signer/jsonrpc.rs
@@ -1,0 +1,95 @@
+//! Support for fetching transaction signing requests via a simple JSONRPC
+//! protocol.
+
+use super::request::TxSigningRequest;
+use crate::{
+    error::{Error, ErrorKind},
+    prelude::*,
+};
+use bytes::Buf;
+use hyper::http::{header, Uri};
+use serde::Deserialize;
+use std::time::Duration;
+
+/// Transaction builder JSONRPC client.
+#[derive(Clone, Debug)]
+pub struct Client {
+    /// URL to fetch JSON document from
+    uri: Uri,
+
+    /// Interval at which we poll the source for new transactions
+    poll_interval: Duration,
+}
+
+impl Client {
+    /// Create a new JSONRPC client.
+    pub fn new(uri: Uri, poll_interval: Duration) -> Self {
+        Self { uri, poll_interval }
+    }
+
+    /// Get the URI this client is requesting
+    pub fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    /// Get the [`Duration`] to sleep after a successful request
+    pub fn poll_interval(&self) -> Duration {
+        self.poll_interval
+    }
+
+    /// Request transactions to be signed from the transaction service
+    pub async fn request(&self) -> Result<Vec<TxSigningRequest>, Error> {
+        let mut request = hyper::Request::post(&self.uri).body(hyper::Body::empty())?;
+
+        {
+            let headers = request.headers_mut();
+            headers.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
+            headers.insert(
+                header::USER_AGENT,
+                format!("tmkms/{}", env!("CARGO_PKG_VERSION"))
+                    .parse()
+                    .unwrap(),
+            );
+        }
+
+        let http_client = hyper::Client::builder().build_http();
+        let response = http_client.request(request).await?;
+        let response_body = hyper::body::aggregate(response.into_body()).await?;
+        let response_json = serde_json::from_slice::<Response>(response_body.bytes())?;
+
+        match response_json.status {
+            Status::Ok => Ok(response_json.tx),
+            Status::Error => fail!(
+                ErrorKind::HttpError,
+                "JSONRPC error: {}",
+                response_json.msg.unwrap_or_default()
+            ),
+        }
+    }
+}
+
+/// JSONRPC responses from the transaction builder service
+#[derive(Clone, Debug, Deserialize)]
+pub struct Response {
+    /// Response status
+    pub status: Status,
+
+    /// Optional response message
+    pub msg: Option<String>,
+
+    /// Transaction signing requests
+    #[serde(default)]
+    pub tx: Vec<TxSigningRequest>,
+}
+
+/// JSONRPC response status
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq)]
+pub enum Status {
+    /// Success
+    #[serde(rename = "ok")]
+    Ok,
+
+    /// Error
+    #[serde(rename = "error")]
+    Error,
+}

--- a/src/tx_signer/request.rs
+++ b/src/tx_signer/request.rs
@@ -1,0 +1,21 @@
+//! Transaction signing requests
+
+use serde::Deserialize;
+use stdtx::StdFee;
+
+/// Request to sign a transaction request
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TxSigningRequest {
+    /// Requested chain ID
+    pub chain_id: String,
+
+    /// Fee
+    pub fee: StdFee,
+
+    /// Memo
+    pub memo: String,
+
+    /// Transaction messages to be signed
+    pub msgs: Vec<serde_json::Value>,
+}

--- a/src/tx_signer/sequence_file.rs
+++ b/src/tx_signer/sequence_file.rs
@@ -1,0 +1,97 @@
+//! File for storing the current transaction sequence
+
+// TODO(tarcieri): replace this with querying the on-chain sequence number
+
+use crate::{
+    error::{Error, ErrorKind},
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+use tempfile::NamedTempFile;
+
+/// Sequence file: persists the current sequence number for a given account
+#[derive(Clone, Debug, Default)]
+pub struct SequenceFile {
+    /// Path to the sequence file
+    path: PathBuf,
+
+    /// Current state
+    state: State,
+}
+
+/// Sequence file state value
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct State {
+    /// Current sequence value
+    sequence: u64,
+}
+
+impl SequenceFile {
+    /// Open the state file and load its contents
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
+        match fs::read_to_string(path.as_ref()) {
+            Ok(state_json) => {
+                let state = serde_json::from_str(&state_json).map_err(|e| {
+                    format_err!(
+                        ErrorKind::ParseError,
+                        "error parsing sequence file `{}`: {}",
+                        path.as_ref().display(),
+                        e
+                    )
+                })?;
+
+                Ok(Self {
+                    path: path.as_ref().to_owned(),
+                    state,
+                })
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Self::create(path.as_ref()),
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+
+    /// Get the current sequence value
+    pub fn sequence(&self) -> u64 {
+        self.state.sequence
+    }
+
+    /// Increment the sequence value and persist it to disk
+    pub fn increment(&mut self) -> Result<u64, Error> {
+        self.state.sequence = self.state.sequence.checked_add(1).unwrap();
+
+        // TODO(tarcieri): rollback if we can't persist?
+        self.sync_to_disk()?;
+
+        Ok(self.sequence())
+    }
+
+    /// Create an initial sequence file on disk
+    fn create(path: &Path) -> Result<Self, Error> {
+        let sequence_file = Self {
+            path: path.to_owned(),
+            state: State::default(),
+        };
+        sequence_file.sync_to_disk()?;
+        Ok(sequence_file)
+    }
+
+    /// Sync the current state to disk
+    fn sync_to_disk(&self) -> io::Result<()> {
+        let parent_dir = self.path.parent().unwrap_or_else(|| {
+            panic!("state file cannot be root directory");
+        });
+
+        let json = serde_json::to_string(&self.state)?;
+
+        let mut state_file = NamedTempFile::new_in(parent_dir)?;
+        state_file.write_all(json.as_bytes())?;
+        state_file.persist(&self.path)?;
+
+        Ok(())
+    }
+}

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -39,14 +39,14 @@ adapter = { type = "usb" }
 auth = { key = 1, password_file = "/path/to/password" } # or pass raw password as `password`
 keys = [
     { chain_ids = ["cosmoshub-1"], key = 1 }
-    # { chain_ids = ["cosmoshub-2"], key = 2, type = "account" }
+    # { chain_ids = ["irishub"], key = 2, type = "account" }
 ]
 #serial_number = "0123456789" # identify serial number of a specific YubiHSM to connect to
 #connector_server = { laddr = "tcp://127.0.0.1:12345", cli = { auth_key = 2 } } # run yubihsm-connector compatible server
 
 # enable the `ledger` feature to use this backend
-[[providers.ledgertm]]
-chain_ids = ["cosmoshub-1"]
+#[[providers.ledgertm]]
+#chain_ids = ["cosmoshub-1"]
 
 # enable the `softsign` feature to use this backend
 # note: the `yubihsm` or `ledger` backends are recommended
@@ -54,3 +54,16 @@ chain_ids = ["cosmoshub-1"]
 #chain_ids = ["cosmoshub-1"]
 #key_format = "base64"
 #path = "path/to/signing.key"
+
+## (Optional) Transaction signer configuration
+
+# example transaction signer: sign StdTx-strucutred transactions with a KMS-managed key
+# [[tx_signer]]
+# chain_id = "irishub"
+# schema = "iris_tx_schema.toml" # See example TERRA_SCHEMA at https://docs.rs/stdtx#usage
+# account_number = 101072
+# account_address = "iap1qqqsyqcyq5rqwzqfpg9scrgwpugpzysnfxh53h" # must be in the keyring for this chain
+# acl = { msg_type = ["oracle/MsgExchangeRatePrevote", "oracle/MsgExchangeRateVote"] }
+# source = { protocol = "jsonrpc", poll_secs = 30, uri = "http://127.0.0.1:23456" }
+# rpc_addr = "tcp://127.0.0.1:26657"
+# seq_file = "irishub-account-seq.json"


### PR DESCRIPTION
Implements #54

This adds a transaction signer based on the `stdtx` crate which presently polls a remote JSONRPC endpoint looking for transactions to sign, parses them, signs them, and broadcasts them via RPC.

Additionally updates `tmkms yubihsm keys list` to display the Bech32-serialized addresses (computed from a compressed secp256k1 curve point) for ECDSA K-256 keys.