### PR TITLE
tx_signer: increment sequence on DeliverTx failure

### DIFF
--- a/src/tx_signer/jsonrpc.rs
+++ b/src/tx_signer/jsonrpc.rs
@@ -29,7 +29,8 @@ impl Client {
     }
 
     /// Request transactions to be signed from the transaction service
-    pub async fn request(&self) -> Result<Vec<TxSigningRequest>, Error> {
+    pub async fn request(&self, _last_tx_ok: bool) -> Result<Vec<TxSigningRequest>, Error> {
+        // TODO(tarcieri): incorporate `last_tx_ok` into request
         let mut request = hyper::Request::post(&self.uri).body(hyper::Body::empty())?;
 
         {


### PR DESCRIPTION
If DeliverTx fails, the transaction has still been accepted by the chain and the sequence number still needs to be updated.

This introduces separate handling for CheckTx vs DeliverTx failures, and ensures if CheckTx succeeds the sequence number is still incremented.