### PR TITLE
v0.8.0-alpha2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,28 @@
-## 0.8.0-alpha1 (2020-06-08)
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.8.0-alpha2 (2020-06-22)
 
 This release adds initial support for [tendermint v0.33].
 
-- Replace `atomicwrites` dependency with `tempfile` ([#62])
-- Refactor locking; add more debug locking ([#60])
+### Added
+- `tmkms init` subcommand ([#89])
+- Initial ECDSA support ([#76], [#86])
+- Transaction signer ([#78])
 - Support both the Tendermint legacy and v0.33 secret connection handshake ([#58])
 
+### Changed
+- Replace `atomicwrites` dependency with `tempfile` ([#62])
+- Refactor locking; add more debug locking ([#60])
+
 [tendermint v0.33]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v033
+[#89]: https://github.com/iqlusioninc/tmkms/pull/89
+[#86]: https://github.com/iqlusioninc/tmkms/pull/86
+[#78]: https://github.com/iqlusioninc/tmkms/pull/78
+[#76]: https://github.com/iqlusioninc/tmkms/pull/76
 [#62]: https://github.com/iqlusioninc/tmkms/pull/62
 [#60]: https://github.com/iqlusioninc/tmkms/pull/60
 [#58]: https://github.com/iqlusioninc/tmkms/pull/58

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,7 +2125,7 @@ checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
 
 [[package]]
 name = "tmkms"
-version = "0.8.0-alpha1"
+version = "0.8.0-alpha2"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.8.0-alpha1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.8.0-alpha2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 repository  = "https://github.com/iqlusioninc/tmkms/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Tendermint Key Management System
 
-#![doc(html_root_url = "https://docs.rs/tmkms/0.8.0-alpha1")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.8.0-alpha2")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
This release adds initial support for [tendermint v0.33].

### Added
- `tmkms init` subcommand ([#89])
- Initial ECDSA support ([#76], [#86])
- Transaction signer ([#78])
- Support both the Tendermint legacy and v0.33 secret connection handshake ([#58])

### Changed
- Replace `atomicwrites` dependency with `tempfile` ([#62])
- Refactor locking; add more debug locking ([#60])

[tendermint v0.33]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v033
[#89]: https://github.com/iqlusioninc/tmkms/pull/89
[#86]: https://github.com/iqlusioninc/tmkms/pull/86
[#78]: https://github.com/iqlusioninc/tmkms/pull/78
[#76]: https://github.com/iqlusioninc/tmkms/pull/76
[#62]: https://github.com/iqlusioninc/tmkms/pull/62
[#60]: https://github.com/iqlusioninc/tmkms/pull/60
[#58]: https://github.com/iqlusioninc/tmkms/pull/58