### PR TITLE
Bump `tendermint`(-rpc) to v0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,8 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.13.0"
-source = "git+https://github.com/informalsystems/tendermint-rs#81f7eb3aac9aac24ac83a02ba7e91ac477bf57fc"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0124960f45f95316351061cd280a3df074160e44cb3d4ef28f64069fac6c8c"
 dependencies = [
  "anomaly",
  "async-trait",
@@ -2036,8 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.1.0"
-source = "git+https://github.com/informalsystems/tendermint-rs#81f7eb3aac9aac24ac83a02ba7e91ac477bf57fc"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e00ce8b37ce16abab8f5cb65bfa01c43db340f166b6288d73c44790fc51e8139"
 dependencies = [
  "async-tungstenite",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ stdtx = { version = "0.2", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = "0.13"
-tendermint-rpc = { version = "0.1.0", optional = true, features = ["client"] }
+tendermint = "0.14"
+tendermint-rpc = { version = "0.14.0", optional = true, features = ["client"] }
 thiserror = "1"
 wait-timeout = "0.2"
 x25519-dalek = "0.6"
@@ -68,7 +68,3 @@ overflow-checks = true
 
 [package.metadata.docs.rs]
 all-features = true
-
-[patch.crates-io]
-tendermint = { git = "https://github.com/informalsystems/tendermint-rs" }
-tendermint-rpc = { git = "https://github.com/informalsystems/tendermint-rs" }


### PR DESCRIPTION
Uses the latest releases of the `tendermint` and `tendermint-rpc` crates:

https://github.com/informalsystems/tendermint-rs/pull/347