### PR TITLE
Bump deps (signatory/stdtx/k256/tendermint/yubihsm)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
+checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
 dependencies = [
  "aes-soft",
  "aesni",
@@ -96,23 +96,23 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
+checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
 dependencies = [
  "block-cipher",
  "byteorder",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
+checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
 dependencies = [
  "block-cipher",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -223,12 +223,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2838fdd79e8776dbe07a106c784b0f8dda571a21b2750a092cc4cbaa653c8e"
+dependencies = [
+ "funty",
+ "radium",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.3",
@@ -240,26 +251,27 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
+ "block-padding 0.2.1",
  "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "block-cipher"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
+checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
 dependencies = [
  "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "block-modes"
-version = "0.4.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538b66bc25a51ce985544067a9c3e17d426447f468c495dd6cb00040e5953692"
+checksum = "0c9b14fd8a4739e6548d4b6018696cf991dcf8c6effd9ef9eb33b29b8a650972"
 dependencies = [
  "block-cipher",
- "block-padding",
+ "block-padding 0.2.1",
 ]
 
 [[package]]
@@ -272,10 +284,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.4.0"
+name = "block-padding"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "byte-tools"
@@ -308,10 +320,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 
 [[package]]
+name = "ccm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbba800a6a55058ecb75c7a42e3d16a715a2b1f1afa9acf07365d6ab30d62ce1"
+dependencies = [
+ "aead",
+ "block-cipher",
+ "subtle",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
@@ -357,22 +386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d29eb15132782371f71da8f947dba48b3717bdb6fa771b9b434d645e40a7193"
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cmac"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a681d7c344a6fbe3dcd1565e76dac74eed379c8a9326b29654ae34a718d16a49"
+checksum = "5220604fe5c112e2851b00da795c72cbb71bf112f2cbd532bdcfb4106eeb320b"
 dependencies = [
- "block-cipher",
- "crypto-mac",
+ "crypto-mac 0.9.1",
  "dbl",
 ]
 
@@ -388,6 +407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d9162b7289a46e86208d6af2c686ca5bfde445878c41a458a9fac706252d0b"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +424,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -413,15 +438,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "1.2.4"
+name = "crypto-mac"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "405681bfe2b7b25ad8660dfd90b6e8be9e470e224ff49e36b587d43f29a22601"
+checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
- "byteorder",
- "clear_on_drop",
- "digest 0.8.1",
- "rand_core 0.3.1",
+ "block-cipher",
+ "generic-array 0.14.4",
  "subtle",
 ]
 
@@ -433,7 +456,7 @@ checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -502,15 +525,22 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6ba8a681d3a9c48875d277f2b11c81934ad690a60a20bcc4eef500ff68e25d"
+checksum = "83c7b18ecf0bb8dae3a2e41e7ec2b8fdb1988a6537c88d3c341e50feb8ee355a"
 dependencies = [
- "elliptic-curve",
- "k256",
- "p256",
- "p384",
- "sha2 0.9.1",
+ "elliptic-curve 0.5.0",
+ "signature",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87bf8bfb05ea8a6f74ddf48c7d1774851ba77bbe51ac984fdfa6c30310e1ff5f"
+dependencies = [
+ "elliptic-curve 0.6.6",
+ "hmac 0.9.0",
  "signature",
 ]
 
@@ -520,20 +550,23 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07dfc993ea376e864fe29a4099a61ca0bb994c6d7745a61bf60ddb3d64e05237"
 dependencies = [
+ "serde",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845aaacc16f01178f33349e7c992ecd0cee095aa5e577f0f4dee35971bd36455"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "clear_on_drop",
- "curve25519-dalek 1.2.4",
- "failure",
- "rand_core 0.3.1",
- "sha2 0.8.2",
+ "curve25519-dalek",
+ "ed25519",
+ "rand",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -544,12 +577,30 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2298f66754d859f4c099b0e645cfd258d2dfdfd1bac9496fd514d603ff6a5c6b"
+checksum = "9abe4578ed343c7a2c9d617cd2b1895ba0a87a6a4dee97bde156d65f608c7b2d"
 dependencies = [
+ "const-oid",
  "generic-array 0.14.4",
- "getrandom",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396db09c483e7fca5d4fdb9112685632b3e76c9a607a2649c1bf904404a01366"
+dependencies = [
+ "bitvec",
+ "const-oid",
+ "digest 0.9.0",
+ "ff",
+ "generic-array 0.14.4",
+ "group",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -583,12 +634,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "ff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -615,6 +677,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba62103ce691c2fd80fbae2213dfdda9ce60804973ac6b6e97de818ea7f52c8"
 
 [[package]]
 name = "futures"
@@ -717,7 +785,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -745,7 +813,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -755,6 +823,17 @@ name = "gimli"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+
+[[package]]
+name = "group"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "gumdrop"
@@ -842,9 +921,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0124735b175a890d1fb749bad117f2d6474ea5c20dfdfdc3a93ab8c10c192d36"
 dependencies = [
  "getrandom",
- "hmac",
+ "hmac 0.8.1",
  "lazy_static",
- "sha2 0.9.1",
+ "sha2",
  "zeroize",
 ]
 
@@ -855,7 +934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe1149865383e4526a43aee8495f9a325f0b806c63ce6427d06336a590abbbc9"
 dependencies = [
  "digest 0.9.0",
- "hmac",
+ "hmac 0.8.1",
 ]
 
 [[package]]
@@ -864,7 +943,17 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+dependencies = [
+ "crypto-mac 0.9.1",
  "digest 0.9.0",
 ]
 
@@ -986,22 +1075,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
-name = "js-sys"
-version = "0.3.45"
+name = "k256"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cb63e78a457abe6e0a36ffee8efffeb1c4887134e696be119854d8d03c0b7aab"
 dependencies = [
- "wasm-bindgen",
+ "cfg-if 0.1.10",
+ "ecdsa 0.7.2",
+ "elliptic-curve 0.5.0",
+ "sha2",
 ]
 
 [[package]]
 name = "k256"
-version = "0.3.0"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f5cb67f9625a99c159fc0776e75d2e37f988cdf31c115e9c25225e61d858c"
+checksum = "c2967b7caf19e57f5d01ac0893551b0aaae1a8e2e2b2a28996e12c9c51b3b486"
 dependencies = [
- "elliptic-curve",
- "subtle",
+ "cfg-if 1.0.0",
+ "ecdsa 0.8.5",
+ "elliptic-curve 0.6.6",
+ "sha2",
+ "sha3",
 ]
 
 [[package]]
@@ -1033,7 +1128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c9a2f47929b010a64a4bf9cdfe03b0d02175d44db0b91e16283f5a4a731d52c"
 dependencies = [
  "byteorder",
- "cfg-if",
+ "cfg-if 0.1.10",
  "hex",
  "hidapi",
  "lazy_static",
@@ -1086,7 +1181,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -1124,7 +1219,7 @@ checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.5.1",
+ "rand_core",
  "zeroize",
 ]
 
@@ -1144,7 +1239,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -1175,7 +1270,7 @@ version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
@@ -1188,7 +1283,7 @@ checksum = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -1247,29 +1342,32 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.3.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a425ecb71515663b2735fd1e65bb638fd134c5ad23857eb197c2f157784476cf"
+checksum = "280ed58e7e5f3052b6e2f596fa40c7eff4c27c4b6b6deecb5d685ba5c2080980"
 dependencies = [
- "elliptic-curve",
+ "ecdsa 0.8.5",
+ "elliptic-curve 0.6.6",
+ "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae962014118ae1621d13f011e14902223013b1b4151922c3a682a233a967ddb"
+checksum = "06de0548166c258c22bb6bdcff3074eac4b07125040aa74db3f61db87fe5f275"
 dependencies = [
- "elliptic-curve",
+ "ecdsa 0.8.5",
+ "elliptic-curve 0.6.6",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216eaa586a190f0a738f2f918511eecfa90f13295abec0e457cdebcceda80cbd"
+checksum = "7170d73bf11f39b4ce1809aabc95bf5c33564cdc16fc3200ddda17a5f6e5e48b"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.9.1",
 ]
 
 [[package]]
@@ -1372,7 +1470,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "sha2 0.9.1",
+ "sha2",
  "syn",
 ]
 
@@ -1392,6 +1490,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64de9a0c5361e034f1aefc9f71a86871ec870e766fe31a009734a989b329286a"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,7 +1504,7 @@ dependencies = [
  "getrandom",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
+ "rand_core",
  "rand_hc",
 ]
 
@@ -1411,23 +1515,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1444,7 +1533,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1487,20 +1576,6 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
-dependencies = [
- "cc",
- "libc",
- "spin",
- "untrusted",
- "web-sys",
  "winapi 0.3.9",
 ]
 
@@ -1564,24 +1639,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "secp256k1"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
-dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "secrecy"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -1672,26 +1729,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "cpuid-bool",
  "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "keccak",
  "opaque-debug 0.3.0",
 ]
 
@@ -1717,34 +1774,23 @@ dependencies = [
 
 [[package]]
 name = "signatory"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c20cbcf205bedce2ce5944ab41dd2e10b1dcee2831a0a2a071806761ed6eaba"
+checksum = "674dfa3a5b97b62e039b9e9d94f23887c6b474a7294f272a10327d65af2c8001"
 dependencies = [
- "ecdsa",
+ "ecdsa 0.8.5",
  "ed25519",
  "getrandom",
- "sha2 0.9.1",
  "signature",
  "subtle-encoding",
  "zeroize",
 ]
 
 [[package]]
-name = "signatory-dalek"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3c0e542d70d6d29c3bc3cba306c41679a6f52e42418fd4c9fc4ef9aa37d85e"
-dependencies = [
- "ed25519-dalek",
- "signatory",
-]
-
-[[package]]
 name = "signatory-ledger-tm"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c29411cdc6a0068363eb142f0fda7d4173e61473846a02f17ce8e8abf6b36ff"
+checksum = "9ecb58903611cba0d53430835782d57c26f2a90f67072d3214ca530428472000"
 dependencies = [
  "byteorder",
  "ledger",
@@ -1753,23 +1799,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatory-secp256k1"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a50b18b66b81b859f8ee57b0e85658e1777fe2683ac37b7e756380f0a28f6e"
-dependencies = [
- "secp256k1",
- "signatory",
- "signature",
-]
-
-[[package]]
 name = "signature"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65211b7b6fc3f14ff9fc7a2011a434e3e6880585bd2e9e9396315ae24cbf7852"
+checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest 0.9.0",
+ "rand_core",
  "signature_derive",
 ]
 
@@ -1806,17 +1842,11 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1826,18 +1856,19 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stdtx"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac38856c3a6c9b0d4107b51409e97879e3e3d6fd6519c22637322de5224820d0"
+checksum = "470756684957fd9ed5060c00641a610e6ab7fae4194f0582e8611c5f6a2cb45b"
 dependencies = [
  "anomaly",
- "ecdsa",
+ "ecdsa 0.8.5",
+ "k256 0.5.9",
  "prost-amino",
  "prost-amino-derive",
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2 0.9.1",
+ "sha2",
  "subtle-encoding",
  "thiserror",
  "toml",
@@ -1923,7 +1954,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",
@@ -1933,15 +1964,18 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3920b9773738bcd15ed4c9088faa0e73671f9b93ba538f04909e893e571725"
+checksum = "b45e7fd7fa5d049de343112ad0d2f45e65e8c700bc395aaed0c806906295b27e"
 dependencies = [
  "anomaly",
  "async-trait",
  "bytes",
  "chrono",
+ "ed25519",
+ "ed25519-dalek",
  "futures",
+ "k256 0.4.2",
  "once_cell",
  "prost-amino",
  "prost-amino-derive",
@@ -1950,10 +1984,8 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
- "sha2 0.9.1",
- "signatory",
- "signatory-dalek",
- "signatory-secp256k1",
+ "sha2",
+ "signature",
  "subtle",
  "subtle-encoding",
  "tai64",
@@ -1964,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee992790a74bf6c83150ca8ff4a060a5db5e0166bf3bc4b6361fb88ae174961"
+checksum = "b718face63ee456cb7305902db0bcdd3b233666cbcf25aa95c173c1252792b4c"
 dependencies = [
  "async-tungstenite",
  "bytes",
@@ -2060,26 +2092,25 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "chrono",
+ "ed25519-dalek",
  "getrandom",
  "gumdrop",
  "hkd32",
  "hkdf",
  "hyper",
- "k256",
+ "k256 0.5.9",
  "merlin",
  "once_cell",
  "prost-amino",
  "prost-amino-derive",
  "rand",
+ "rand_core",
  "rpassword",
- "secp256k1",
  "serde",
  "serde_json",
- "sha2 0.9.1",
+ "sha2",
  "signatory",
- "signatory-dalek",
  "signatory-ledger-tm",
- "signatory-secp256k1",
  "stdtx",
  "subtle",
  "subtle-encoding",
@@ -2157,7 +2188,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -2278,12 +2309,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,70 +2384,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
-dependencies = [
- "bumpalo",
- "lazy_static",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
-
-[[package]]
-name = "web-sys"
-version = "0.3.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,13 +2437,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
 name = "x25519-dalek"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
- "curve25519-dalek 3.0.0",
- "rand_core 0.5.1",
+ "curve25519-dalek",
+ "rand_core",
  "zeroize",
 ]
 
@@ -2497,28 +2464,33 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.34.0"
+version = "0.35.0-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a09001a8f9f315e342326450eb6d5c7446077b69bfe277b96b92edf7b4bc7ac"
+checksum = "5711694d1003e4074362c3be1597a3d0eb84eee78b726e74a01d91b9bc179887"
 dependencies = [
  "aes",
  "anomaly",
  "bitflags",
  "block-modes",
+ "ccm",
  "chrono",
  "cmac",
- "getrandom",
+ "digest 0.9.0",
+ "ecdsa 0.8.5",
+ "ed25519",
+ "ed25519-dalek",
  "harp",
- "hmac",
+ "hmac 0.9.0",
+ "k256 0.5.9",
  "log",
+ "p256",
+ "p384",
  "pbkdf2",
- "ring",
+ "rand_core",
  "rusb",
- "secp256k1",
  "serde",
  "serde_json",
- "sha2 0.9.1",
- "signatory",
+ "sha2",
  "signature",
  "subtle",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,45 +16,43 @@ abscissa_tokio = { version = "0.5", optional = true }
 bytes = "0.5"
 chacha20poly1305 = "0.5"
 chrono = "0.4"
+ed25519-dalek = "1"
 getrandom = "0.1"
 gumdrop = "0.7"
 hkd32 = { version = "0.4", default-features = false, features = ["mnemonic"] }
 hkdf = "0.9"
 hyper = { version = "0.13", optional = true }
-k256 = "0.3"
+k256 = { version = "0.5", features = ["ecdsa", "sha256"] }
 merlin = "2"
 once_cell = "1.4"
 prost-amino = "0.6"
 prost-amino-derive = "0.6"
-rand = "0.7"
+rand_core = { version = "0.5", features = ["std"] }
 rpassword = { version = "5", optional = true }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
-secp256k1 = { version = "0.17", optional = true }
-signatory = { version = "0.20", features = ["ecdsa", "ed25519", "encoding"] }
-signatory-dalek = "0.20"
-signatory-secp256k1 = { version = "0.20", optional = true }
-signatory-ledger-tm = { version = "0.20", optional = true }
-stdtx = { version = "0.2.4", optional = true }
+signatory = { version = "0.22", features = ["ecdsa", "ed25519", "encoding"] }
+signatory-ledger-tm = { version = "0.22", optional = true }
+stdtx = { version = "0.3", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = { version = "0.15.0", features = ["secp256k1"] }
-tendermint-rpc = { version = "0.15.0", optional = true, features = ["client"] }
+tendermint = { version = "0.16.0", features = ["secp256k1"] }
+tendermint-rpc = { version = "0.16.0", optional = true, features = ["client"] }
 thiserror = "1"
 wait-timeout = "0.2"
 x25519-dalek = "1.1"
-yubihsm = { version = "0.34", features = ["secp256k1", "setup", "usb"], optional = true }
+yubihsm = { version = "=0.35.0-rc", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
 
-[dev-dependencies.abscissa_core]
-version = "0.5"
-features = ["testing"]
+[dev-dependencies]
+abscissa_core = { version = "0.5", features = ["testing"] }
+rand = "0.7"
 
 [features]
 ledgertm = ["signatory-ledger-tm"]
-softsign = ["secp256k1", "signatory-secp256k1"]
+softsign = []
 tx-signer = ["abscissa_tokio", "hyper", "stdtx", "tendermint-rpc"]
 yubihsm-mock = ["yubihsm/mockhsm"]
 yubihsm-server = ["yubihsm/http-server", "rpassword"]

--- a/src/commands/yubihsm/keys/import.rs
+++ b/src/commands/yubihsm/keys/import.rs
@@ -171,7 +171,8 @@ impl ImportCommand {
             .priv_key;
 
         let seed = match private_key {
-            PrivateKey::Ed25519(pk) => pk.to_seed(),
+            PrivateKey::Ed25519(pk) => pk.secret,
+            _ => unreachable!(),
         };
 
         let label =
@@ -183,7 +184,7 @@ impl ImportCommand {
             DEFAULT_DOMAINS,
             DEFAULT_CAPABILITIES | yubihsm::Capability::EXPORTABLE_UNDER_WRAP,
             yubihsm::asymmetric::Algorithm::Ed25519,
-            seed.as_secret_slice(),
+            seed.as_bytes().as_ref(),
         ) {
             status_err!("couldn't import key #{}: {}", self.key_id.unwrap(), e);
             process::exit(1);

--- a/src/commands/yubihsm/keys/list.rs
+++ b/src/commands/yubihsm/keys/list.rs
@@ -121,16 +121,14 @@ fn display_key_info(
         yubihsm::asymmetric::Algorithm::EcK256 => {
             // The YubiHSM2 returns the uncompressed public key, so for
             // compatibility with Tendermint, we have to compress it first
-            let uncompressed_pubkey =
-                k256::PublicKey::from_untagged_point(GenericArray::from_slice(public_key.as_ref()));
+            let compressed_pubkey = k256::EncodedPoint::from_untagged_bytes(
+                GenericArray::from_slice(public_key.as_ref()),
+            )
+            .compress();
 
-            let compressed_point = k256::arithmetic::AffinePoint::from_pubkey(&uncompressed_pubkey)
-                .unwrap()
-                .to_compressed_pubkey();
-
-            let compressed_pubkey =
-                PublicKey::from_raw_secp256k1(compressed_point.as_bytes()).unwrap();
-            TendermintKey::AccountKey(compressed_pubkey)
+            TendermintKey::AccountKey(
+                PublicKey::from_raw_secp256k1(compressed_pubkey.as_ref()).unwrap(),
+            )
         }
         yubihsm::asymmetric::Algorithm::Ed25519 => {
             let pk = PublicKey::from_raw_ed25519(public_key.as_ref()).unwrap();

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -1,13 +1,6 @@
 //! Validator configuration
 
-use crate::{
-    connection::secret_connection,
-    error::{Error, ErrorKind::*},
-    keyring::SecretKeyEncoding,
-    prelude::*,
-};
 use serde::{Deserialize, Serialize};
-use signatory::{ed25519, encoding::Decode};
 use std::path::PathBuf;
 use tendermint::{chain, net};
 
@@ -49,35 +42,6 @@ pub enum TendermintVersion {
     /// Tendermint v0.33+ SecretConnection Handshake
     #[serde(rename = "v0.33")]
     V0_33,
-}
-
-impl ValidatorConfig {
-    /// Load the configured secret key from disk
-    pub fn load_secret_key(&self) -> Result<ed25519::Seed, Error> {
-        let secret_key_path = self.secret_key.as_ref().ok_or_else(|| {
-            format_err!(
-                VerificationError,
-                "config error: no `secret_key` for validator {}",
-                &self.addr
-            )
-        })?;
-
-        if !secret_key_path.exists() {
-            secret_connection::generate_key(&secret_key_path)?;
-        }
-
-        ed25519::Seed::decode_from_file(secret_key_path, &SecretKeyEncoding::default()).map_err(
-            |e| {
-                format_err!(
-                    ConfigError,
-                    "error loading Secret Connection key from {}: {}",
-                    secret_key_path.display(),
-                    e
-                )
-                .into()
-            },
-        )
-    }
 }
 
 /// Default value for the `ValidatorConfig` reconnect field

--- a/src/connection/secret_connection/public_key.rs
+++ b/src/connection/secret_connection/public_key.rs
@@ -1,7 +1,7 @@
 //! Secret Connection peer public keys
 
+use ed25519_dalek as ed25519;
 use sha2::{digest::Digest, Sha256};
-use signatory::ed25519;
 use std::fmt::{self, Display};
 use tendermint::{
     error::{self, Error},
@@ -9,18 +9,18 @@ use tendermint::{
 };
 
 /// Secret Connection peer public keys (signing, presently Ed25519-only)
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum PublicKey {
-    /// Ed25519 Secret Connection keys
+    /// Ed25519 Secret Connection Keys
     Ed25519(ed25519::PublicKey),
 }
 
 impl PublicKey {
     /// From raw Ed25519 public key bytes
     pub fn from_raw_ed25519(bytes: &[u8]) -> Result<PublicKey, Error> {
-        Ok(PublicKey::Ed25519(
-            ed25519::PublicKey::from_bytes(bytes).ok_or_else(|| error::Kind::Crypto)?,
-        ))
+        ed25519::PublicKey::from_bytes(bytes)
+            .map(PublicKey::Ed25519)
+            .map_err(|_| error::Kind::Crypto.into())
     }
 
     /// Get Ed25519 public key
@@ -47,6 +47,12 @@ impl PublicKey {
 impl Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.peer_id())
+    }
+}
+
+impl From<&ed25519::Keypair> for PublicKey {
+    fn from(sk: &ed25519::Keypair) -> PublicKey {
+        PublicKey::Ed25519(sk.public)
     }
 }
 

--- a/src/key_utils.rs
+++ b/src/key_utils.rs
@@ -1,0 +1,76 @@
+//! Utilities
+
+use crate::{
+    error::{Error, ErrorKind::*},
+    prelude::*,
+};
+use ed25519_dalek as ed25519;
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    os::unix::fs::OpenOptionsExt,
+    path::Path,
+};
+use subtle_encoding::base64;
+use zeroize::Zeroizing;
+
+/// File permissions for secret data
+pub const SECRET_FILE_PERMS: u32 = 0o600;
+
+/// Load Base64-encoded secret data (i.e. key) from the given path
+pub fn load_base64_secret(path: impl AsRef<Path>) -> Result<Zeroizing<Vec<u8>>, Error> {
+    // TODO(tarcieri): check file permissions are correct
+    let base64_data = Zeroizing::new(fs::read_to_string(path.as_ref()).map_err(|e| {
+        format_err!(
+            IoError,
+            "couldn't read key from {}: {}",
+            path.as_ref().display(),
+            e
+        )
+    })?);
+
+    // TODO(tarcieri): constant-time string trimming
+    let data = Zeroizing::new(base64::decode(base64_data.trim_end()).map_err(|e| {
+        format_err!(
+            IoError,
+            "can't decode key from `{}`: {}",
+            path.as_ref().display(),
+            e
+        )
+    })?);
+
+    Ok(data)
+}
+
+/// Load a Base64-encoded Ed25519 secret key
+pub fn load_base64_ed25519_key(path: impl AsRef<Path>) -> Result<ed25519::Keypair, Error> {
+    let key_bytes = load_base64_secret(path)?;
+
+    let secret = ed25519::SecretKey::from_bytes(&*key_bytes)
+        .map_err(|e| format_err!(InvalidKey, "invalid Ed25519 key: {}", e))?;
+
+    let public = ed25519::PublicKey::from(&secret);
+    Ok(ed25519::Keypair { secret, public })
+}
+
+/// Store Base64-encoded secret data at the given path
+pub fn write_base64_secret(path: impl AsRef<Path>, data: &[u8]) -> Result<(), Error> {
+    let base64_data = Zeroizing::new(base64::encode(data));
+
+    OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(SECRET_FILE_PERMS)
+        .open(path.as_ref())
+        .and_then(|mut file| file.write_all(&*base64_data))
+        .map_err(|e| {
+            format_err!(
+                IoError,
+                "couldn't write `{}`: {}",
+                path.as_ref().display(),
+                e
+            )
+            .into()
+        })
+}

--- a/src/keyring/ecdsa.rs
+++ b/src/keyring/ecdsa.rs
@@ -1,6 +1,6 @@
 //! ECDSA keys
 
-pub use signatory::ecdsa::curve::secp256k1::{FixedSignature as Signature, PublicKey};
+pub use k256::{ecdsa::Signature, EncodedPoint as PublicKey};
 
 use crate::{
     error::{Error, ErrorKind::*},

--- a/src/keyring/providers/softsign.rs
+++ b/src/keyring/providers/softsign.rs
@@ -9,15 +9,13 @@ use crate::{
         KeyType,
     },
     error::{Error, ErrorKind::*},
-    keyring::{self, SecretKeyEncoding, SigningProvider},
+    key_utils,
+    keyring::{self, SigningProvider},
     prelude::*,
 };
-use signatory::{ed25519, encoding::Decode, public_key::PublicKeyed};
-use signatory_dalek::Ed25519Signer;
-use signatory_secp256k1::EcdsaSigner;
-use std::{fs, process};
+use ed25519_dalek as ed25519;
+use k256::ecdsa;
 use tendermint::{config::PrivValidatorKey, PrivateKey, TendermintKey};
-use zeroize::Zeroizing;
 
 /// Create software-backed Ed25519 signer objects from the given configuration
 pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) -> Result<(), Error> {
@@ -31,13 +29,9 @@ pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) ->
         match config.key_type {
             KeyType::Account => {
                 let signer = load_secp256k1_key(&config)?;
-                let public_key = tendermint::PublicKey::from_raw_secp256k1(
-                    signer
-                        .public_key()
-                        .map_err(|_| Error::from(InvalidKey))?
-                        .as_bytes(),
-                )
-                .unwrap();
+                let public_key =
+                    tendermint::PublicKey::from_raw_secp256k1(&signer.verify_key().to_bytes())
+                        .unwrap();
 
                 let account_pubkey = TendermintKey::AccountKey(public_key);
 
@@ -61,15 +55,13 @@ pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) ->
 
                 loaded_consensus_key = true;
 
-                let signer = load_ed25519_key(&config)?;
-                let public_key = signer.public_key().map_err(|_| Error::from(InvalidKey))?;
-
-                let consensus_pubkey = TendermintKey::ConsensusKey(public_key.into());
+                let signing_key = load_ed25519_key(&config)?;
+                let consensus_pubkey = TendermintKey::ConsensusKey(signing_key.public.into());
 
                 let signer = keyring::ed25519::Signer::new(
                     SigningProvider::SoftSign,
                     consensus_pubkey,
-                    Box::new(signer),
+                    Box::new(signing_key),
                 );
 
                 for chain_id in &config.chain_ids {
@@ -83,52 +75,34 @@ pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) ->
 }
 
 /// Load an Ed25519 key according to the provided configuration
-fn load_ed25519_key(config: &SoftsignConfig) -> Result<Ed25519Signer, Error> {
+fn load_ed25519_key(config: &SoftsignConfig) -> Result<ed25519::Keypair, Error> {
     let key_format = config.key_format.as_ref().cloned().unwrap_or_default();
 
     match key_format {
-        KeyFormat::Base64 => {
-            let key_base64 = Zeroizing::new(fs::read_to_string(&config.path).map_err(|e| {
-                format_err!(
-                    ConfigError,
-                    "couldn't read key from `{}`: {}",
-                    &config.path.as_ref().display(),
-                    e
-                )
-            })?);
-
-            let seed = ed25519::Seed::decode_from_str(
-                key_base64.trim_end(),
-                &SecretKeyEncoding::default(),
-            )
-            .map_err(|e| {
-                format_err!(
-                    ConfigError,
-                    "can't decode key from `{}`: {}",
-                    config.path.as_ref().display(),
-                    e
-                )
-            })?;
-
-            Ok(Ed25519Signer::from(&seed))
-        }
+        KeyFormat::Base64 => key_utils::load_base64_ed25519_key(&config.path),
         KeyFormat::Json => {
             let private_key = PrivValidatorKey::load_json_file(&config.path)
-                .unwrap_or_else(|e| {
-                    status_err!("couldn't load `{}`: {}", config.path.as_ref().display(), e);
-                    process::exit(1);
-                })
+                .map_err(|e| {
+                    format_err!(
+                        ConfigError,
+                        "couldn't load `{}`: {}",
+                        config.path.as_ref().display(),
+                        e
+                    )
+                })?
                 .priv_key;
 
-            match private_key {
-                PrivateKey::Ed25519(pk) => Ok(pk.to_signer()),
+            if let PrivateKey::Ed25519(pk) = private_key {
+                Ok(pk)
+            } else {
+                unreachable!("unsupported priv_validator.json algorithm");
             }
         }
     }
 }
 
 /// Load a secp256k1 (ECDSA) key according to the provided configuration
-fn load_secp256k1_key(config: &SoftsignConfig) -> Result<EcdsaSigner, Error> {
+fn load_secp256k1_key(config: &SoftsignConfig) -> Result<ecdsa::SigningKey, Error> {
     if config.key_format.unwrap_or_default() != KeyFormat::Base64 {
         fail!(
             ConfigError,
@@ -136,36 +110,16 @@ fn load_secp256k1_key(config: &SoftsignConfig) -> Result<EcdsaSigner, Error> {
         );
     }
 
-    let key_base64 = Zeroizing::new(fs::read_to_string(&config.path).map_err(|e| {
+    let key_bytes = key_utils::load_base64_secret(&config.path)?;
+
+    let secret_key = ecdsa::SigningKey::new(key_bytes.as_slice()).map_err(|e| {
         format_err!(
             ConfigError,
-            "couldn't read key from {}: {}",
-            &config.path.as_ref().display(),
+            "can't decode account key base64 from {}: {}",
+            config.path.as_ref().display(),
             e
         )
-    })?);
+    })?;
 
-    // TODO(tarcieri): constant-time string trimming
-    let key_bytes = Zeroizing::new(
-        subtle_encoding::base64::decode(key_base64.trim_end()).map_err(|e| {
-            format_err!(
-                ConfigError,
-                "can't decode key from `{}`: {}",
-                config.path.as_ref().display(),
-                e
-            )
-        })?,
-    );
-
-    let secret_key =
-        signatory_secp256k1::SecretKey::from_bytes(key_bytes.as_slice()).map_err(|e| {
-            format_err!(
-                ConfigError,
-                "can't decode account key base64 from {}: {}",
-                config.path.as_ref().display(),
-                e
-            )
-        })?;
-
-    Ok(EcdsaSigner::from(&secret_key))
+    Ok(secret_key)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod commands;
 pub mod config;
 pub mod connection;
 pub mod error;
+pub mod key_utils;
 pub mod keyring;
 pub mod prelude;
 pub mod rpc;

--- a/src/session.rs
+++ b/src/session.rs
@@ -38,7 +38,6 @@ impl Session {
                     &config.chain_id, &config.addr
                 );
 
-                let seed = config.load_secret_key()?;
                 let v0_33_handshake = match config.protocol_version {
                     TendermintVersion::V0_33 => true,
                     TendermintVersion::Legacy => false,
@@ -47,7 +46,7 @@ impl Session {
                 let conn = tcp::open_secret_connection(
                     host,
                     *port,
-                    &seed,
+                    &config.secret_key,
                     peer_id,
                     config.timeout,
                     v0_33_handshake,

--- a/src/tx_signer.rs
+++ b/src/tx_signer.rs
@@ -296,7 +296,7 @@ impl TxSigner {
             .keyring
             .get_account_pubkey(account_id)
             .expect("missing account key")
-            .as_bytes();
+            .to_bytes();
 
         let msg_type_info = msg_types
             .iter()


### PR DESCRIPTION
Upgrades the following dependencies to the latest versions:

- `signatory` v0.22.0
- `stdtx` v0.3.0
- `k256` v0.5.9
- `tendermint` v0.16.0
- `yubihsm` v0.35.0-rc

This commit also moves away from Signatory-based abstractions in several places, leaning more directly on `ed25519-dalek` and the `k256` crate, the latter of which now contains full ECDSA/secp256k1 support. Additionally, it completely removes use of `signatory-dalek` and `rust-secp256k1`/`signatory-secp256k1`.

The rationale is that ed25519-dalek has natively adopted the `Signer` and `Verifier` traits which Signatory originally provided, which eliminates the need to use it through an abstraction layer/wrapper. The `signatory-dalek` crate has also since been retired.