### PR TITLE
tx_signer: speculatively increment sequence on error

### DIFF
--- a/src/tx_signer/sign_msg.rs
+++ b/src/tx_signer/sign_msg.rs
@@ -31,7 +31,7 @@ pub struct SignMsg {
 impl SignMsg {
     /// Create a new [`SignMsg`] from a [`TxSigningRequest`]
     pub fn new(
-        req: TxSigningRequest,
+        req: &TxSigningRequest,
         tx_builder: &stdtx::Builder,
         sequence: u64,
     ) -> Result<Self, Error> {
@@ -48,7 +48,7 @@ impl SignMsg {
 
         Ok(Self {
             fee: req.fee.clone(),
-            memo: req.memo,
+            memo: req.memo.clone(),
             msgs,
             msg_types,
             repr,


### PR DESCRIPTION
When encountering an error broadcasting a transaction, speculatively retry the operation once with an incremented sequence number.

This is to handle the case where a transaction was successfully broadcast, but an error occurred returning the response.

In such a case, the sequence number may be out-of-sync with the chain, so if we replay the transaction in such cases we may get it to succeed.