### PR TITLE
tx_signer: extract `LastTx` and `SignMsg` types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.43.0
+          - 1.44.0 # MSRV
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -95,7 +95,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.43.0
+          - 1.44.0 # MSRV
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -273,7 +273,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.44.0 # MSRV
           override: true
 
       - name: Install libudev-dev

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If successful, this will produce a `tmkms` executable located at
 
 ### Installing with the `cargo install` command
 
-With Rust (1.41+) installed, you can install tmkms with the following:
+With Rust (1.44+) installed, you can install tmkms with the following:
 
 ```
 cargo install tmkms --features=yubihsm
@@ -230,7 +230,7 @@ limitations under the License.
 [build-link]: https://github.com/iqlusioninc/tmkms/actions
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/tmkms/blob/develop/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.41+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.44+-blue.svg
 
 [//]: # (general links)
 

--- a/src/tx_signer/last_tx.rs
+++ b/src/tx_signer/last_tx.rs
@@ -1,0 +1,64 @@
+//! State of the last transaction signed by a particular signer
+
+use tendermint_rpc::endpoint::broadcast::tx_commit;
+
+/// State of the last broadcasted transaction
+#[derive(Clone, Debug)]
+pub enum LastTx {
+    /// No previously broadcast transaction (i.e. starting up)
+    None,
+
+    /// Tendermint RPC response
+    Response(tx_commit::Response),
+
+    /// Error broadcasting the previous transaction
+    Error(tendermint_rpc::error::Error),
+}
+
+impl Default for LastTx {
+    fn default() -> LastTx {
+        LastTx::None
+    }
+}
+
+impl LastTx {
+    /// Get the RPC response, if there was one
+    pub fn response(&self) -> Option<&tx_commit::Response> {
+        match self {
+            LastTx::Response(ref resp) => Some(resp),
+            _ => None,
+        }
+    }
+
+    /// Get the RPC error, if there was one
+    pub fn error(&self) -> Option<&tendermint_rpc::error::Error> {
+        match self {
+            LastTx::Error(ref resp) => Some(resp),
+            _ => None,
+        }
+    }
+
+    /// Was there no last TX?
+    pub fn is_none(&self) -> bool {
+        match self {
+            LastTx::None => true,
+            _ => false,
+        }
+    }
+
+    /// Was there a response from the last transaction broadcast?
+    pub fn is_response(&self) -> bool {
+        self.response().is_some()
+    }
+
+    /// Was there an error broadcasting the last transaction?
+    pub fn is_error(&self) -> bool {
+        self.error().is_some()
+    }
+}
+
+impl From<&LastTx> for Option<tx_commit::Response> {
+    fn from(state: &LastTx) -> Option<tx_commit::Response> {
+        state.response().cloned()
+    }
+}

--- a/src/tx_signer/sign_msg.rs
+++ b/src/tx_signer/sign_msg.rs
@@ -1,0 +1,96 @@
+//! String representation of a message to be signed
+
+use super::tx_request::TxSigningRequest;
+use crate::{
+    config::tx_signer::TxAcl,
+    error::{Error, ErrorKind},
+    prelude::*,
+};
+use std::collections::BTreeSet as Set;
+use stdtx::{Msg, StdFee, StdSignature, StdTx, TypeName};
+
+/// String representation of a message that describes a particular transaction
+/// to be signed by transaction signer
+pub struct SignMsg {
+    /// Fee
+    pub fee: StdFee,
+
+    /// Memo
+    pub memo: String,
+
+    /// Messages
+    msgs: Vec<Msg>,
+
+    /// Message types
+    msg_types: Set<TypeName>,
+
+    /// String representation
+    repr: String,
+}
+
+impl SignMsg {
+    /// Create a new [`SignMsg`] from a [`TxSigningRequest`]
+    pub fn new(
+        req: TxSigningRequest,
+        tx_builder: &stdtx::Builder,
+        sequence: u64,
+    ) -> Result<Self, Error> {
+        let mut msgs = vec![];
+        let mut msg_types = Set::new();
+
+        for msg_value in &req.msgs {
+            let msg = stdtx::Msg::from_json_value(tx_builder.schema(), msg_value.clone())?;
+            msg_types.insert(msg.type_name().clone());
+            msgs.push(msg);
+        }
+
+        let repr = tx_builder.create_sign_msg(sequence, &req.fee, &req.memo, msgs.as_slice());
+
+        Ok(Self {
+            fee: req.fee.clone(),
+            memo: req.memo,
+            msgs,
+            msg_types,
+            repr,
+        })
+    }
+
+    /// Authorize a message for signing according to the given ACL
+    pub fn authorize(&self, acl: &TxAcl) -> Result<(), Error> {
+        // Ensure message types are authorized in the ACL
+        for msg_type in &self.msg_types {
+            if !acl.msg_type.contains(&msg_type) {
+                fail!(
+                    ErrorKind::AccessError,
+                    "unauthorized request to sign `{}` message",
+                    msg_type
+                );
+            }
+        }
+
+        // TODO(tarcieri): check fee
+        // if req.fee != ...
+
+        Ok(())
+    }
+
+    /// Serialize a [`StdTx`] after obtaining a signature
+    pub fn to_stdtx(&self, sig: StdSignature) -> StdTx {
+        StdTx::new(&self.msgs, self.fee.clone(), vec![sig], self.memo.clone())
+    }
+
+    /// Borrow the signed messages
+    pub fn msgs(&self) -> &[Msg] {
+        self.msgs.as_slice()
+    }
+
+    /// Borrow the set of signed message types
+    pub fn msg_types(&self) -> &Set<TypeName> {
+        &self.msg_types
+    }
+
+    /// Get the signed byte representation
+    pub fn sign_bytes(&self) -> &[u8] {
+        self.repr.as_bytes()
+    }
+}


### PR DESCRIPTION
Adds complete tracking of the state of the last signed transaction in the form of a `LastTx` enum, which stores whether we're just starting up, whether we got a response from Tendermint, or if the last transaction errored out (storing the error).

Additionally extracts a SignMsg type which encapsulates all of the values needed to produce a signature and handles a flow:

    TxSigningRequest -> SignMsg -> StdTx