### PR TITLE
Remove `signatory`; vendor signatory-ledger-tm under `ledger` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
       - run: cargo build --no-default-features --features softsign --release
       - run: cargo build --features=yubihsm --release
       - run: cargo build --features=yubihsm-server --release
-      - run: cargo build --features=ledgertm --release
-      - run: cargo build --features=yubihsm-server,ledgertm,softsign --release
+      - run: cargo build --features=ledger --release
+      - run: cargo build --features=yubihsm-server,ledger,softsign --release
 
   test:
     name: Test Suite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,32 +1773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatory"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674dfa3a5b97b62e039b9e9d94f23887c6b474a7294f272a10327d65af2c8001"
-dependencies = [
- "ecdsa 0.8.5",
- "ed25519",
- "getrandom",
- "signature",
- "subtle-encoding",
- "zeroize",
-]
-
-[[package]]
-name = "signatory-ledger-tm"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecb58903611cba0d53430835782d57c26f2a90f67072d3214ca530428472000"
-dependencies = [
- "byteorder",
- "ledger",
- "signatory",
- "thiserror",
-]
-
-[[package]]
 name = "signature"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2054,7 @@ version = "0.9.0-rc6"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
+ "byteorder",
  "bytes",
  "chacha20poly1305",
  "chrono",
@@ -2090,6 +2065,7 @@ dependencies = [
  "hkdf",
  "hyper",
  "k256 0.5.9",
+ "ledger",
  "merlin",
  "once_cell",
  "prost-amino",
@@ -2100,8 +2076,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "signatory",
- "signatory-ledger-tm",
+ "signature",
  "stdtx",
  "subtle",
  "subtle-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hkd32 = { version = "0.5", default-features = false, features = ["mnemonic"] }
 hkdf = "0.10.0-alpha.0"
 hyper = { version = "0.13", optional = true }
 k256 = { version = "0.5", features = ["ecdsa", "sha256"] }
+ledger = { version = "0.2", optional = true }
 merlin = "2"
 once_cell = "1.4"
 prost-amino = "0.6"
@@ -32,8 +33,7 @@ rpassword = { version = "5", optional = true }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
-signatory = { version = "0.22", features = ["ecdsa", "ed25519", "encoding"] }
-signatory-ledger-tm = { version = "0.22", optional = true }
+signature = { version = "1.2", features = ["std"] }
 stdtx = { version = "0.3", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
@@ -48,10 +48,10 @@ zeroize = "1"
 
 [dev-dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }
+byteorder = "1"
 rand = "0.7"
 
 [features]
-ledgertm = ["signatory-ledger-tm"]
 softsign = []
 tx-signer = ["abscissa_tokio", "hyper", "stdtx", "tendermint-rpc"]
 yubihsm-mock = ["yubihsm/mockhsm"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following signing backend providers are presently supported:
 #### Hardware Security Modules (recommended)
 
 - [YubiHSM2] (gated under the `yubihsm` cargo feature. See [README.yubihsm.md][yubihsm2] for more info)
-- [Ledger] (gated under the `ledgertm` cargo feature)
+- [Ledger] (gated under the `ledger` cargo feature)
 
 #### Software-Only (not recommended)
 
@@ -110,7 +110,7 @@ $ git clone https://github.com/iqlusioninc/tmkms.git && cd tmkms
 $ cargo build --release --features=yubihsm
 ```
 
-Alternatively, substitute `--features=ledgertm` to enable Ledger support.
+Alternatively, substitute `--features=ledger` to enable Ledger support.
 
 If successful, this will produce a `tmkms` executable located at
 `./target/release/tmkms`
@@ -129,7 +129,7 @@ Or to install a specific version (recommended):
 cargo install tmkms --features=yubihsm --version=0.4.0
 ```
 
-Alternatively, substitute `--features=ledgertm` to enable Ledger support.
+Alternatively, substitute `--features=ledger` to enable Ledger support.
 
 ## Configuration: `tmkms init`
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,7 +1,7 @@
 //! Subcommands of the `tmkms` command-line application
 
 pub mod init;
-#[cfg(feature = "ledgertm")]
+#[cfg(feature = "ledger")]
 pub mod ledger;
 #[cfg(feature = "softsign")]
 pub mod softsign;
@@ -10,7 +10,7 @@ pub mod version;
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;
 
-#[cfg(feature = "ledgertm")]
+#[cfg(feature = "ledger")]
 pub use self::ledger::LedgerCommand;
 #[cfg(feature = "softsign")]
 pub use self::softsign::SoftsignCommand;
@@ -47,8 +47,8 @@ pub enum KmsCommand {
     #[options(help = "subcommands for YubiHSM2")]
     Yubihsm(YubihsmCommand),
 
-    /// `ledgertm` subcommand
-    #[cfg(feature = "ledgertm")]
+    /// `ledger` subcommand
+    #[cfg(feature = "ledger")]
     #[options(help = "subcommands for Ledger")]
     Ledger(LedgerCommand),
 
@@ -78,7 +78,7 @@ impl Configurable<KmsConfig> for KmsCommand {
             KmsCommand::Start(start) => start.config.as_ref(),
             #[cfg(feature = "yubihsm")]
             KmsCommand::Yubihsm(yubihsm) => yubihsm.config_path(),
-            #[cfg(feature = "ledgertm")]
+            #[cfg(feature = "ledger")]
             KmsCommand::Ledger(ledger) => ledger.config_path(),
             _ => return None,
         };

--- a/src/commands/init/config_builder.rs
+++ b/src/commands/init/config_builder.rs
@@ -75,7 +75,7 @@ impl ConfigBuilder {
         #[cfg(feature = "yubihsm")]
         self.add_yubihsm_provider_config();
 
-        #[cfg(feature = "ledgertm")]
+        #[cfg(feature = "ledger")]
         self.add_ledgertm_provider_config();
 
         #[cfg(feature = "softsign")]
@@ -149,7 +149,7 @@ impl ConfigBuilder {
     }
 
     /// Add `[[provdier.ledgertm]]` configuration
-    #[cfg(feature = "ledgertm")]
+    #[cfg(feature = "ledger")]
     fn add_ledgertm_provider_config(&mut self) {
         self.add_str("### Ledger Provider Configuration\n\n");
         self.add_template_with_chain_id(include_str!("templates/keyring/ledgertm.toml"));

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -1,13 +1,13 @@
 //! Cryptographic service providers: signing backends
 
-#[cfg(feature = "ledgertm")]
+#[cfg(feature = "ledger")]
 pub mod ledgertm;
 #[cfg(feature = "softsign")]
 pub mod softsign;
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;
 
-#[cfg(feature = "ledgertm")]
+#[cfg(feature = "ledger")]
 use self::ledgertm::LedgerTendermintConfig;
 #[cfg(feature = "softsign")]
 use self::softsign::SoftsignConfig;
@@ -32,7 +32,7 @@ pub struct ProviderConfig {
     pub yubihsm: Vec<YubihsmConfig>,
 
     /// Map of ledger-tm labels to their configurations
-    #[cfg(feature = "ledgertm")]
+    #[cfg(feature = "ledger")]
     #[serde(default)]
     pub ledgertm: Vec<LedgerTendermintConfig>,
 }

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -184,7 +184,7 @@ pub fn load_config(registry: &mut chain::Registry, config: &ProviderConfig) -> R
     #[cfg(feature = "yubihsm")]
     providers::yubihsm::init(registry, &config.yubihsm)?;
 
-    #[cfg(feature = "ledgertm")]
+    #[cfg(feature = "ledger")]
     providers::ledgertm::init(registry, &config.ledgertm)?;
 
     Ok(())

--- a/src/keyring/ecdsa.rs
+++ b/src/keyring/ecdsa.rs
@@ -7,7 +7,6 @@ use crate::{
     keyring::SigningProvider,
     prelude::*,
 };
-use signatory::signature;
 use std::sync::Arc;
 use tendermint::TendermintKey;
 

--- a/src/keyring/ed25519.rs
+++ b/src/keyring/ed25519.rs
@@ -1,13 +1,12 @@
 //! Ed25519 signing keys
 
-pub use signatory::ed25519::{PublicKey, Seed, Signature, PUBLIC_KEY_SIZE};
+pub use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature};
 
 use crate::{
     error::{Error, ErrorKind::*},
     keyring::SigningProvider,
     prelude::*,
 };
-use signatory::signature;
 use std::sync::Arc;
 use tendermint::TendermintKey;
 

--- a/src/keyring/providers.rs
+++ b/src/keyring/providers.rs
@@ -1,6 +1,6 @@
 //! Signature providers (i.e. backends/plugins)
 
-#[cfg(feature = "ledgertm")]
+#[cfg(feature = "ledger")]
 pub mod ledgertm;
 
 #[cfg(feature = "softsign")]
@@ -19,7 +19,7 @@ pub enum SigningProvider {
     Yubihsm,
 
     /// Ledger + Tendermint application
-    #[cfg(feature = "ledgertm")]
+    #[cfg(feature = "ledger")]
     LedgerTm,
 
     /// Software signer (not intended for production use)
@@ -33,7 +33,7 @@ impl Display for SigningProvider {
             #[cfg(feature = "yubihsm")]
             SigningProvider::Yubihsm => write!(f, "yubihsm"),
 
-            #[cfg(feature = "ledgertm")]
+            #[cfg(feature = "ledger")]
             SigningProvider::LedgerTm => write!(f, "ledgertm"),
 
             #[cfg(feature = "softsign")]

--- a/src/keyring/providers/ledgertm.rs
+++ b/src/keyring/providers/ledgertm.rs
@@ -1,5 +1,10 @@
 //! Ledger Tendermint signer
 
+mod client;
+mod error;
+mod signer;
+
+use self::signer::Ed25519LedgerTmAppSigner;
 use crate::{
     chain,
     config::provider::ledgertm::LedgerTendermintConfig,
@@ -10,7 +15,6 @@ use crate::{
     },
     prelude::*,
 };
-use signatory_ledger_tm::Ed25519LedgerTmAppSigner;
 use tendermint::{PublicKey, TendermintKey};
 
 /// Create Ledger Tendermint signer object from the given configuration

--- a/src/keyring/providers/ledgertm/client.rs
+++ b/src/keyring/providers/ledgertm/client.rs
@@ -1,0 +1,340 @@
+//! Ledger Tendermint signer
+
+/*******************************************************************************
+*   (c) 2018, 2019 ZondaX GmbH
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+use super::error::Error;
+use ledger::{ApduAnswer, ApduCommand};
+
+const CLA: u8 = 0x56;
+const INS_PUBLIC_KEY_ED25519: u8 = 0x01;
+const INS_SIGN_ED25519: u8 = 0x02;
+
+const USER_MESSAGE_CHUNK_SIZE: usize = 250;
+
+#[allow(dead_code)]
+const INS_GET_VERSION: u8 = 0x00;
+
+pub(super) struct TendermintValidatorApp {
+    app: ledger::LedgerApp,
+}
+
+// TODO(tarcieri): check this is actually sound?!
+#[allow(unsafe_code)]
+unsafe impl Send for TendermintValidatorApp {}
+
+#[allow(dead_code)]
+pub struct Version {
+    mode: u8,
+    major: u8,
+    minor: u8,
+    patch: u8,
+}
+
+impl TendermintValidatorApp {
+    pub fn connect() -> Result<Self, Error> {
+        let app = ledger::LedgerApp::new()?;
+        Ok(TendermintValidatorApp { app })
+    }
+
+    /// Get version
+    #[allow(dead_code)]
+    pub fn version(&self) -> Result<Version, Error> {
+        let command = ApduCommand {
+            cla: CLA,
+            ins: INS_GET_VERSION,
+            p1: 0x00,
+            p2: 0x00,
+            length: 0,
+            data: Vec::new(),
+        };
+
+        let response = self.app.exchange(command)?;
+
+        // TODO: this is just temporary, ledger errors should check for 0x9000
+        if response.retcode != 0x9000 {
+            return Err(Error::InvalidVersion);
+        }
+
+        let version = Version {
+            mode: response.data[0],
+            major: response.data[1],
+            minor: response.data[2],
+            patch: response.data[3],
+        };
+
+        Ok(version)
+    }
+
+    /// Get public key
+    pub fn public_key(&self) -> Result<[u8; 32], Error> {
+        let command = ApduCommand {
+            cla: CLA,
+            ins: INS_PUBLIC_KEY_ED25519,
+            p1: 0x00,
+            p2: 0x00,
+            length: 0,
+            data: Vec::new(),
+        };
+
+        match self.app.exchange(command) {
+            Ok(response) => {
+                if response.retcode != 0x9000 {
+                    println!("WARNING: retcode={:X?}", response.retcode);
+                }
+
+                if response.data.len() != 32 {
+                    return Err(Error::InvalidPK);
+                }
+
+                let mut array = [0u8; 32];
+                array.copy_from_slice(&response.data[..32]);
+                Ok(array)
+            }
+            Err(err) => {
+                // TODO: Friendly error
+                Err(Error::Ledger(err))
+            }
+        }
+    }
+
+    /// Sign message
+    pub fn sign(&self, message: &[u8]) -> Result<[u8; 64], Error> {
+        let chunks = message.chunks(USER_MESSAGE_CHUNK_SIZE);
+
+        if chunks.len() > 255 {
+            return Err(Error::InvalidMessageSize);
+        }
+
+        if chunks.len() == 0 {
+            return Err(Error::InvalidEmptyMessage);
+        }
+
+        let packet_count = chunks.len() as u8;
+        let mut response: ApduAnswer = ApduAnswer {
+            data: vec![],
+            retcode: 0,
+        };
+
+        // Send message chunks
+        for (packet_idx, chunk) in chunks.enumerate() {
+            let _command = ApduCommand {
+                cla: CLA,
+                ins: INS_SIGN_ED25519,
+                p1: (packet_idx + 1) as u8,
+                p2: packet_count,
+                length: chunk.len() as u8,
+                data: chunk.to_vec(),
+            };
+
+            response = self.app.exchange(_command)?;
+        }
+
+        if response.data.is_empty() && response.retcode == 0x9000 {
+            return Err(Error::NoSignature);
+        }
+
+        // Last response should contain the answer
+        if response.data.len() != 64 {
+            return Err(Error::InvalidSignature);
+        }
+
+        let mut array = [0u8; 64];
+        array.copy_from_slice(&response.data[..64]);
+        Ok(array)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ed25519_dalek::ed25519::signature::{Signature, Verifier};
+    use once_cell::sync::Lazy;
+    use std::sync::Mutex;
+    use std::time::Instant;
+
+    use super::{Error, TendermintValidatorApp};
+
+    static APP: Lazy<Mutex<TendermintValidatorApp>> =
+        Lazy::new(|| Mutex::new(TendermintValidatorApp::connect().unwrap()));
+
+    fn get_fake_proposal(index: u64, round: i64) -> Vec<u8> {
+        use byteorder::{LittleEndian, WriteBytesExt};
+        let other: [u8; 12] = [
+            0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+        ];
+
+        let mut message = Vec::new();
+        message.write_u8(0).unwrap(); // (field_number << 3) | wire_type
+
+        message.write_u8(0x08).unwrap(); // (field_number << 3) | wire_type
+        message.write_u8(0x01).unwrap(); // PrevoteType
+
+        message.write_u8(0x11).unwrap(); // (field_number << 3) | wire_type
+        message.write_u64::<LittleEndian>(index).unwrap();
+
+        message.write_u8(0x19).unwrap(); // (field_number << 3) | wire_type
+        message.write_i64::<LittleEndian>(round).unwrap();
+
+        // remaining fields (timestamp, not checked):
+        message.write_u8(0x22).unwrap(); // (field_number << 3) | wire_type
+        message.extend_from_slice(&other);
+
+        // Increase index
+        message[0] = message.len() as u8 - 1;
+        message
+    }
+
+    #[test]
+    #[ignore]
+    fn version() {
+        let app = APP.lock().unwrap();
+
+        let resp = app.version();
+
+        match resp {
+            Ok(version) => {
+                println!("mode  {}", version.mode);
+                println!("major {}", version.major);
+                println!("minor {}", version.minor);
+                println!("patch {}", version.patch);
+
+                assert_eq!(version.mode, 0xFF);
+                assert_eq!(version.major, 0x00);
+                assert!(version.minor >= 0x04);
+            }
+            Err(err) => {
+                eprintln!("Error: {:?}", err);
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn public_key() {
+        let app = APP.lock().unwrap();
+        let resp = app.public_key();
+
+        match resp {
+            Ok(pk) => {
+                assert_eq!(pk.len(), 32);
+                println!("PK {:0X?}", pk);
+            }
+            Err(err) => {
+                eprintln!("Error: {:?}", err);
+                panic!()
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn sign_empty() {
+        let app = APP.lock().unwrap();
+
+        let some_message0 = b"";
+
+        let signature = app.sign(some_message0);
+        assert!(signature.is_err());
+        assert!(matches!(
+            signature.err().unwrap(),
+            Error::InvalidEmptyMessage
+        ));
+    }
+
+    #[test]
+    #[ignore]
+    fn sign_verify() {
+        let app = APP.lock().unwrap();
+
+        let some_message1 = get_fake_proposal(5, 0);
+        app.sign(&some_message1).unwrap();
+
+        let some_message2 = get_fake_proposal(6, 0);
+        match app.sign(&some_message2) {
+            Ok(sig) => {
+                use ed25519_dalek::PublicKey;
+                use ed25519_dalek::Signature;
+
+                println!("{:#?}", sig.to_vec());
+
+                // First, get public key
+                let public_key_bytes = app.public_key().unwrap();
+                let public_key = PublicKey::from_bytes(&public_key_bytes).unwrap();
+                let signature = Signature::from_bytes(&sig).unwrap();
+
+                // Verify signature
+                assert!(public_key.verify(&some_message2, &signature).is_ok());
+            }
+            Err(e) => {
+                println!("Err {:#?}", e);
+                panic!();
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn sign_many() {
+        let app = APP.lock().unwrap();
+
+        // First, get public key
+        let _resp = app.public_key().unwrap();
+
+        // Now send several votes
+        for index in 50u8..254u8 {
+            let some_message1 = [
+                0x8,  // (field_number << 3) | wire_type
+                0x1,  // PrevoteType
+                0x11, // (field_number << 3) | wire_type
+                index, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+                0x19, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // round
+                0x22, // (field_number << 3) | wire_type
+                // remaining fields (timestamp):
+                0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+            ];
+
+            let signature = app.sign(&some_message1);
+            match signature {
+                Ok(sig) => {
+                    println!("{:#?}", sig.to_vec());
+                }
+                Err(e) => {
+                    println!("Err {:#?}", e);
+                    panic!();
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn quick_benchmark() {
+        let app = APP.lock().unwrap();
+
+        // initialize app with a vote
+        let msg = get_fake_proposal(0, 100);
+        app.sign(&msg).unwrap();
+
+        let start = Instant::now();
+        // Now send several votes
+        for i in 1u64..20u64 {
+            app.sign(&get_fake_proposal(i, 100)).unwrap();
+        }
+        let duration = start.elapsed();
+        println!("Elapsed {:?}", duration);
+    }
+}

--- a/src/keyring/providers/ledgertm/error.rs
+++ b/src/keyring/providers/ledgertm/error.rs
@@ -1,0 +1,33 @@
+//! Ledger errors
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("This version is not supported")]
+    InvalidVersion,
+
+    #[error("message cannot be empty")]
+    InvalidEmptyMessage,
+
+    #[error("message size is invalid (too big)")]
+    InvalidMessageSize,
+
+    #[error("received an invalid PK")]
+    InvalidPK,
+
+    #[error("received no signature back")]
+    NoSignature,
+
+    #[error("received an invalid signature")]
+    InvalidSignature,
+
+    #[error("ledger error")]
+    Ledger(ledger::Error),
+}
+
+impl From<ledger::Error> for Error {
+    fn from(err: ledger::Error) -> Error {
+        Error::Ledger(err)
+    }
+}

--- a/src/keyring/providers/ledgertm/signer.rs
+++ b/src/keyring/providers/ledgertm/signer.rs
@@ -1,0 +1,149 @@
+/*******************************************************************************
+*   (c) 2018, 2019 ZondaX GmbH
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+********************************************************************************/
+
+use super::client::TendermintValidatorApp;
+use crate::keyring::ed25519::{PublicKey, Signature};
+use signature::{Error, Signer};
+use std::sync::{Arc, Mutex};
+
+/// ed25519 signature provider for the Ledger Tendermint Validator app
+pub(super) struct Ed25519LedgerTmAppSigner {
+    app: Arc<Mutex<TendermintValidatorApp>>,
+}
+
+impl Ed25519LedgerTmAppSigner {
+    /// Create a new Ed25519 signer based on Ledger Nano S - Tendermint Validator app
+    pub fn connect() -> Result<Self, Error> {
+        let validator_app = TendermintValidatorApp::connect().map_err(Error::from_source)?;
+        let app = Arc::new(Mutex::new(validator_app));
+        Ok(Ed25519LedgerTmAppSigner { app })
+    }
+}
+
+impl From<&Ed25519LedgerTmAppSigner> for PublicKey {
+    /// Returns the public key that corresponds to the Tendermint Validator app connected to this signer
+    fn from(signer: &Ed25519LedgerTmAppSigner) -> PublicKey {
+        let app = signer.app.lock().unwrap();
+        PublicKey::from_bytes(&app.public_key().unwrap()).expect("invalid Ed25519 public key")
+    }
+}
+
+impl Signer<Signature> for Ed25519LedgerTmAppSigner {
+    /// c: Compute a compact, fixed-sized signature of the given amino/json vote
+    fn try_sign(&self, msg: &[u8]) -> Result<Signature, Error> {
+        let app = self.app.lock().unwrap();
+        let sig = app.sign(&msg).map_err(Error::from_source)?;
+        Ok(Signature::from(sig))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Ed25519LedgerTmAppSigner, PublicKey};
+    use signature::Signer;
+
+    #[test]
+    #[ignore]
+    fn public_key() {
+        let signer = Ed25519LedgerTmAppSigner::connect().unwrap();
+        let pk = PublicKey::from(&signer);
+        println!("PK {:0X?}", pk);
+    }
+
+    #[test]
+    #[ignore]
+    fn sign() {
+        let signer = Ed25519LedgerTmAppSigner::connect().unwrap();
+
+        // Sign message1
+        let some_message1 = [
+            33, 0x8,  // (field_number << 3) | wire_type
+            0x1,  // PrevoteType
+            0x11, // (field_number << 3) | wire_type
+            0x10, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+            0x19, // (field_number << 3) | wire_type
+            0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // round
+            0x22, // (field_number << 3) | wire_type
+            // remaining fields (timestamp):
+            0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+        ];
+
+        signer.sign(&some_message1);
+    }
+
+    #[test]
+    #[ignore]
+    fn sign2() {
+        let signer = Ed25519LedgerTmAppSigner::connect().unwrap();
+
+        // Sign message1
+        let some_message1 = [
+            33, 0x8,  // (field_number << 3) | wire_type
+            0x1,  // PrevoteType
+            0x11, // (field_number << 3) | wire_type
+            0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+            0x19, // (field_number << 3) | wire_type
+            0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // round
+            0x22, // (field_number << 3) | wire_type
+            // remaining fields (timestamp):
+            0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+        ];
+
+        signer.sign(&some_message1);
+
+        // Sign message2
+        let some_message2 = [
+            33, 0x8,  // (field_number << 3) | wire_type
+            0x1,  // PrevoteType
+            0x11, // (field_number << 3) | wire_type
+            0x10, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+            0x19, // (field_number << 3) | wire_type
+            0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // round
+            0x22, // (field_number << 3) | wire_type
+            // remaining fields (timestamp):
+            0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+        ];
+
+        signer.sign(&some_message2);
+    }
+
+    #[test]
+    #[ignore]
+    fn sign_many() {
+        let signer = Ed25519LedgerTmAppSigner::connect().unwrap();
+
+        // Get public key to initialize
+        let pk = PublicKey::from(&signer);
+        println!("PK {:0X?}", pk);
+
+        for index in 50u8..254u8 {
+            // Sign message1
+            let some_message = [
+                33, 0x8,  // (field_number << 3) | wire_type
+                0x1,  // PrevoteType
+                0x11, // (field_number << 3) | wire_type
+                0x40, 0x00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+                0x19, // (field_number << 3) | wire_type
+                index, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // round
+                0x22, // (field_number << 3) | wire_type
+                // remaining fields (timestamp):
+                0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+            ];
+
+            signer.sign(&some_message);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! Tendermint Key Management System
 
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
-#[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
+#[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledger")))]
 compile_error!(
     "please enable one of the following backends with cargo's --features argument: \
      yubihsm, ledgertm, softsign (e.g. --features=yubihsm)"


### PR DESCRIPTION
As discussed in iqlusioninc/signatory#71, this commit removes the remaining dependencies on Signatory in favor of directly integrating the last remaining Signatory-based provider, `signatory-ledger-tm`, which was vendored from code as of this commit:

https://github.com/iqlusioninc/signatory/tree/4110887/signatory-ledger-tm

It also renames the feature to simply `ledger`, so it can be gated on the `ledger` crate dependency.