### PR TITLE
tx_signer: block-based polling interval

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -47,16 +47,14 @@ fn compute_prefix(name: &str) -> Vec<u8> {
     sh.update(name.as_bytes());
     let output = sh.finalize();
 
-    let prefix_bytes: Vec<u8> = output
+    output
         .iter()
         .filter(|&x| *x != 0x00)
         .skip(3)
         .filter(|&x| *x != 0x00)
         .cloned()
         .take(4)
-        .collect();
-
-    prefix_bytes
+        .collect()
 }
 
 // pre-compute registered types prefix (this is probably sth. our amino library should

--- a/src/tx_signer/jsonrpc.rs
+++ b/src/tx_signer/jsonrpc.rs
@@ -9,32 +9,23 @@ use crate::{
 use bytes::Buf;
 use hyper::http::{header, Uri};
 use serde::Deserialize;
-use std::time::Duration;
 
 /// Transaction builder JSONRPC client.
 #[derive(Clone, Debug)]
 pub struct Client {
     /// URL to fetch JSON document from
     uri: Uri,
-
-    /// Interval at which we poll the source for new transactions
-    poll_interval: Duration,
 }
 
 impl Client {
     /// Create a new JSONRPC client.
-    pub fn new(uri: Uri, poll_interval: Duration) -> Self {
-        Self { uri, poll_interval }
+    pub fn new(uri: Uri) -> Self {
+        Self { uri }
     }
 
     /// Get the URI this client is requesting
     pub fn uri(&self) -> &Uri {
         &self.uri
-    }
-
-    /// Get the [`Duration`] to sleep after a successful request
-    pub fn poll_interval(&self) -> Duration {
-        self.poll_interval
     }
 
     /// Request transactions to be signed from the transaction service

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -64,6 +64,7 @@ keys = [
 # account_number = 101072
 # account_address = "iap1qqqsyqcyq5rqwzqfpg9scrgwpugpzysnfxh53h" # must be in the keyring for this chain
 # acl = { msg_type = ["oracle/MsgExchangeRatePrevote", "oracle/MsgExchangeRateVote"] }
-# source = { protocol = "jsonrpc", poll_secs = 30, uri = "http://127.0.0.1:23456" }
-# rpc_addr = "tcp://127.0.0.1:26657"
+# poll_interval = { blocks = 5 }
+# source = { protocol = "jsonrpc", uri = "http://127.0.0.1:23456" }
+# rpc = { addr = "tcp://127.0.0.1:26657" }
 # seq_file = "irishub-account-seq.json"


### PR DESCRIPTION
Replaces (for now) wall-time based polling with polling at given block intervals.

The main use case for this is a Terra Oracle feeder, but this approach should be generally useful for anything which wants to sync transaction signing with incoming blocks.