### PR TITLE
secret_connection: refactor in prep for Tendermint v0.34 work

### DIFF
--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -1,11 +1,12 @@
 //! Validator configuration
 
+use crate::connection::secret_connection;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tendermint::{chain, net};
 
 /// Validator configuration
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ValidatorConfig {
     /// Address of the validator (`tcp://` or `unix://`)
@@ -27,29 +28,11 @@ pub struct ValidatorConfig {
     /// Height at which to stop signing
     pub max_height: Option<tendermint::block::Height>,
 
-    /// Use Tendermint v0.33 handshake
-    #[serde(default = "protocol_default")]
-    pub protocol_version: TendermintVersion,
-}
-
-/// Tendermint secure connection protocol version
-#[derive(Deserialize, Serialize, Clone, Debug)]
-pub enum TendermintVersion {
-    /// Legacy V1 SecretConnection Handshake
-    #[serde(rename = "legacy")]
-    Legacy,
-
-    /// Tendermint v0.33+ SecretConnection Handshake
-    #[serde(rename = "v0.33")]
-    V0_33,
+    /// Version of Secret Connection protocol to use when connecting
+    pub protocol_version: secret_connection::Version,
 }
 
 /// Default value for the `ValidatorConfig` reconnect field
 fn reconnect_default() -> bool {
     true
-}
-
-/// Default value for the `ValidatorConfig` reconnect field
-fn protocol_default() -> TendermintVersion {
-    TendermintVersion::Legacy
 }

--- a/src/connection/secret_connection/protocol.rs
+++ b/src/connection/secret_connection/protocol.rs
@@ -1,0 +1,118 @@
+//! Secret Connection Protocol: message framing and versioning
+
+use crate::{
+    error::{Error, ErrorKind},
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+use x25519_dalek::PublicKey as EphemeralPublic;
+
+/// Size of an X25519 or Ed25519 public key
+const PUBLIC_KEY_SIZE: usize = 32;
+
+/// Protocol version (based on the Tendermint version)
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[allow(non_camel_case_types)]
+pub enum Version {
+    /// Pre-Tendermint v0.33
+    #[serde(rename = "legacy")]
+    Legacy,
+
+    /// Tendermint v0.33
+    #[serde(rename = "v0.33")]
+    V0_33,
+}
+
+impl Version {
+    /// Does this version of Secret Connection use a transcript hash
+    pub fn has_transcript(self) -> bool {
+        self != Version::Legacy
+    }
+
+    /// Encode the initial handshake message (i.e. first one sent by both peers)
+    pub fn encode_initial_handshake(self, eph_pubkey: &EphemeralPublic) -> Vec<u8> {
+        let mut buf = Vec::new();
+
+        // Note: this is not regular protobuf encoding but raw length prefixed amino encoding;
+        // amino prefixes with the total length, and the raw bytes array's length, too:
+        buf.push(PUBLIC_KEY_SIZE as u8 + 1);
+        buf.push(PUBLIC_KEY_SIZE as u8);
+        buf.extend_from_slice(eph_pubkey.as_bytes());
+        buf
+    }
+
+    /// Decode the initial handshake message
+    pub fn decode_initial_handshake(self, bytes: &[u8]) -> Result<EphemeralPublic, Error> {
+        // this is the receiving part of:
+        // https://github.com/tendermint/tendermint/blob/013b9cef642f875634c614019ab13b17570778ad/p2p/conn/secret_connection.go#L208-L238
+
+        // Check that the length matches what we expect and the length prefix is correct
+        if bytes.len() != 33 || bytes[0] != 32 {
+            fail!(
+                ErrorKind::ProtocolError,
+                "malformed handshake message (protocol version mismatch?)"
+            );
+        }
+
+        let eph_pubkey_bytes: [u8; 32] = bytes[1..].try_into().unwrap();
+        let eph_pubkey = EphemeralPublic::from(eph_pubkey_bytes);
+
+        // Reject the key if it is of low order
+        if is_low_order_point(&eph_pubkey) {
+            return Err(ErrorKind::InvalidKey.into());
+        }
+
+        Ok(eph_pubkey)
+    }
+}
+
+/// Reject low order points listed on <https://cr.yp.to/ecdh.html>
+///
+/// These points contain low-order X25519 field elements. Rejecting them is
+/// suggested in the "May the Fourth" paper under Section 5:
+/// Software Countermeasures (see "Rejecting Known Bad Points" subsection):
+///
+/// <https://eprint.iacr.org/2017/806.pdf>
+fn is_low_order_point(point: &EphemeralPublic) -> bool {
+    // Note: as these are public points and do not interact with secret-key
+    // material in any way, this check does not need to be performed in
+    // constant-time.
+    match point.as_bytes() {
+        // 0 (order 4)
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] => {
+            true
+        }
+
+        // 1 (order 1)
+        [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] => {
+            true
+        }
+
+        // 325606250916557431795983626356110631294008115727848805560023387167927233504 (order 8)
+        &[0xe0, 0xeb, 0x7a, 0x7c, 0x3b, 0x41, 0xb8, 0xae, 0x16, 0x56, 0xe3, 0xfa, 0xf1, 0x9f, 0xc4, 0x6a, 0xda, 0x09, 0x8d, 0xeb, 0x9c, 0x32, 0xb1, 0xfd, 0x86, 0x62, 0x05, 0x16, 0x5f, 0x49, 0xb8, 0x00] => {
+            true
+        }
+
+        // 39382357235489614581723060781553021112529911719440698176882885853963445705823 (order 8)
+        &[0x5f, 0x9c, 0x95, 0xbc, 0xa3, 0x50, 0x8c, 0x24, 0xb1, 0xd0, 0xb1, 0x55, 0x9c, 0x83, 0xef, 0x5b, 0x04, 0x44, 0x5c, 0xc4, 0x58, 0x1c, 0x8e, 0x86, 0xd8, 0x22, 0x4e, 0xdd, 0xd0, 0x9f, 0x11, 0x57] => {
+            true
+        }
+
+        // p - 1 (order 2)
+        [0xec, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f] => {
+            true
+        }
+
+        // p (order 4) */
+        [0xed, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f] => {
+            true
+        }
+
+        // p + 1 (order 1)
+        [0xee, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f] => {
+            true
+        }
+        _ => false,
+    }
+}

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -1,6 +1,6 @@
 //! TCP socket connection to a validator
 
-use super::secret_connection::{PublicKey, SecretConnection};
+use super::secret_connection::{self, PublicKey, SecretConnection};
 use crate::{
     error::{Error, ErrorKind::*},
     key_utils,
@@ -20,7 +20,7 @@ pub fn open_secret_connection(
     identity_key_path: &Option<PathBuf>,
     peer_id: &Option<node::Id>,
     timeout: Option<u16>,
-    v0_33_handshake: bool,
+    protocol_version: secret_connection::Version,
 ) -> Result<SecretConnection<TcpStream>, Error> {
     let identity_key_path = identity_key_path.as_ref().ok_or_else(|| {
         format_err!(
@@ -39,7 +39,7 @@ pub fn open_secret_connection(
     socket.set_read_timeout(Some(timeout))?;
     socket.set_write_timeout(Some(timeout))?;
 
-    let connection = SecretConnection::new(socket, &identity_key, v0_33_handshake)?;
+    let connection = SecretConnection::new(socket, &identity_key, protocol_version)?;
     let actual_peer_id = connection.remote_pubkey().peer_id();
 
     // TODO(tarcieri): move this into `SecretConnection::new`

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     chain::{self, state::StateErrorKind, Chain},
-    config::{TendermintVersion, ValidatorConfig},
+    config::ValidatorConfig,
     connection::{tcp, unix::UnixConnection, Connection},
     error::{Error, ErrorKind::*},
     prelude::*,
@@ -38,18 +38,13 @@ impl Session {
                     &config.chain_id, &config.addr
                 );
 
-                let v0_33_handshake = match config.protocol_version {
-                    TendermintVersion::V0_33 => true,
-                    TendermintVersion::Legacy => false,
-                };
-
                 let conn = tcp::open_secret_connection(
                     host,
                     *port,
                     &config.secret_key,
                     peer_id,
                     config.timeout,
-                    v0_33_handshake,
+                    config.protocol_version,
                 )?;
 
                 info!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -141,6 +141,7 @@ impl KmsProcess {
             max_height = "500000"
             reconnect = false
             secret_key = "tests/support/secret_connection.key"
+            protocol_version = "legacy"
 
             [[providers.softsign]]
             chain_ids = ["test_chain_id"]
@@ -168,7 +169,7 @@ impl KmsProcess {
             addr = "unix://{}"
             chain_id = "test_chain_id"
             max_height = "500000"
-
+            protocol_version = "legacy"
 
             [[providers.softsign]]
             chain_ids = ["test_chain_id"]
@@ -193,7 +194,12 @@ impl KmsProcess {
                 let socket_cp = sock.try_clone().unwrap();
 
                 KmsConnection::Tcp(
-                    SecretConnection::new(socket_cp, &identity_keypair, false).unwrap(),
+                    SecretConnection::new(
+                        socket_cp,
+                        &identity_keypair,
+                        secret_connection::Version::Legacy,
+                    )
+                    .unwrap(),
                 )
             }
 

--- a/tests/support/gen-validator-integration-cfg.sh
+++ b/tests/support/gen-validator-integration-cfg.sh
@@ -22,6 +22,7 @@ addr = "VALIDATOR_ADDR"
 chain_id = "CHAIN_ID"
 reconnect = true # true is the default
 secret_key = "SECRET_KEY"
+protocol_version = "legacy"
 
 [[providers.softsign]]
 chain_ids = ["CHAIN_ID"]

--- a/tests/support/kms_yubihsm_mock.toml
+++ b/tests/support/kms_yubihsm_mock.toml
@@ -12,6 +12,7 @@ addr = "tcp://f88883b673fc69d7869cab098de3bafc2ff76eb8@127.0.0.1:23456"
 chain_id = "test_chain_id"
 reconnect = false
 secret_key = "tests/seccon.key"
+protocol_version = "legacy"
 
 [[providers.yubihsm]]
 adapter = { type = "usb" }

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -14,7 +14,7 @@
 #   of this chain. The command should output JSON which looks like the following:
 #   {"latest_block_height": "347290"}
 [[chain]]
-id = "cosmoshub-1"
+id = "cosmoshub-3"
 key_format = { type = "bech32", account_key_prefix = "cosmospub", consensus_key_prefix = "cosmosvalconspub" }
 # state_file = "/path/to/cosmoshub_priv_validator_state.json"
 # state_hook = { cmd = ["/path/to/block/height_script", "--example-arg", "cosmoshub"] }
@@ -28,11 +28,11 @@ key_format = { type = "bech32", account_key_prefix = "iap", consensus_key_prefix
 [[validator]]
 addr = "tcp://f88883b673fc69d7869cab098de3bafc2ff76eb8@example1.example.com:26658"
 # or addr = "unix:///path/to/socket"
-chain_id = "cosmoshub-1"
+chain_id = "cosmoshub-3"
 reconnect = true # true is the default
 secret_key = "path/to/secret_connection.key"
 # max_height = "500000"
-protocol_version = "v0.33" # "legacy" is the default
+protocol_version = "legacy" # or "v0.33", "v0.34" (i.e. Tendermint version)
 
 ## Signing provider configuration
 
@@ -41,7 +41,7 @@ protocol_version = "v0.33" # "legacy" is the default
 adapter = { type = "usb" }
 auth = { key = 1, password_file = "/path/to/password" } # or pass raw password as `password`
 keys = [
-    { chain_ids = ["cosmoshub-1"], key = 1, type = "consensus" }
+    { chain_ids = ["cosmoshub-3"], key = 1, type = "consensus" }
     # { chain_ids = ["irishub"], key = 2, type = "account" }
 ]
 #serial_number = "0123456789" # identify serial number of a specific YubiHSM to connect to
@@ -49,12 +49,12 @@ keys = [
 
 # enable the `ledger` feature to use this backend
 #[[providers.ledgertm]]
-#chain_ids = ["cosmoshub-1"]
+#chain_ids = ["cosmoshub-3"]
 
 # enable the `softsign` feature to use this backend
 # note: the `yubihsm` or `ledger` backends are preferred over this one
 [[providers.softsign]]
-chain_ids = ["cosmoshub-1"]
+chain_ids = ["cosmoshub-3"]
 key_type = "consensus"
 path = "path/to/consensus-ed25519.key" # generate using `tmkms softsign keygen -t consensus consensus-ed25519.key`
 


### PR DESCRIPTION
This commit contains a set of initial refactoring to better support multiple versions of Secret Connection.

It leans more heavily on the (newly extracted) `protocol::Version` enum, moving much of the protocol framing there in advance so as to lean on the enum itself to decide how messages are framed.