### PR TITLE
Add `tmkms init` subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,6 @@ x25519-dalek = "0.6"
 yubihsm = { version = "0.34", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
 
-[dev-dependencies]
-tempfile = "3"
-
 [dev-dependencies.abscissa_core]
 version = "0.5"
 features = ["testing"]

--- a/README.md
+++ b/README.md
@@ -131,10 +131,31 @@ cargo install tmkms --features=yubihsm --version=0.4.0
 
 Alternatively, substitute `--features=ledgertm` to enable Ledger support.
 
-## Usage
+## Configuration: `tmkms init`
 
-After compiling, start `tmkms` with the following:
+The `tmkms init` command can be used to generate a directory containing
+the configuration files needed to run the KMS. Run the following:
 
+```
+$ tmkms init /path/to/kms/home
+```
+
+This will output a `tmkms.toml` file, a `kms-identity.key` (used to authenticate
+the KMS to the validator), and create `secrets` and `state` subdirectories.
+
+Please look through `tmkms.toml` after it's generated, as various sections
+will require some customization.
+
+The `tmkms init` command also accepts a `-n` or `--networks` argument which can
+be used to specify certain well-known Tendermint chains to initialize:
+
+```
+$ tmkms init -n cosmoshub,irishub,columbus /path/to/kms/home
+```
+
+## Running: `tmkms start`
+
+After creading the configuration, start `tmkms` with the following:
 
 ```
 $ tmkms start

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,13 +1,14 @@
 //! Subcommands of the `tmkms` command-line application
 
+pub mod init;
 #[cfg(feature = "ledgertm")]
-mod ledger;
+pub mod ledger;
 #[cfg(feature = "softsign")]
-mod softsign;
-mod start;
-mod version;
+pub mod softsign;
+pub mod start;
+pub mod version;
 #[cfg(feature = "yubihsm")]
-mod yubihsm;
+pub mod yubihsm;
 
 #[cfg(feature = "ledgertm")]
 pub use self::ledger::LedgerCommand;
@@ -16,7 +17,8 @@ pub use self::softsign::SoftsignCommand;
 #[cfg(feature = "yubihsm")]
 pub use self::yubihsm::YubihsmCommand;
 
-pub use self::{start::StartCommand, version::VersionCommand};
+pub use self::{init::InitCommand, start::StartCommand, version::VersionCommand};
+
 use crate::config::{KmsConfig, CONFIG_ENV_VAR, CONFIG_FILE_NAME};
 use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use std::{env, path::PathBuf};
@@ -27,6 +29,10 @@ pub enum KmsCommand {
     /// `help` subcommand
     #[options(help = "show help for a command")]
     Help(Help<Self>),
+
+    /// `init` subcommand
+    #[options(help = "initialize KMS configuration")]
+    Init(InitCommand),
 
     /// `start` subcommand
     #[options(help = "start the KMS application")]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,138 @@
+//! `init` subcommand
+
+pub mod config_builder;
+pub mod networks;
+
+use self::{config_builder::ConfigBuilder, networks::Network};
+use crate::{config::CONFIG_FILE_NAME, connection::secret_connection, prelude::*};
+use abscissa_core::{Command, Options, Runnable};
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process,
+};
+
+/// Subdirectories to create within the parent directory
+pub const SUBDIRECTORIES: &[&str] = &["schema", "secrets", "state"];
+
+/// Filesystem permissions to set on the secrets directory
+pub const SECRETS_DIR_PERMISSIONS: u32 = 0o700;
+
+/// Default name of the Secret Connection key
+pub const SECRET_CONNECTION_KEY: &str = "kms-identity.key";
+
+/// Abort the operation, printing a formatted message and exiting the process
+/// with a status code of 1 (i.e. error)
+macro_rules! abort {
+    ($fmt:expr, $($arg:tt)+) => {
+        status_err!(format!($fmt, $($arg)+));
+        process::exit(1);
+    };
+}
+
+/// `init` subcommand
+#[derive(Command, Debug, Options)]
+pub struct InitCommand {
+    #[options(
+        short = "n",
+        long = "networks",
+        help = "Tendermint networks to configure (comma separated)"
+    )]
+    networks: Option<String>,
+
+    #[options(free, help = "path where config files should be generated")]
+    output_paths: Vec<PathBuf>,
+}
+
+impl Runnable for InitCommand {
+    fn run(&self) {
+        if self.output_paths.len() != 1 {
+            eprintln!("Usage: tmkms init [-f] KMS_HOME_PATH");
+            process::exit(1);
+        }
+
+        // Parse specified networks to initialize
+        let mut networks = vec![];
+        match &self.networks {
+            Some(chain_ids) => {
+                for chain_id in chain_ids.split(',') {
+                    networks.push(Network::parse(chain_id));
+                }
+            }
+            None => {
+                networks.push(Network::CosmosHub);
+            }
+        }
+
+        let kms_home = {
+            let output_path = &self.output_paths[0];
+
+            // Create KMS home directory
+            if !output_path.exists() {
+                status_ok!("Creating", "{}", output_path.display());
+
+                fs::create_dir_all(&output_path).unwrap_or_else(|e| {
+                    abort!("couldn't create `{}`: {}", output_path.display(), e);
+                });
+            }
+
+            fs::canonicalize(&output_path).unwrap_or_else(|e| {
+                abort!("couldn't canonicalize `{}`: {}", output_path.display(), e);
+            })
+        };
+
+        // Create subdirectories within the KMS home directory
+        for subdir in SUBDIRECTORIES {
+            let subdir_path = kms_home.join(subdir);
+
+            fs::create_dir_all(&subdir_path).unwrap_or_else(|e| {
+                abort!("couldn't create `{}`: {}", subdir_path.display(), e);
+            });
+        }
+
+        // Restrict filesystem permissions to the `secrets` subdirectory
+        let secrets_dir = kms_home.join("secrets");
+
+        set_permissions(&secrets_dir, SECRETS_DIR_PERMISSIONS);
+
+        let config_path = kms_home.join(CONFIG_FILE_NAME);
+        let config_toml = ConfigBuilder::new(&kms_home, &networks).generate();
+
+        fs::write(&config_path, config_toml).unwrap_or_else(|e| {
+            abort!("couldn't write `{}`: {}", config_path.display(), e);
+        });
+
+        status_ok!("Generated", "KMS configuration: {}", config_path.display());
+
+        let secret_connection_key = secrets_dir.join(SECRET_CONNECTION_KEY);
+        secret_connection::generate_key(&secret_connection_key).unwrap_or_else(|e| {
+            abort!(
+                "couldn't generate `{}`: {}",
+                secret_connection_key.display(),
+                e
+            );
+        });
+
+        status_ok!(
+            "Generated",
+            "Secret Connection key: {}",
+            secret_connection_key.display()
+        );
+
+        // TODO(tarcieri): generate consensus and account keys when using softsign
+    }
+}
+
+/// Set Unix permissions on the given path.
+///
+/// On error, prints a message and exits the process with status 1 (error)
+fn set_permissions(path: impl AsRef<Path>, mode: u32) {
+    fs::set_permissions(path.as_ref(), fs::Permissions::from_mode(mode)).unwrap_or_else(|e| {
+        abort!(
+            "couldn't set permissions on `{}`: {}",
+            path.as_ref().display(),
+            e
+        );
+    });
+}

--- a/src/commands/init/config_builder.rs
+++ b/src/commands/init/config_builder.rs
@@ -1,0 +1,212 @@
+//! Configuration file builder
+
+use super::networks::Network;
+use std::{
+    fmt::{self, Display},
+    path::Path,
+};
+
+/// Header to place at the top of `tmkms.toml`
+pub const KMS_CONFIG_HEADER: &str = "# Tendermint KMS configuration file";
+
+/// Configuration file builder
+pub struct ConfigBuilder {
+    /// Path to the KMS home directory (as a string)
+    kms_home: String,
+
+    /// Networks to include in configuration
+    networks: Vec<Network>,
+
+    /// Contents of the configuration file in-progress
+    contents: String,
+}
+
+impl ConfigBuilder {
+    /// Create config builder in the default state
+    pub fn new(kms_home: impl AsRef<Path>, networks: &[Network]) -> Self {
+        let mut result = Self {
+            // We need to template the KMS homedir into a config file so we have
+            // to convert it into a string
+            kms_home: kms_home.as_ref().display().to_string(),
+            networks: networks.to_vec(),
+            contents: String::new(),
+        };
+
+        result.add_str(KMS_CONFIG_HEADER);
+        result.add_str("\n\n");
+
+        result
+    }
+
+    /// Generate configuration, returning a serialized TOML string
+    pub fn generate(mut self) -> String {
+        self.add_chain_config();
+        self.add_provider_config();
+        self.add_validator_config();
+
+        #[cfg(feature = "tx-signer")]
+        self.add_tx_signer_config();
+
+        self.contents
+    }
+
+    /// Add a comment describing a particular section
+    fn add_section_comment(&mut self, section: &str) {
+        self.add_str(&format!("## {}\n\n", section));
+    }
+
+    /// Add `[[chain]]` configurations
+    fn add_chain_config(&mut self) {
+        self.add_section_comment("Chain Configuration");
+
+        for network in &self.networks.clone() {
+            self.add_template(match network {
+                Network::Columbus => include_str!("templates/networks/columbus.toml"),
+                Network::CosmosHub => include_str!("templates/networks/cosmoshub.toml"),
+                Network::IrisHub => include_str!("templates/networks/irishub.toml"),
+            });
+        }
+    }
+
+    /// Add `[[provider]]` configuration (customized for enabled signing providers)
+    fn add_provider_config(&mut self) {
+        self.add_section_comment("Signing Provider Configuration");
+
+        #[cfg(feature = "yubihsm")]
+        self.add_yubihsm_provider_config();
+
+        #[cfg(feature = "ledgertm")]
+        self.add_ledgertm_provider_config();
+
+        #[cfg(feature = "softsign")]
+        self.add_softsign_provider_config();
+    }
+
+    /// Add `[[validator]]` configurations
+    fn add_validator_config(&mut self) {
+        self.add_section_comment("Validator Configuration");
+        self.add_template_with_chain_id(include_str!("templates/validator.toml"));
+    }
+
+    /// Add `[[tx_signer]]` configurations
+    #[cfg(feature = "tx-signer")]
+    fn add_tx_signer_config(&mut self) {
+        self.add_section_comment("Transaction Signer Configuration");
+
+        for network in self.networks.clone() {
+            self.add_str(&format_template(
+                include_str!("templates/tx_signer.toml"),
+                &[
+                    ("$KMS_HOME", self.kms_home.as_ref()),
+                    ("$CHAIN_ID", network.chain_id()),
+                    ("$SCHEMA", network.schema_file()),
+                ],
+            ));
+
+            self.add_str("\n\n");
+        }
+    }
+
+    /// Add `[[provider.yubihsm]]` configuration
+    #[cfg(feature = "yubihsm")]
+    fn add_yubihsm_provider_config(&mut self) {
+        self.add_str("### YubiHSM2 Provider Configuration\n\n");
+
+        self.add_str(&format_template(
+            include_str!("templates/keyring/yubihsm.toml"),
+            &[("$KMS_HOME", self.kms_home.as_ref())],
+        ));
+
+        self.add_str("\nkeys = [\n");
+
+        let mut key_id = 1;
+
+        #[allow(unused_mut)]
+        let mut key_types = vec!["consensus"];
+
+        #[cfg(feature = "tx-signer")]
+        key_types.push("account");
+
+        for network in self.networks.clone() {
+            for key_type in &key_types {
+                self.add_str(&format!(
+                    "    {{ key = {}, type = \"{}\", chain_ids = [\"{}\"] }}, \n",
+                    key_id,
+                    key_type,
+                    network.chain_id(),
+                ));
+
+                key_id += 1;
+            }
+        }
+
+        self.add_str("]\n");
+
+        #[cfg(feature = "yubihsm-server")]
+        self.add_str(include_str!("templates/keyring/yubihsm_server.toml"));
+
+        self.add_str("\n");
+    }
+
+    /// Add `[[provdier.ledgertm]]` configuration
+    #[cfg(feature = "ledgertm")]
+    fn add_ledgertm_provider_config(&mut self) {
+        self.add_str("### Ledger Provider Configuration\n\n");
+        self.add_template_with_chain_id(include_str!("templates/keyring/ledgertm.toml"));
+    }
+
+    /// Add `[[provider.softsign]]` configuration
+    #[cfg(feature = "softsign")]
+    fn add_softsign_provider_config(&mut self) {
+        self.add_str("### Software-based Signer Configuration\n\n");
+
+        self.add_template_with_chain_id(include_str!("templates/keyring/softsign_consensus.toml"));
+
+        #[cfg(feature = "tx-signer")]
+        self.add_template_with_chain_id(include_str!("templates/keyring/softsign_account.toml"));
+    }
+
+    /// Append a template to the config file, substituting `$KMS_HOME`
+    fn add_template(&mut self, template: &str) {
+        self.add_str(&format_template(
+            template,
+            &[("$KMS_HOME", self.kms_home.as_ref())],
+        ));
+
+        self.add_str("\n\n");
+    }
+
+    /// Append a template to the config file, substituting `$KMS_HOME` and `$CHAIN_ID`
+    fn add_template_with_chain_id(&mut self, template: &str) {
+        for network in self.networks.clone() {
+            self.add_str(&format_template(
+                template,
+                &[
+                    ("$KMS_HOME", self.kms_home.as_ref()),
+                    ("$CHAIN_ID", network.chain_id()),
+                ],
+            ));
+
+            self.add_str("\n\n");
+        }
+    }
+
+    /// Add a string to `self.contents`
+    fn add_str(&mut self, str: impl AsRef<str>) {
+        self.contents.push_str(str.as_ref())
+    }
+}
+
+impl Display for ConfigBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.contents)
+    }
+}
+
+/// Apply the given set of substitutions and trim newlines
+fn format_template(template: &str, substitutions: &[(&str, &str)]) -> String {
+    substitutions.iter().fold(
+        template.trim_end().to_owned(),
+        |string, (name, replacement)| string.replace(name, replacement),
+    )
+}

--- a/src/commands/init/networks.rs
+++ b/src/commands/init/networks.rs
@@ -1,0 +1,74 @@
+//! Tendermint KMS configuration file networks
+
+use crate::prelude::*;
+use std::{
+    fmt::{self, Display},
+    process,
+};
+
+/// Tendermint networks we have config networks for
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Network {
+    /// Terra `columbus` chain
+    Columbus,
+
+    /// Cosmos `cosmoshub` chain
+    CosmosHub,
+
+    /// Iris `irishub` chain
+    IrisHub,
+}
+
+impl Display for Network {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Network::Columbus => "columbus",
+            Network::CosmosHub => "cosmoshub",
+            Network::IrisHub => "irishub",
+        })
+    }
+}
+
+impl Network {
+    /// Get a slice containing all known networks
+    pub fn all() -> &'static [Network] {
+        &[Network::Columbus, Network::CosmosHub, Network::IrisHub]
+    }
+
+    /// Parse a network name from the chain ID prefix
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "columbus" => Network::Columbus,
+            "cosmoshub" => Network::CosmosHub,
+            "irishub" => Network::IrisHub,
+            other => {
+                status_err!("unknown Tendermint network: `{}`", other);
+                eprintln!("\nRegistered networks:");
+
+                for network in Self::all() {
+                    eprintln!("- {}", network);
+                }
+
+                process::exit(1);
+            }
+        }
+    }
+
+    /// Get the current production chain ID for this network
+    pub fn chain_id(&self) -> &str {
+        match self {
+            Network::Columbus => "columbus-3",
+            Network::CosmosHub => "cosmoshub-3",
+            Network::IrisHub => "irishub",
+        }
+    }
+
+    /// Get the schema file for this network
+    pub fn schema_file(&self) -> &str {
+        match self {
+            Network::Columbus => "terra.toml",
+            Network::CosmosHub => "cosmos-sdk.toml",
+            Network::IrisHub => "iris.toml",
+        }
+    }
+}

--- a/src/commands/init/templates/keyring/ledgertm.toml
+++ b/src/commands/init/templates/keyring/ledgertm.toml
@@ -1,0 +1,2 @@
+[[providers.ledgertm]]
+chain_ids = ["cosmoshub-1"]

--- a/src/commands/init/templates/keyring/softsign_account.toml
+++ b/src/commands/init/templates/keyring/softsign_account.toml
@@ -1,0 +1,4 @@
+[[providers.softsign]]
+chain_ids = ["$CHAIN_ID"]
+key_type = "account"
+path = "$KMS_HOME/secrets/$CHAIN_ID-account.key"

--- a/src/commands/init/templates/keyring/softsign_consensus.toml
+++ b/src/commands/init/templates/keyring/softsign_consensus.toml
@@ -1,0 +1,4 @@
+[[providers.softsign]]
+chain_ids = ["$CHAIN_ID"]
+key_type = "consensus"
+path = "$KMS_HOME/secrets/$CHAIN_ID-consensus.key"

--- a/src/commands/init/templates/keyring/yubihsm.toml
+++ b/src/commands/init/templates/keyring/yubihsm.toml
@@ -1,0 +1,4 @@
+[[providers.yubihsm]]
+adapter = { type = "usb" }
+auth = { key = 1, password_file = "$KMS_HOME/secrets/yubihsm-password.txt" }
+#serial_number = "0123456789" # serial number of a specific YubiHSM to connect to (optional)

--- a/src/commands/init/templates/keyring/yubihsm_server.toml
+++ b/src/commands/init/templates/keyring/yubihsm_server.toml
@@ -1,0 +1,1 @@
+#connector_server = { laddr = "tcp://127.0.0.1:12345", cli = { auth_key = 2 } }

--- a/src/commands/init/templates/networks/columbus.toml
+++ b/src/commands/init/templates/networks/columbus.toml
@@ -1,0 +1,6 @@
+### Terra Columbus Network
+
+[[chain]]
+id = "columbus-3"
+key_format = { type = "bech32", account_key_prefix = "terra", consensus_key_prefix = "terravalconspub" }
+state_file = "$KMS_HOME/state/columbus-3-consensus.json"

--- a/src/commands/init/templates/networks/cosmoshub.toml
+++ b/src/commands/init/templates/networks/cosmoshub.toml
@@ -1,0 +1,6 @@
+### Cosmos Hub Network
+
+[[chain]]
+id = "cosmoshub-3"
+key_format = { type = "bech32", account_key_prefix = "cosmospub", consensus_key_prefix = "cosmosvalconspub" }
+state_file = "$KMS_HOME/state/cosmoshub-3-consensus.json"

--- a/src/commands/init/templates/networks/irishub.toml
+++ b/src/commands/init/templates/networks/irishub.toml
@@ -1,0 +1,6 @@
+### Iris Hub Network
+
+[[chain]]
+id = "irishub"
+key_format = { type = "bech32", account_key_prefix = "iap", consensus_key_prefix = "icp" }
+state_file = "$KMS_HOME/state/irishub-consensus.json"

--- a/src/commands/init/templates/schema/cosmos-sdk.toml
+++ b/src/commands/init/templates/schema/cosmos-sdk.toml
@@ -1,0 +1,4 @@
+# TODO
+#
+# If you're interested in this, please open an issue at:
+# <https://github.com/iqlusioninc/tmkms>

--- a/src/commands/init/templates/schema/iris.toml
+++ b/src/commands/init/templates/schema/iris.toml
@@ -1,0 +1,4 @@
+# TODO
+#
+# If you're interested in this, please open an issue at:
+# <https://github.com/iqlusioninc/tmkms>

--- a/src/commands/init/templates/schema/terra.toml
+++ b/src/commands/init/templates/schema/terra.toml
@@ -1,0 +1,34 @@
+# Terra stablecoin project schema
+# <https://terra.money/>
+
+namespace = "core/StdTx"
+acc_prefix = "terra"
+val_prefix = "terravaloper"
+
+#
+# Oracle vote transactions
+# <https://docs.terra.money/dev/spec-oracle.html>
+#
+
+# MsgExchangeRatePrevote
+# <https://docs.terra.money/dev/spec-oracle.html#msgexchangerateprevote>
+[[definition]]
+type_name = "oracle/MsgExchangeRatePrevote"
+fields = [
+    { name = "hash",  type = "string" },
+    { name = "denom", type = "string" },
+    { name = "feeder", type = "sdk.AccAddress" },
+    { name = "validator", type = "sdk.ValAddress" },
+]
+
+# MsgExchangeRateVote
+# <https://docs.terra.money/dev/spec-oracle.html#msgexchangeratevote>
+[[definition]]
+type_name = "oracle/MsgExchangeRateVote"
+fields = [
+    { name = "exchange_rate", type = "sdk.Dec"},
+    { name = "salt", type = "string" },
+    { name = "denom", type = "string" },
+    { name = "feeder", type = "sdk.AccAddress" },
+    { name = "validator", type = "sdk.ValAddress" },
+]

--- a/src/commands/init/templates/tx_signer.toml
+++ b/src/commands/init/templates/tx_signer.toml
@@ -1,0 +1,10 @@
+#[[tx_signer]]
+#chain_id = "$CHAIN_ID"
+#schema = "$SCHEMA"
+#account_number = 123456 # CHANGE ME!
+#account_address = "cosmos1..." # CHANGE ME!
+#acl = { msg_type = ["sdk/Tx"] } # CHANGE ME!
+#poll_interval = { blocks = 5 }
+#source = { protocol = "jsonrpc", uri = "http://127.0.0.1:23456/" } # CHANGE ME!
+#rpc = { addr =  "tcp://127.0.0.1:26657" } # CHANGE ME!
+#seq_file = "$KMS_HOME/state/$CHAIN_ID-account-seq.json"

--- a/src/commands/init/templates/validator.toml
+++ b/src/commands/init/templates/validator.toml
@@ -1,0 +1,6 @@
+[[validator]]
+chain_id = "$CHAIN_ID"
+addr = "tcp://deadbeefdeadbeefdeadbeefdeadbeefdeadbeef@example1.example.com:26658"
+secret_key = "$KMS_HOME/secrets/kms-identity.key"
+protocol_version = "legacy"
+reconnect = true

--- a/src/commands/yubihsm/keys.rs
+++ b/src/commands/yubihsm/keys.rs
@@ -26,18 +26,23 @@ pub const DEFAULT_WRAP_KEY: yubihsm::object::Id = 1;
 /// The `yubihsm keys` subcommand
 #[derive(Command, Debug, Options, Runnable)]
 pub enum KeysCommand {
+    /// `yubihsm keys export`
     #[options(help = "export an encrypted backup of a signing key inside the HSM device")]
     Export(ExportCommand),
 
+    /// `yubihsm keys generate`
     #[options(help = "generate an Ed25519 signing key inside the HSM device")]
     Generate(GenerateCommand),
 
+    /// `yubihsm keys help`
     #[options(help = "show help for the 'yubihsm keys' subcommand")]
     Help(Help<Self>),
 
+    /// `yubihsm keys import`
     #[options(help = "import validator signing key for the 'yubihsm keys' subcommand")]
     Import(ImportCommand),
 
+    /// `yubihsm keys list`
     #[options(help = "list all suitable Ed25519 keys in the HSM")]
     List(ListCommand),
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -26,7 +26,6 @@ pub struct Session {
 
 impl Session {
     /// Open a session using the given validator configuration
-    #[allow(clippy::cognitive_complexity)] // TODO(tarcieri): needs refactoring
     pub fn open(config: ValidatorConfig) -> Result<Self, Error> {
         let connection: Box<dyn Connection> = match &config.addr {
             net::Address::Tcp {

--- a/tests/cli/init.rs
+++ b/tests/cli/init.rs
@@ -1,0 +1,43 @@
+//! Integration tests for the `init` subcommand
+
+use crate::cli;
+use abscissa_core::Config;
+use std::{ffi::OsStr, fs};
+use tmkms::{commands::init::networks::Network, config::KmsConfig};
+
+#[test]
+fn test_command() {
+    let parent_dir = tempfile::tempdir().unwrap();
+
+    let output_dir = parent_dir.path().join("tmkms");
+    assert!(!output_dir.exists());
+
+    // Network names to test with
+    let networks = Network::all()
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+
+    let result = cli::run(&[
+        OsStr::new("init"),
+        OsStr::new("-n"),
+        OsStr::new(&networks.join(",")),
+        output_dir.as_os_str(),
+    ]);
+
+    assert!(result.status.success());
+
+    // Ensure generated configuration file parses
+    let kms_config_path = output_dir.join("tmkms.toml");
+    let kms_config = KmsConfig::load_toml(fs::read_to_string(&kms_config_path).unwrap()).unwrap();
+
+    // Ensure all expected chain IDs are present
+    assert_eq!(
+        &kms_config
+            .chain
+            .iter()
+            .map(|c| c.id.as_str().split("-").next().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        &networks
+    )
+}

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -8,6 +8,8 @@ use std::{
 
 use super::KMS_EXE_PATH;
 
+mod init;
+
 #[cfg(feature = "yubihsm")]
 mod yubihsm;
 
@@ -22,6 +24,7 @@ where
 
 /// Run the `tmkms` CLI command with the expectation that it will exit successfully,
 /// panicking and printing stdout/stderr if it does not
+#[allow(dead_code)]
 pub fn run_successfully<I, S>(args: I) -> Output
 where
     I: IntoIterator<Item = S>,

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -1,6 +1,9 @@
 # Example KMS configuration file
 #
-# Copy this to 'tmkms.toml' and edit for your own purposes
+# This is just an example for reference. You can now use the following command
+# to generate a customizable configuration based on your preferences:
+#
+#     $ tmkms init [-n cosmoshub,irishub,...] /path/to/tmkms/homedir
 
 # Information about Tendermint blockchain networks this KMS services
 #


### PR DESCRIPTION
Adds a configuration generator subcommand ala `gaiad init` which generates a "home directory" for the KMS containing a `tmkms.toml` file along with a Secret Connection key (`kms-identity.key`).

The configuration file is automatically customized based on what Cargo features are enabled.