### PR TITLE
tx_signer: only send sync info in request

### DIFF
--- a/src/tx_signer.rs
+++ b/src/tx_signer.rs
@@ -217,7 +217,7 @@ impl TxSigner {
         let params = jsonrpc::Request {
             network: self.chain_id,
             context: self.context.clone(),
-            status,
+            status: status.sync_info,
             last_tx_response: self.last_tx_response.take(),
         };
 

--- a/src/tx_signer/jsonrpc.rs
+++ b/src/tx_signer/jsonrpc.rs
@@ -73,7 +73,7 @@ pub struct Request {
     pub context: String,
 
     /// Network status
-    pub status: status::Response,
+    pub status: status::SyncInfo,
 
     /// Response from last signed TX (if available)
     pub last_tx_response: Option<tx_commit::Response>,


### PR DESCRIPTION
Previously the KMS sent the entire status reply. This commit whittles it down to just the sync info, which is probably the most relevant thing.