### PR TITLE
Cargo.toml: disable `tx-signer` feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition     = "2018"
 
 [dependencies]
 abscissa_core = "0.5"
-abscissa_tokio = "0.5"
+abscissa_tokio = { version = "0.5", optional = true }
 bytes = "0.5"
 chacha20poly1305 = "0.5"
 chrono = "0.4"
@@ -53,10 +53,9 @@ version = "0.5"
 features = ["testing"]
 
 [features]
-default = ["tx-signer"]
 ledgertm = ["signatory-ledger-tm"]
 softsign = ["secp256k1", "signatory-secp256k1"]
-tx-signer = ["hyper", "stdtx", "tendermint-rpc"]
+tx-signer = ["abscissa_tokio", "hyper", "stdtx", "tendermint-rpc"]
 yubihsm-mock = ["yubihsm/mockhsm"]
 yubihsm-server = ["yubihsm/http-server", "rpassword"]
 


### PR DESCRIPTION
Having it on by default was convenient for developing it. However, it (especially now) pulls in a large number of dependencies which can be avoided by not enabling it by default.