### PR TITLE
softsign: add account key support; drop `raw` format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "prost-amino-derive",
  "rand",
  "rpassword",
+ "secp256k1",
  "serde",
  "serde_json",
  "sha2 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,10 @@ rpassword = { version = "4", optional = true }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
+secp256k1 = { version = "0.17", optional = true }
 signatory = { version = "0.20", features = ["ecdsa", "ed25519", "encoding"] }
 signatory-dalek = "0.20"
-signatory-secp256k1 = "0.20"
+signatory-secp256k1 = { version = "0.20", optional = true }
 signatory-ledger-tm = { version = "0.20", optional = true }
 stdtx = { version = "0.2", optional = true }
 subtle = "2"
@@ -57,7 +58,7 @@ features = ["testing"]
 [features]
 default = ["tx-signer"]
 ledgertm = ["signatory-ledger-tm"]
-softsign = []
+softsign = ["secp256k1", "signatory-secp256k1"]
 tx-signer = ["hyper", "stdtx", "tendermint-rpc"]
 yubihsm-mock = ["yubihsm/mockhsm"]
 yubihsm-server = ["yubihsm/http-server", "rpassword"]

--- a/src/commands/softsign/import.rs
+++ b/src/commands/softsign/import.rs
@@ -2,12 +2,8 @@
 
 use crate::{config::provider::softsign::KeyFormat, keyring::SecretKeyEncoding, prelude::*};
 use abscissa_core::{Command, Options, Runnable};
-use signatory::{
-    ed25519,
-    encoding::{Decode, Encode},
-};
+use signatory::{ed25519, encoding::Encode};
 use std::{path::PathBuf, process};
-use subtle_encoding::IDENTITY;
 use tendermint::{config::PrivValidatorKey, PrivateKey};
 
 /// `import` command: import a `priv_validator.json` formatted key and convert
@@ -62,12 +58,6 @@ impl Runnable for ImportCommand {
                         ed25519::Seed::from_bytes(pk.to_seed().as_secret_slice()).unwrap()
                     }
                 }
-            }
-            KeyFormat::Raw => {
-                ed25519::Seed::decode_from_file(input_path, IDENTITY).unwrap_or_else(|e| {
-                    status_err!("couldn't load {}: {}", input_path.display(), e);
-                    process::exit(1);
-                })
             }
             KeyFormat::Base64 => {
                 status_err!("invalid format: baes64 (must be 'json' or 'raw')");

--- a/src/commands/softsign/keygen.rs
+++ b/src/commands/softsign/keygen.rs
@@ -2,12 +2,25 @@
 
 use crate::{keyring::SecretKeyEncoding, prelude::*};
 use abscissa_core::{Command, Options, Runnable};
+use rand::{rngs::OsRng, RngCore};
 use signatory::{ed25519, encoding::Encode};
+use std::{fs::OpenOptions, io::Write, os::unix::fs::OpenOptionsExt};
 use std::{path::PathBuf, process};
+use zeroize::Zeroize;
+
+/// Default type of key to generate
+pub const DEFAULT_KEY_TYPE: &str = "consensus";
 
 /// `keygen` command
 #[derive(Command, Debug, Default, Options)]
 pub struct KeygenCommand {
+    #[options(
+        short = "t",
+        long = "type",
+        help = "type of key: 'account' or 'consensus' (default 'consensus')"
+    )]
+    key_type: Option<String>,
+
     #[options(free, help = "path where generated key should be created")]
     output_paths: Vec<PathBuf>,
 }
@@ -16,22 +29,85 @@ impl Runnable for KeygenCommand {
     /// Generate an Ed25519 secret key for use with a software provider (i.e. ed25519-dalek)
     fn run(&self) {
         if self.output_paths.len() != 1 {
-            eprintln!("Usage: tmkms softsign keygen [PATH]");
+            eprintln!("Usage: tmkms softsign keygen [-t account,consensus] PATH");
             process::exit(1);
         }
 
         let output_path = &self.output_paths[0];
 
-        let seed = ed25519::Seed::generate();
-        seed.encode_to_file(output_path, &SecretKeyEncoding::default())
-            .unwrap_or_else(|e| {
-                status_err!("couldn't write to {}: {}", output_path.display(), e);
+        match self
+            .key_type
+            .as_ref()
+            .map(AsRef::as_ref)
+            .unwrap_or(DEFAULT_KEY_TYPE)
+        {
+            "account" => generate_secp256k1_key(output_path),
+            "consensus" => generate_ed25519_key(output_path),
+            other => {
+                status_err!(
+                    "unknown key type: {} (must be 'account' or 'consensus')",
+                    other
+                );
                 process::exit(1);
-            });
-
-        info!(
-            "Wrote random Ed25519 private key to {}",
-            output_path.display()
-        );
+            }
+        }
     }
+}
+
+/// Randomly generate a Base64-encoded secp256k1 key and store it at the given path
+fn generate_secp256k1_key(output_path: &PathBuf) {
+    // This method may look gross but it is in fact the same method
+    // used by the upstream `secp256k1` crate's `rand` feature.
+    // We don't use that because it's using the outdated `rand` v0.6
+    let mut bytes = [0u8; 32];
+
+    loop {
+        OsRng.fill_bytes(&mut bytes);
+        if secp256k1::key::SecretKey::from_slice(&bytes).is_ok() {
+            break;
+        }
+    }
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(output_path)
+        .unwrap_or_else(|e| {
+            status_err!("couldn't open `{}`: {}", output_path.display(), e);
+            process::exit(1);
+        });
+
+    let mut encoded = subtle_encoding::base64::encode(&bytes);
+    bytes.zeroize();
+
+    file.write_all(&encoded).unwrap_or_else(|e| {
+        status_err!("couldn't write to `{}`: {}", output_path.display(), e);
+        process::exit(1);
+    });
+
+    encoded.zeroize();
+
+    status_ok!(
+        "Generated",
+        "account (secp256k1) private key at: {}",
+        output_path.display()
+    );
+}
+
+/// Randomly generate a Base64-encoded Ed25519 key and store it at the given path
+fn generate_ed25519_key(output_path: &PathBuf) {
+    let seed = ed25519::Seed::generate();
+    seed.encode_to_file(output_path, &SecretKeyEncoding::default())
+        .unwrap_or_else(|e| {
+            status_err!("couldn't write to `{}`: {}", output_path.display(), e);
+            process::exit(1);
+        });
+
+    status_ok!(
+        "Generated",
+        "consensus (Ed25519) private key at: {}",
+        output_path.display()
+    );
 }

--- a/src/config/provider/softsign.rs
+++ b/src/config/provider/softsign.rs
@@ -1,5 +1,6 @@
 //! Configuration for software-backed signer (using ed25519-dalek)
 
+use super::KeyType;
 use crate::{
     chain,
     error::{Error, ErrorKind::ConfigError},
@@ -17,6 +18,10 @@ use std::{
 pub struct SoftsignConfig {
     /// Chains this signing key is authorized to be used from
     pub chain_ids: Vec<chain::Id>,
+
+    /// Type of key (account vs consensus, default consensus)
+    #[serde(default)]
+    pub key_type: KeyType,
 
     /// Private key file format
     pub key_format: Option<KeyFormat>,
@@ -41,10 +46,6 @@ impl AsRef<Path> for SoftPrivateKey {
 /// Private key format
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
 pub enum KeyFormat {
-    /// Raw (i.e. binary)
-    #[serde(rename = "raw")]
-    Raw,
-
     /// Base64-encoded
     #[serde(rename = "base64")]
     Base64,
@@ -56,8 +57,7 @@ pub enum KeyFormat {
 
 impl Default for KeyFormat {
     fn default() -> Self {
-        // TODO(tarcieri): change to Base64
-        KeyFormat::Raw
+        KeyFormat::Base64
     }
 }
 
@@ -66,7 +66,6 @@ impl FromStr for KeyFormat {
 
     fn from_str(s: &str) -> Result<Self, Error> {
         let format = match s {
-            "raw" => KeyFormat::Raw,
             "base64" => KeyFormat::Base64,
             "json" => KeyFormat::Json,
             other => fail!(ConfigError, "invalid key format: {}", other),

--- a/src/keyring/providers/softsign.rs
+++ b/src/keyring/providers/softsign.rs
@@ -1,18 +1,23 @@
 //! ed25519-dalek software-based signer
 //!
-//! This is mainly intended for testing/CI. Ideally real validators will use HSMs
+//! This is mainly intended for testing/CI. Ideally real validators will use HSMs.
 
 use crate::{
     chain,
-    config::provider::softsign::{KeyFormat, SoftsignConfig},
+    config::provider::{
+        softsign::{KeyFormat, SoftsignConfig},
+        KeyType,
+    },
     error::{Error, ErrorKind::*},
-    keyring::{ed25519::Signer, SecretKeyEncoding, SigningProvider},
+    keyring::{self, SecretKeyEncoding, SigningProvider},
     prelude::*,
 };
 use signatory::{ed25519, encoding::Decode, public_key::PublicKeyed};
 use signatory_dalek::Ed25519Signer;
+use signatory_secp256k1::EcdsaSigner;
 use std::{fs, process};
 use tendermint::{config::PrivValidatorKey, PrivateKey, TendermintKey};
+use zeroize::Zeroizing;
 
 /// Create software-backed Ed25519 signer objects from the given configuration
 pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) -> Result<(), Error> {
@@ -20,93 +25,147 @@ pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) ->
         return Ok(());
     }
 
-    // TODO(tarcieri): support for multiple softsign keys?
-    if configs.len() != 1 {
-        fail!(
-            ConfigError,
-            "expected one [softsign.provider] in config, found: {}",
-            configs.len()
-        );
+    let mut loaded_consensus_key = false;
+
+    for config in configs {
+        match config.key_type {
+            KeyType::Account => {
+                let signer = load_secp256k1_key(&config)?;
+                let public_key = tendermint::PublicKey::from_raw_secp256k1(
+                    signer
+                        .public_key()
+                        .map_err(|_| Error::from(InvalidKey))?
+                        .as_bytes(),
+                )
+                .unwrap();
+
+                let account_pubkey = TendermintKey::AccountKey(public_key);
+
+                let signer = keyring::ecdsa::Signer::new(
+                    SigningProvider::SoftSign,
+                    account_pubkey,
+                    Box::new(signer),
+                );
+
+                for chain_id in &config.chain_ids {
+                    chain_registry.add_account_key(chain_id, signer.clone())?;
+                }
+            }
+            KeyType::Consensus => {
+                if loaded_consensus_key {
+                    fail!(
+                        ConfigError,
+                        "only one [[providers.softsign]] consensus key allowed"
+                    );
+                }
+
+                loaded_consensus_key = true;
+
+                let signer = load_ed25519_key(&config)?;
+                let public_key = signer.public_key().map_err(|_| Error::from(InvalidKey))?;
+
+                let consensus_pubkey = TendermintKey::ConsensusKey(public_key.into());
+
+                let signer = keyring::ed25519::Signer::new(
+                    SigningProvider::SoftSign,
+                    consensus_pubkey,
+                    Box::new(signer),
+                );
+
+                for chain_id in &config.chain_ids {
+                    chain_registry.add_consensus_key(chain_id, signer.clone())?;
+                }
+            }
+        }
     }
 
-    let config = &configs[0];
+    Ok(())
+}
+
+/// Load an Ed25519 key according to the provided configuration
+fn load_ed25519_key(config: &SoftsignConfig) -> Result<Ed25519Signer, Error> {
     let key_format = config.key_format.as_ref().cloned().unwrap_or_default();
 
-    let seed = match key_format {
+    match key_format {
         KeyFormat::Base64 => {
-            let base64 = fs::read_to_string(&config.path).map_err(|e| {
+            let key_base64 = Zeroizing::new(fs::read_to_string(&config.path).map_err(|e| {
                 format_err!(
                     ConfigError,
-                    "couldn't read key from {}: {}",
+                    "couldn't read key from `{}`: {}",
                     &config.path.as_ref().display(),
                     e
                 )
-            })?;
+            })?);
 
-            // TODO(tarcieri): constant-time string trimming
-            let base64_trimmed = base64.trim_end();
-
-            ed25519::Seed::decode_from_str(base64_trimmed, &SecretKeyEncoding::default()).map_err(
-                |e| {
-                    format_err!(
-                        ConfigError,
-                        "can't decode key from {}: {}",
-                        config.path.as_ref().display(),
-                        e
-                    )
-                },
-            )?
-        }
-        KeyFormat::Raw => {
-            let bytes = fs::read(&config.path).map_err(|e| {
+            let seed = ed25519::Seed::decode_from_str(
+                key_base64.trim_end(),
+                &SecretKeyEncoding::default(),
+            )
+            .map_err(|e| {
                 format_err!(
                     ConfigError,
-                    "couldn't read key from {}: {}",
-                    &config.path.as_ref().display(),
-                    e
-                )
-            })?;
-
-            ed25519::Seed::from_bytes(&bytes).ok_or_else(|| {
-                format_err!(
-                    ConfigError,
-                    "malformed 'raw' softsign key: {}",
+                    "can't decode key from `{}`: {}",
                     config.path.as_ref().display(),
+                    e
                 )
-            })?
+            })?;
+
+            Ok(Ed25519Signer::from(&seed))
         }
         KeyFormat::Json => {
             let private_key = PrivValidatorKey::load_json_file(&config.path)
                 .unwrap_or_else(|e| {
-                    status_err!("couldn't load {}: {}", config.path.as_ref().display(), e);
+                    status_err!("couldn't load `{}`: {}", config.path.as_ref().display(), e);
                     process::exit(1);
                 })
                 .priv_key;
 
             match private_key {
-                PrivateKey::Ed25519(pk) => {
-                    // TODO(tarcieri): upgrade Signatory version
-                    ed25519::Seed::from_bytes(pk.to_seed().as_secret_slice()).unwrap()
-                }
+                PrivateKey::Ed25519(pk) => Ok(pk.to_signer()),
             }
         }
-    };
+    }
+}
 
-    let provider = Ed25519Signer::from(&seed);
-    let public_key = provider.public_key().map_err(|_| Error::from(InvalidKey))?;
-
-    // TODO(tarcieri): support for adding account keys into keyrings
-    let consensus_pubkey = TendermintKey::ConsensusKey(public_key.into());
-
-    let signer = Signer::new(
-        SigningProvider::SoftSign,
-        consensus_pubkey,
-        Box::new(provider),
-    );
-
-    for chain_id in &config.chain_ids {
-        chain_registry.add_consensus_key(chain_id, signer.clone())?;
+/// Load a secp256k1 (ECDSA) key according to the provided configuration
+fn load_secp256k1_key(config: &SoftsignConfig) -> Result<EcdsaSigner, Error> {
+    if config.key_format.unwrap_or_default() != KeyFormat::Base64 {
+        fail!(
+            ConfigError,
+            "[[providers.softsign]] account keys must be `base64` encoded"
+        );
     }
 
-    Ok(())
+    let key_base64 = Zeroizing::new(fs::read_to_string(&config.path).map_err(|e| {
+        format_err!(
+            ConfigError,
+            "couldn't read key from {}: {}",
+            &config.path.as_ref().display(),
+            e
+        )
+    })?);
+
+    // TODO(tarcieri): constant-time string trimming
+    let key_bytes = Zeroizing::new(
+        subtle_encoding::base64::decode(key_base64.trim_end()).map_err(|e| {
+            format_err!(
+                ConfigError,
+                "can't decode key from `{}`: {}",
+                config.path.as_ref().display(),
+                e
+            )
+        })?,
+    );
+
+    let secret_key =
+        signatory_secp256k1::SecretKey::from_bytes(key_bytes.as_slice()).map_err(|e| {
+            format_err!(
+                ConfigError,
+                "can't decode account key base64 from {}: {}",
+                config.path.as_ref().display(),
+                e
+            )
+        })?;
+
+    Ok(EcdsaSigner::from(&secret_key))
 }

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -38,7 +38,7 @@ protocol_version = "v0.33" # "legacy" is the default
 adapter = { type = "usb" }
 auth = { key = 1, password_file = "/path/to/password" } # or pass raw password as `password`
 keys = [
-    { chain_ids = ["cosmoshub-1"], key = 1 }
+    { chain_ids = ["cosmoshub-1"], key = 1, type = "consensus" }
     # { chain_ids = ["irishub"], key = 2, type = "account" }
 ]
 #serial_number = "0123456789" # identify serial number of a specific YubiHSM to connect to
@@ -49,11 +49,17 @@ keys = [
 #chain_ids = ["cosmoshub-1"]
 
 # enable the `softsign` feature to use this backend
-# note: the `yubihsm` or `ledger` backends are recommended
+# note: the `yubihsm` or `ledger` backends are preferred over this one
+[[providers.softsign]]
+chain_ids = ["cosmoshub-1"]
+key_type = "consensus"
+path = "path/to/consensus-ed25519.key" # generate using `tmkms softsign keygen -t consensus consensus-ed25519.key`
+
+# the `softsign` backend also supports account keys
 #[[providers.softsign]]
-#chain_ids = ["cosmoshub-1"]
-#key_format = "base64"
-#path = "path/to/signing.key"
+#chain_ids = ["irishub"]
+#key_type = "account"
+#path = "path/to/account-secp256k1.key" # generate using `tmkms softsign keygen -t account account-secp256k1.key`
 
 ## (Optional) Transaction signer configuration
 


### PR DESCRIPTION
Adds support for generating and loading secp256k1 (ECDSA) account keys when using the `softsign` provider.

Keys must be serialized as raw Base64.

For maintainability purposes, this commit also drops support for the legacy `raw` key format. Users who still have keys in this format will need to Base64 encode them.