### PR TITLE
Vendor `amino_types`

### DIFF
--- a/src/amino_types.rs
+++ b/src/amino_types.rs
@@ -1,0 +1,62 @@
+//! Legacy message types serialized using the Amino serialization format
+//! <https://github.com/tendermint/amino_rs>
+
+#![allow(missing_docs)]
+
+pub mod block_id;
+pub mod ed25519;
+pub mod message;
+pub mod ping;
+pub mod proposal;
+pub mod remote_error;
+pub mod signature;
+pub mod time;
+pub mod validate;
+pub mod version;
+pub mod vote;
+
+pub use self::{
+    block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader, PartsSetHeader},
+    ed25519::{
+        PubKeyRequest, PubKeyResponse, AMINO_NAME as PUBKEY_AMINO_NAME,
+        AMINO_PREFIX as PUBKEY_PREFIX,
+    },
+    ping::{PingRequest, PingResponse, AMINO_NAME as PING_AMINO_NAME, AMINO_PREFIX as PING_PREFIX},
+    proposal::{
+        Proposal, SignProposalRequest, SignedProposalResponse, AMINO_NAME as PROPOSAL_AMINO_NAME,
+        AMINO_PREFIX as PROPOSAL_PREFIX,
+    },
+    remote_error::RemoteError,
+    signature::{SignableMsg, SignedMsgType},
+    time::TimeMsg,
+    validate::ConsensusMessage,
+    version::ConsensusVersion,
+    vote::{
+        SignVoteRequest, SignedVoteResponse, Vote, AMINO_NAME as VOTE_AMINO_NAME,
+        AMINO_PREFIX as VOTE_PREFIX,
+    },
+};
+
+use crate::rpc;
+use sha2::{Digest, Sha256};
+
+/// Tendermint requests
+pub trait TendermintRequest: SignableMsg {
+    fn build_response(self, error: Option<RemoteError>) -> rpc::Response;
+}
+
+/// Compute the Amino prefix for the given registered type name
+pub fn compute_prefix(name: &str) -> Vec<u8> {
+    let mut sh = Sha256::default();
+    sh.update(name.as_bytes());
+    let output = sh.finalize();
+
+    output
+        .iter()
+        .filter(|&x| *x != 0x00)
+        .skip(3)
+        .filter(|&x| *x != 0x00)
+        .cloned()
+        .take(4)
+        .collect()
+}

--- a/src/amino_types/block_id.rs
+++ b/src/amino_types/block_id.rs
@@ -1,0 +1,156 @@
+use super::validate::{self, ConsensusMessage, Error::*};
+use crate::proto_types;
+use prost_amino_derive::Message;
+use tendermint::{
+    block::{self, parts},
+    error::Error,
+    hash,
+    hash::{Hash, SHA256_HASH_SIZE},
+};
+
+#[derive(Clone, PartialEq, Message)]
+pub struct BlockId {
+    #[prost_amino(bytes, tag = "1")]
+    pub hash: Vec<u8>,
+    #[prost_amino(message, tag = "2")]
+    pub parts_header: Option<PartsSetHeader>,
+}
+
+impl BlockId {
+    pub fn new(hash: Vec<u8>, parts_header: Option<PartsSetHeader>) -> Self {
+        BlockId { hash, parts_header }
+    }
+}
+
+impl block::ParseId for BlockId {
+    fn parse_block_id(&self) -> Result<block::Id, Error> {
+        let hash = Hash::new(hash::Algorithm::Sha256, &self.hash)?;
+        let parts_header = self
+            .parts_header
+            .as_ref()
+            .and_then(PartsSetHeader::parse_parts_header);
+        Ok(block::Id::new(hash, parts_header))
+    }
+}
+
+impl From<&block::Id> for BlockId {
+    fn from(bid: &block::Id) -> Self {
+        let bid_hash = bid.hash.as_bytes();
+        BlockId::new(
+            bid_hash.to_vec(),
+            bid.parts.as_ref().map(PartsSetHeader::from),
+        )
+    }
+}
+
+impl From<proto_types::BlockId> for BlockId {
+    fn from(block_id: proto_types::BlockId) -> BlockId {
+        BlockId::new(
+            block_id.hash,
+            block_id.part_set_header.map(|psh| PartsSetHeader {
+                total: psh.total as i64,
+                hash: psh.hash,
+            }),
+        )
+    }
+}
+
+impl From<BlockId> for proto_types::BlockId {
+    fn from(block_id: BlockId) -> proto_types::BlockId {
+        proto_types::BlockId {
+            hash: block_id.hash,
+            part_set_header: block_id.parts_header.map(|psh| proto_types::PartSetHeader {
+                total: psh.total as u32,
+                hash: psh.hash,
+            }),
+        }
+    }
+}
+
+impl ConsensusMessage for BlockId {
+    fn validate_basic(&self) -> Result<(), validate::Error> {
+        // Hash can be empty in case of POLBlockID in Proposal.
+        if !self.hash.is_empty() && self.hash.len() != SHA256_HASH_SIZE {
+            return Err(InvalidHashSize);
+        }
+        self.parts_header
+            .as_ref()
+            .map_or(Ok(()), ConsensusMessage::validate_basic)
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct CanonicalBlockId {
+    #[prost_amino(bytes, tag = "1")]
+    pub hash: Vec<u8>,
+    #[prost_amino(message, tag = "2")]
+    pub parts_header: Option<CanonicalPartSetHeader>,
+}
+
+impl block::ParseId for CanonicalBlockId {
+    fn parse_block_id(&self) -> Result<block::Id, Error> {
+        let hash = Hash::new(hash::Algorithm::Sha256, &self.hash)?;
+        let parts_header = self
+            .parts_header
+            .as_ref()
+            .and_then(CanonicalPartSetHeader::parse_parts_header);
+        Ok(block::Id::new(hash, parts_header))
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct PartsSetHeader {
+    #[prost_amino(int64, tag = "1")]
+    pub total: i64,
+    #[prost_amino(bytes, tag = "2")]
+    pub hash: Vec<u8>,
+}
+
+impl PartsSetHeader {
+    pub fn new(total: i64, hash: Vec<u8>) -> Self {
+        PartsSetHeader { total, hash }
+    }
+}
+
+impl From<&parts::Header> for PartsSetHeader {
+    fn from(parts: &parts::Header) -> Self {
+        PartsSetHeader::new(parts.total as i64, parts.hash.as_bytes().to_vec())
+    }
+}
+
+impl PartsSetHeader {
+    fn parse_parts_header(&self) -> Option<block::parts::Header> {
+        Hash::new(hash::Algorithm::Sha256, &self.hash)
+            .map(|hash| block::parts::Header::new(self.total as u64, hash))
+            .ok()
+    }
+}
+
+impl ConsensusMessage for PartsSetHeader {
+    fn validate_basic(&self) -> Result<(), validate::Error> {
+        if self.total < 0 {
+            return Err(NegativeTotal);
+        }
+        // Hash can be empty in case of POLBlockID.PartsHeader in Proposal.
+        if !self.hash.is_empty() && self.hash.len() != SHA256_HASH_SIZE {
+            return Err(InvalidHashSize);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct CanonicalPartSetHeader {
+    #[prost_amino(bytes, tag = "1")]
+    pub hash: Vec<u8>,
+    #[prost_amino(int64, tag = "2")]
+    pub total: i64,
+}
+
+impl CanonicalPartSetHeader {
+    fn parse_parts_header(&self) -> Option<block::parts::Header> {
+        Hash::new(hash::Algorithm::Sha256, &self.hash)
+            .map(|hash| block::parts::Header::new(self.total as u64, hash))
+            .ok()
+    }
+}

--- a/src/amino_types/ed25519.rs
+++ b/src/amino_types/ed25519.rs
@@ -1,0 +1,187 @@
+use super::compute_prefix;
+use crate::prelude::*;
+use once_cell::sync::Lazy;
+use prost_amino_derive::Message;
+use std::convert::TryFrom;
+use tendermint::{
+    error,
+    public_key::{Ed25519, PublicKey},
+    Error,
+};
+
+// Note:On the golang side this is generic in the sense that it could everything that implements
+// github.com/tendermint/tendermint/crypto.PubKey
+// While this is meant to be used with different key-types, it currently only uses a PubKeyEd25519
+// version.
+// TODO(ismail): make this more generic (by modifying prost and adding a trait for PubKey)
+
+pub const AMINO_NAME: &str = "tendermint/remotesigner/PubKeyRequest";
+pub static AMINO_PREFIX: Lazy<Vec<u8>> = Lazy::new(|| compute_prefix(AMINO_NAME));
+
+#[derive(Clone, PartialEq, Message)]
+#[amino_name = "tendermint/remotesigner/PubKeyResponse"]
+pub struct PubKeyResponse {
+    #[prost_amino(bytes, tag = "1", amino_name = "tendermint/PubKeyEd25519")]
+    pub pub_key_ed25519: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+#[amino_name = "tendermint/remotesigner/PubKeyRequest"]
+pub struct PubKeyRequest {}
+
+impl TryFrom<PubKeyResponse> for PublicKey {
+    type Error = Error;
+
+    // This does not check if the underlying pub_key_ed25519 has the right size.
+    // The caller needs to make sure that this is actually the case.
+    fn try_from(response: PubKeyResponse) -> Result<PublicKey, Error> {
+        Ed25519::from_bytes(&response.pub_key_ed25519)
+            .map(Into::into)
+            .map_err(|_| format_err!(error::Kind::InvalidKey, "malformed Ed25519 key").into())
+    }
+}
+
+impl From<PublicKey> for PubKeyResponse {
+    fn from(public_key: PublicKey) -> PubKeyResponse {
+        if let PublicKey::Ed25519(ref pk) = public_key {
+            PubKeyResponse {
+                pub_key_ed25519: pk.as_bytes().to_vec(),
+            }
+        } else {
+            unimplemented!(
+                "PubKeyResponse unimplemented for this type: {:?}",
+                public_key
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::PUBLIC_KEY_LENGTH;
+    use prost_amino::Message;
+    use std::convert::TryInto;
+
+    #[test]
+    fn test_empty_pubkey_msg() {
+        // test-vector generated via the following go code:
+        //
+        // --------------------------------------------------------------------
+        //package main
+        //
+        //import (
+        //	"fmt"
+        //
+        //	"github.com/tendermint/go-amino"
+        //	"github.com/tendermint/tendermint/crypto"
+        //	"github.com/tendermint/tendermint/privval"
+        //)
+        //
+        //func main() {
+        //	cdc := amino.NewCodec()
+        //
+        //	cdc.RegisterInterface((*crypto.PubKey)(nil), nil)
+        //	cdc.RegisterConcrete(crypto.PubKeyEd25519{},
+        //		"tendermint/PubKeyEd25519", nil)
+        //	cdc.RegisterConcrete(&privval.PubKeyRequest{},
+        //      "tendermint/remotesigner/PubKeyRequest", nil)
+        //	b, _ := cdc.MarshalBinary(&privval.PubKeyRequest{})
+        //	fmt.Printf("%#v\n\n", b)
+        //}
+        // --------------------------------------------------------------------
+        // Output:
+        // []byte{0x4, 0xcb, 0x94, 0xd6, 0x20}
+        //
+        //
+
+        let want = vec![0x4, 0xcb, 0x94, 0xd6, 0x20];
+        let msg = PubKeyRequest {};
+        let mut got = vec![];
+        let _have = msg.encode(&mut got);
+
+        assert_eq!(got, want);
+
+        match PubKeyRequest::decode(want.as_ref()) {
+            Ok(have) => assert_eq!(have, msg),
+            Err(err) => panic!(err.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_ed25519_pubkey_msg() {
+        // test-vector generated exactly as for test_empty_pubkey_msg
+        // but with the following modifications:
+        //	cdc.RegisterConcrete(&privval.PubKeyResponse{},
+        //      "tendermint/remotesigner/PubKeyResponse", nil)
+        //
+        //  var pubKey [32]byte
+        //	copy(pubKey[:],[]byte{0x79, 0xce, 0xd, 0xe0, 0x43, 0x33, 0x4a, 0xec, 0xe0, 0x8b, 0x7b,
+        //  0xb5, 0x61, 0xbc, 0xe7, 0xc1,
+        //	0xd4, 0x69, 0xc3, 0x44, 0x26, 0xec, 0xef, 0xc0, 0x72, 0xa, 0x52, 0x4d, 0x37, 0x32, 0xef,
+        // 0xed})
+        //
+        //	b, _ = cdc.MarshalBinary(&privval.PubKeyResponse{PubKey: crypto.PubKeyEd25519(pubKey)})
+        //	fmt.Printf("%#v\n\n", b)
+        //
+        let encoded = vec![
+            0x2b, // length
+            0x17, 0xe, 0xd5, 0x7c, // prefix
+            0xa, 0x25, 0x16, 0x24, 0xde, 0x64, 0x20, 0x79, 0xce, 0xd, 0xe0, 0x43, 0x33, 0x4a, 0xec,
+            0xe0, 0x8b, 0x7b, 0xb5, 0x61, 0xbc, 0xe7, 0xc1, 0xd4, 0x69, 0xc3, 0x44, 0x26, 0xec,
+            0xef, 0xc0, 0x72, 0xa, 0x52, 0x4d, 0x37, 0x32, 0xef, 0xed,
+        ];
+
+        let msg = PubKeyResponse {
+            pub_key_ed25519: vec![
+                0x79, 0xce, 0xd, 0xe0, 0x43, 0x33, 0x4a, 0xec, 0xe0, 0x8b, 0x7b, 0xb5, 0x61, 0xbc,
+                0xe7, 0xc1, 0xd4, 0x69, 0xc3, 0x44, 0x26, 0xec, 0xef, 0xc0, 0x72, 0xa, 0x52, 0x4d,
+                0x37, 0x32, 0xef, 0xed,
+            ],
+        };
+        let mut got = vec![];
+        let _have = msg.encode(&mut got);
+
+        assert_eq!(got, encoded);
+
+        match PubKeyResponse::decode(encoded.as_ref()) {
+            Ok(have) => assert_eq!(have, msg),
+            Err(err) => panic!(err),
+        }
+    }
+
+    #[test]
+    fn test_into() {
+        let raw_pk: [u8; PUBLIC_KEY_LENGTH] = [
+            0xaf, 0xf3, 0x94, 0xc5, 0xb7, 0x5c, 0xfb, 0xd, 0xd9, 0x28, 0xe5, 0x8a, 0x92, 0xdd,
+            0x76, 0x55, 0x2b, 0x2e, 0x8d, 0x19, 0x6f, 0xe9, 0x12, 0x14, 0x50, 0x80, 0x6b, 0xd0,
+            0xd9, 0x3f, 0xd0, 0xcb,
+        ];
+        let want = PublicKey::Ed25519(Ed25519::from_bytes(&raw_pk).unwrap());
+        let pk = PubKeyResponse {
+            pub_key_ed25519: vec![
+                0xaf, 0xf3, 0x94, 0xc5, 0xb7, 0x5c, 0xfb, 0xd, 0xd9, 0x28, 0xe5, 0x8a, 0x92, 0xdd,
+                0x76, 0x55, 0x2b, 0x2e, 0x8d, 0x19, 0x6f, 0xe9, 0x12, 0x14, 0x50, 0x80, 0x6b, 0xd0,
+                0xd9, 0x3f, 0xd0, 0xcb,
+            ],
+        };
+        let orig = pk.clone();
+        let got: PublicKey = pk.try_into().unwrap();
+
+        assert_eq!(got, want);
+
+        // and back:
+        let round_trip_pk: PubKeyResponse = got.into();
+        assert_eq!(round_trip_pk, orig);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_empty_into() {
+        let empty_msg = PubKeyResponse {
+            pub_key_ed25519: vec![],
+        };
+        // we expect this to panic:
+        let _got: PublicKey = empty_msg.try_into().unwrap();
+    }
+}

--- a/src/amino_types/message.rs
+++ b/src/amino_types/message.rs
@@ -1,0 +1,39 @@
+use prost_amino::encoding::encoded_len_varint;
+use std::convert::TryInto;
+
+/// Extend the original prost_amino::Message trait with a few helper functions in order to
+/// reduce boiler-plate code (and without modifying the prost-amino dependency).
+pub trait AminoMessage: prost_amino::Message {
+    /// Directly amino encode a prost-amino message into a freshly created Vec<u8>.
+    /// This can be useful when passing those bytes directly to a hasher, or,
+    /// to reduce boiler plate code when working with the encoded bytes.
+    ///
+    /// Warning: Only use this method, if you are in control what will be encoded.
+    /// If there is an encoding error, this method will panic.
+    fn bytes_vec(&self) -> Vec<u8>
+    where
+        Self: Sized,
+    {
+        let mut res = Vec::with_capacity(self.encoded_len());
+        self.encode(&mut res).unwrap();
+        res
+    }
+
+    /// Encode prost-amino message as length delimited.
+    ///
+    /// Warning: Only use this method, if you are in control what will be encoded.
+    /// If there is an encoding error, this method will panic.
+    fn bytes_vec_length_delimited(&self) -> Vec<u8>
+    where
+        Self: Sized,
+    {
+        let len = self.encoded_len();
+        let mut res =
+            Vec::with_capacity(len + encoded_len_varint(len.try_into().expect("length overflow")));
+        self.encode_length_delimited(&mut res).unwrap();
+        res
+    }
+}
+impl<M: prost_amino::Message> AminoMessage for M {
+    // blanket impl
+}

--- a/src/amino_types/ping.rs
+++ b/src/amino_types/ping.rs
@@ -1,0 +1,14 @@
+use super::compute_prefix;
+use once_cell::sync::Lazy;
+use prost_amino_derive::Message;
+
+pub const AMINO_NAME: &str = "tendermint/remotesigner/PingRequest";
+pub static AMINO_PREFIX: Lazy<Vec<u8>> = Lazy::new(|| compute_prefix(AMINO_NAME));
+
+#[derive(Clone, PartialEq, Message)]
+#[amino_name = "tendermint/remotesigner/PingRequest"]
+pub struct PingRequest {}
+
+#[derive(Clone, PartialEq, Message)]
+#[amino_name = "tendermint/remotesigner/PingResponse"]
+pub struct PingResponse {}

--- a/src/amino_types/proposal.rs
+++ b/src/amino_types/proposal.rs
@@ -1,0 +1,322 @@
+use super::{
+    block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader},
+    compute_prefix,
+    remote_error::RemoteError,
+    signature::{SignableMsg, SignedMsgType},
+    time::TimeMsg,
+    validate::{self, ConsensusMessage, Error::*},
+    TendermintRequest,
+};
+use crate::rpc;
+use bytes::BufMut;
+use ed25519_dalek as ed25519;
+use once_cell::sync::Lazy;
+use prost_amino::{EncodeError, Message};
+use prost_amino_derive::Message;
+use std::convert::TryFrom;
+use tendermint::{
+    block::{self, ParseId},
+    chain, consensus, error,
+};
+
+#[derive(Clone, PartialEq, Message)]
+pub struct Proposal {
+    #[prost_amino(uint32, tag = "1")]
+    pub msg_type: u32,
+    #[prost_amino(int64)]
+    pub height: i64,
+    #[prost_amino(int64)]
+    pub round: i64,
+    #[prost_amino(int64)]
+    pub pol_round: i64,
+    #[prost_amino(message)]
+    pub block_id: Option<BlockId>,
+    #[prost_amino(message)]
+    pub timestamp: Option<TimeMsg>,
+    #[prost_amino(bytes)]
+    pub signature: Vec<u8>,
+}
+
+// TODO(tony): custom derive proc macro for this e.g. `derive(ParseBlockHeight)`
+impl block::ParseHeight for Proposal {
+    fn parse_block_height(&self) -> Result<block::Height, error::Error> {
+        block::Height::try_from(self.height)
+    }
+}
+
+pub const AMINO_NAME: &str = "tendermint/remotesigner/SignProposalRequest";
+pub static AMINO_PREFIX: Lazy<Vec<u8>> = Lazy::new(|| compute_prefix(AMINO_NAME));
+
+#[derive(Clone, PartialEq, Message)]
+#[amino_name = "tendermint/remotesigner/SignProposalRequest"]
+pub struct SignProposalRequest {
+    #[prost_amino(message, tag = "1")]
+    pub proposal: Option<Proposal>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct CanonicalProposal {
+    #[prost_amino(uint32, tag = "1")]
+    msg_type: u32, /* this is a byte in golang, which is a varint encoded UInt8 (using amino's
+                    * EncodeUvarint) */
+    #[prost_amino(sfixed64)]
+    height: i64,
+    #[prost_amino(sfixed64)]
+    round: i64,
+    #[prost_amino(sfixed64)]
+    pol_round: i64,
+    #[prost_amino(message)]
+    block_id: Option<CanonicalBlockId>,
+    #[prost_amino(message)]
+    timestamp: Option<TimeMsg>,
+    #[prost_amino(string)]
+    pub chain_id: String,
+}
+
+impl chain::ParseId for CanonicalProposal {
+    fn parse_chain_id(&self) -> Result<chain::Id, error::Error> {
+        self.chain_id.parse()
+    }
+}
+
+impl block::ParseHeight for CanonicalProposal {
+    fn parse_block_height(&self) -> Result<block::Height, error::Error> {
+        block::Height::try_from(self.height)
+    }
+}
+
+#[derive(Clone, PartialEq, Message)]
+#[amino_name = "tendermint/remotesigner/SignedProposalResponse"]
+pub struct SignedProposalResponse {
+    #[prost_amino(message, tag = "1")]
+    pub proposal: Option<Proposal>,
+    #[prost_amino(message, tag = "2")]
+    pub err: Option<RemoteError>,
+}
+
+impl SignableMsg for SignProposalRequest {
+    fn sign_bytes<B>(&self, chain_id: chain::Id, sign_bytes: &mut B) -> Result<bool, EncodeError>
+    where
+        B: BufMut,
+    {
+        let mut spr = self.clone();
+        if let Some(ref mut pr) = spr.proposal {
+            pr.signature = vec![];
+        }
+        let proposal = spr.proposal.unwrap();
+        let cp = CanonicalProposal {
+            chain_id: chain_id.to_string(),
+            msg_type: SignedMsgType::Proposal.to_u32(),
+            height: proposal.height,
+            block_id: match proposal.block_id {
+                Some(bid) => Some(CanonicalBlockId {
+                    hash: bid.hash,
+                    parts_header: match bid.parts_header {
+                        Some(psh) => Some(CanonicalPartSetHeader {
+                            hash: psh.hash,
+                            total: psh.total,
+                        }),
+                        None => None,
+                    },
+                }),
+                None => None,
+            },
+            pol_round: proposal.pol_round,
+            round: proposal.round,
+            timestamp: proposal.timestamp,
+        };
+
+        cp.encode_length_delimited(sign_bytes)?;
+        Ok(true)
+    }
+    fn set_signature(&mut self, sig: &ed25519::Signature) {
+        if let Some(ref mut prop) = self.proposal {
+            prop.signature = sig.as_ref().to_vec();
+        }
+    }
+    fn validate(&self) -> Result<(), validate::Error> {
+        match self.proposal {
+            Some(ref p) => p.validate_basic(),
+            None => Err(MissingConsensusMessage),
+        }
+    }
+    fn consensus_state(&self) -> Option<consensus::State> {
+        match self.proposal {
+            Some(ref p) => Some(consensus::State {
+                height: match block::Height::try_from(p.height) {
+                    Ok(h) => h,
+                    Err(_err) => return None, // TODO(tarcieri): return an error?
+                },
+                round: p.round,
+                step: 3,
+                block_id: {
+                    match p.block_id {
+                        Some(ref b) => match b.parse_block_id() {
+                            Ok(id) => Some(id),
+                            Err(_) => None,
+                        },
+                        None => None,
+                    }
+                },
+            }),
+            None => None,
+        }
+    }
+
+    fn height(&self) -> Option<i64> {
+        self.proposal.as_ref().map(|proposal| proposal.height)
+    }
+
+    fn msg_type(&self) -> Option<SignedMsgType> {
+        Some(SignedMsgType::Proposal)
+    }
+}
+
+impl TendermintRequest for SignProposalRequest {
+    fn build_response(self, error: Option<RemoteError>) -> rpc::Response {
+        let response = if let Some(e) = error {
+            SignedProposalResponse {
+                proposal: None,
+                err: Some(e),
+            }
+        } else {
+            SignedProposalResponse {
+                proposal: self.proposal,
+                err: None,
+            }
+        };
+
+        rpc::Response::SignedProposal(response)
+    }
+}
+
+impl ConsensusMessage for Proposal {
+    fn validate_basic(&self) -> Result<(), validate::Error> {
+        if self.msg_type != SignedMsgType::Proposal.to_u32() {
+            return Err(InvalidMessageType);
+        }
+        if self.height < 0 {
+            return Err(NegativeHeight);
+        }
+        if self.round < 0 {
+            return Err(NegativeRound);
+        }
+        if self.pol_round < -1 {
+            return Err(NegativePOLRound);
+        }
+        // TODO validate proposal's block_id
+
+        // signature will be missing as the KMS provides it
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::amino_types::block_id::PartsSetHeader;
+    use chrono::{DateTime, Utc};
+    use prost_amino::Message;
+
+    #[test]
+    fn test_serialization() {
+        let dt = "2018-02-11T07:09:22.765Z".parse::<DateTime<Utc>>().unwrap();
+        let t = TimeMsg {
+            seconds: dt.timestamp(),
+            nanos: dt.timestamp_subsec_nanos() as i32,
+        };
+        let proposal = Proposal {
+            msg_type: SignedMsgType::Proposal.to_u32(),
+            height: 12345,
+            round: 23456,
+            pol_round: -1,
+            block_id: Some(BlockId {
+                hash: b"hash".to_vec(),
+                parts_header: Some(PartsSetHeader {
+                    total: 1_000_000,
+                    hash: b"parts_hash".to_vec(),
+                }),
+            }),
+            timestamp: Some(t),
+            signature: vec![],
+        };
+        let mut got = vec![];
+
+        let _have = SignProposalRequest {
+            proposal: Some(proposal),
+        }
+        .encode(&mut got);
+        // test-vector generated via:
+        // cdc := amino.NewCodec()
+        // privval.RegisterRemoteSignerMsg(cdc)
+        // stamp, _ := time.Parse(time.RFC3339Nano, "2018-02-11T07:09:22.765Z")
+        // data, _ := cdc.MarshalBinaryLengthPrefixed(privval.SignProposalRequest{Proposal:
+        // &types.Proposal{     Type:     types.ProposalType, // 0x20
+        //     Height:   12345,
+        //     Round:    23456,
+        //     POLRound: -1,
+        //     BlockID: types.BlockID{
+        //         Hash: []byte("hash"),
+        //         PartsHeader: types.PartSetHeader{
+        //             Hash:  []byte("parts_hash"),
+        //             Total: 1000000,
+        //         },
+        //     },
+        //     Timestamp: stamp,
+        // }})
+        // fmt.Println(strings.Join(strings.Split(fmt.Sprintf("%v", data), " "), ", "))
+        let want = vec![
+            66, // len
+            189, 228, 152, 226, // prefix
+            10, 60, 8, 32, 16, 185, 96, 24, 160, 183, 1, 32, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 1, 42, 24, 10, 4, 104, 97, 115, 104, 18, 16, 8, 192, 132, 61, 18, 10, 112,
+            97, 114, 116, 115, 95, 104, 97, 115, 104, 50, 12, 8, 162, 216, 255, 211, 5, 16, 192,
+            242, 227, 236, 2,
+        ];
+
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let dt = "2018-02-11T07:09:22.765Z".parse::<DateTime<Utc>>().unwrap();
+        let t = TimeMsg {
+            seconds: dt.timestamp(),
+            nanos: dt.timestamp_subsec_nanos() as i32,
+        };
+        let proposal = Proposal {
+            msg_type: SignedMsgType::Proposal.to_u32(),
+            height: 12345,
+            round: 23456,
+            timestamp: Some(t),
+
+            pol_round: -1,
+            block_id: Some(BlockId {
+                hash: b"hash".to_vec(),
+                parts_header: Some(PartsSetHeader {
+                    total: 1_000_000,
+                    hash: b"parts_hash".to_vec(),
+                }),
+            }),
+            signature: vec![],
+        };
+        let want = SignProposalRequest {
+            proposal: Some(proposal),
+        };
+
+        let data = vec![
+            66, // len
+            189, 228, 152, 226, // prefix
+            10, 60, 8, 32, 16, 185, 96, 24, 160, 183, 1, 32, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 1, 42, 24, 10, 4, 104, 97, 115, 104, 18, 16, 8, 192, 132, 61, 18, 10, 112,
+            97, 114, 116, 115, 95, 104, 97, 115, 104, 50, 12, 8, 162, 216, 255, 211, 5, 16, 192,
+            242, 227, 236, 2,
+        ];
+
+        match SignProposalRequest::decode(data.as_ref()) {
+            Ok(have) => assert_eq!(have, want),
+            Err(err) => panic!(err.to_string()),
+        }
+    }
+}

--- a/src/amino_types/remote_error.rs
+++ b/src/amino_types/remote_error.rs
@@ -1,0 +1,32 @@
+use prost_amino_derive::Message;
+
+#[derive(Clone, PartialEq, Message)]
+pub struct RemoteError {
+    #[prost_amino(sint32, tag = "1")]
+    pub code: i32,
+    #[prost_amino(string, tag = "2")]
+    pub description: String,
+}
+
+/// Error codes for remote signer failures
+// TODO(tarcieri): add these to Tendermint. See corresponding TODO here:
+// <https://github.com/tendermint/tendermint/blob/master/privval/errors.go>
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(i32)]
+pub enum RemoteErrorCode {
+    /// Generic error code useful when the others don't apply
+    RemoteSignerError = 1,
+
+    /// Double signing detected
+    DoubleSignError = 2,
+}
+
+impl RemoteError {
+    /// Create a new double signing error with the given message
+    pub fn double_sign(height: i64) -> Self {
+        RemoteError {
+            code: RemoteErrorCode::DoubleSignError as i32,
+            description: format!("double signing requested at height: {}", height),
+        }
+    }
+}

--- a/src/amino_types/signature.rs
+++ b/src/amino_types/signature.rs
@@ -1,0 +1,58 @@
+use super::validate;
+use bytes::BufMut;
+use ed25519_dalek as ed25519;
+use prost_amino::{DecodeError, EncodeError};
+use tendermint::{chain, consensus};
+
+/// Amino messages which are signable within a Tendermint network
+pub trait SignableMsg {
+    /// Sign this message as bytes
+    fn sign_bytes<B: BufMut>(
+        &self,
+        chain_id: chain::Id,
+        sign_bytes: &mut B,
+    ) -> Result<bool, EncodeError>;
+
+    /// Set the Ed25519 signature on the underlying message
+    fn set_signature(&mut self, sig: &ed25519::Signature);
+    fn validate(&self) -> Result<(), validate::Error>;
+    fn consensus_state(&self) -> Option<consensus::State>;
+    fn height(&self) -> Option<i64>;
+    fn msg_type(&self) -> Option<SignedMsgType>;
+}
+
+/// Signed message types. This follows:
+/// <https://github.com/tendermint/tendermint/blob/455d34134cc53c334ebd3195ac22ea444c4b59bb/types/signed_msg_type.go#L3-L16>
+#[derive(Copy, Clone, Debug)]
+pub enum SignedMsgType {
+    /// Votes
+    PreVote,
+
+    /// Commits
+    PreCommit,
+
+    /// Proposals
+    Proposal,
+}
+
+impl SignedMsgType {
+    pub fn to_u32(self) -> u32 {
+        match self {
+            // Votes
+            SignedMsgType::PreVote => 0x01,
+            SignedMsgType::PreCommit => 0x02,
+            // Proposals
+            SignedMsgType::Proposal => 0x20,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn from(data: u32) -> Result<SignedMsgType, DecodeError> {
+        match data {
+            0x01 => Ok(SignedMsgType::PreVote),
+            0x02 => Ok(SignedMsgType::PreCommit),
+            0x20 => Ok(SignedMsgType::Proposal),
+            _ => Err(DecodeError::new("Invalid vote type")),
+        }
+    }
+}

--- a/src/amino_types/time.rs
+++ b/src/amino_types/time.rs
@@ -1,0 +1,48 @@
+//! Timestamps
+
+use chrono::{TimeZone, Utc};
+use prost_amino_derive::Message;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tendermint::{
+    error::Error,
+    time::{ParseTimestamp, Time},
+};
+
+#[derive(Clone, PartialEq, Message)]
+pub struct TimeMsg {
+    // TODO(ismail): switch to protobuf's well known type as soon as
+    // https://github.com/tendermint/go-amino/pull/224 was merged
+    // and tendermint caught up on the latest amino release.
+    #[prost_amino(int64, tag = "1")]
+    pub seconds: i64,
+    #[prost_amino(int32, tag = "2")]
+    pub nanos: i32,
+}
+
+impl ParseTimestamp for TimeMsg {
+    fn parse_timestamp(&self) -> Result<Time, Error> {
+        Ok(Utc.timestamp(self.seconds, self.nanos as u32).into())
+    }
+}
+
+impl From<Time> for TimeMsg {
+    fn from(ts: Time) -> TimeMsg {
+        // TODO: non-panicking method for getting this?
+        let duration = ts.duration_since(Time::unix_epoch()).unwrap();
+        let seconds = duration.as_secs() as i64;
+        let nanos = duration.subsec_nanos() as i32;
+
+        TimeMsg { seconds, nanos }
+    }
+}
+
+/// Converts `Time` to a `SystemTime`.
+impl From<TimeMsg> for SystemTime {
+    fn from(time: TimeMsg) -> SystemTime {
+        if time.seconds >= 0 {
+            UNIX_EPOCH + Duration::new(time.seconds as u64, time.nanos as u32)
+        } else {
+            UNIX_EPOCH - Duration::new(time.seconds as u64, time.nanos as u32)
+        }
+    }
+}

--- a/src/amino_types/validate.rs
+++ b/src/amino_types/validate.rs
@@ -1,0 +1,28 @@
+use thiserror::Error;
+
+pub trait ConsensusMessage {
+    fn validate_basic(&self) -> Result<(), Error>;
+}
+
+/// Kinds of validation errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Error)]
+pub enum Error {
+    #[error("invalid Type")]
+    InvalidMessageType,
+    #[error("consensus message is missing")]
+    MissingConsensusMessage,
+    #[error("negative height")]
+    NegativeHeight,
+    #[error("negative round")]
+    NegativeRound,
+    #[error("negative POLRound (exception: -1)")]
+    NegativePOLRound,
+    #[error("negative ValidatorIndex")]
+    NegativeValidatorIndex,
+    #[error("expected ValidatorAddress size to be 20 bytes")]
+    InvalidValidatorAddressSize,
+    #[error("Wrong hash: expected Hash size to be 32 bytes")]
+    InvalidHashSize,
+    #[error("negative total")]
+    NegativeTotal,
+}

--- a/src/amino_types/version.rs
+++ b/src/amino_types/version.rs
@@ -1,0 +1,22 @@
+use prost_amino_derive::Message;
+use tendermint::block::*;
+
+#[derive(Clone, Message)]
+pub struct ConsensusVersion {
+    /// Block version
+    #[prost_amino(uint64, tag = "1")]
+    pub block: u64,
+
+    /// App version
+    #[prost_amino(uint64, tag = "2")]
+    pub app: u64,
+}
+
+impl From<&header::Version> for ConsensusVersion {
+    fn from(version: &header::Version) -> Self {
+        ConsensusVersion {
+            block: version.block,
+            app: version.app,
+        }
+    }
+}

--- a/src/amino_types/vote.rs
+++ b/src/amino_types/vote.rs
@@ -1,0 +1,527 @@
+use super::{
+    block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader},
+    compute_prefix,
+    remote_error::RemoteError,
+    signature::SignableMsg,
+    time::TimeMsg,
+    validate::{self, ConsensusMessage, Error::*},
+    PartsSetHeader, SignedMsgType, TendermintRequest,
+};
+use crate::rpc;
+use bytes::BufMut;
+use ed25519_dalek as ed25519;
+use once_cell::sync::Lazy;
+use prost_amino::{error::EncodeError, Message};
+use prost_amino_derive::Message;
+use std::convert::TryFrom;
+use tendermint::{
+    block::{self, ParseId},
+    chain, consensus,
+    error::Error,
+    vote,
+};
+
+const VALIDATOR_ADDR_SIZE: usize = 20;
+
+#[derive(Clone, PartialEq, Message)]
+pub struct Vote {
+    #[prost_amino(uint32, tag = "1")]
+    pub vote_type: u32,
+    #[prost_amino(int64)]
+    pub height: i64,
+    #[prost_amino(int64)]
+    pub round: i64,
+    #[prost_amino(message)]
+    pub block_id: Option<BlockId>,
+    #[prost_amino(message)]
+    pub timestamp: Option<TimeMsg>,
+    #[prost_amino(bytes)]
+    pub validator_address: Vec<u8>,
+    #[prost_amino(int64)]
+    pub validator_index: i64,
+    #[prost_amino(bytes)]
+    pub signature: Vec<u8>,
+}
+
+impl Vote {
+    fn msg_type(&self) -> Option<SignedMsgType> {
+        if self.vote_type == SignedMsgType::PreVote.to_u32() {
+            Some(SignedMsgType::PreVote)
+        } else if self.vote_type == SignedMsgType::PreCommit.to_u32() {
+            Some(SignedMsgType::PreCommit)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<&vote::Vote> for Vote {
+    fn from(vote: &vote::Vote) -> Self {
+        Vote {
+            vote_type: vote.vote_type.to_u32(),
+            height: vote.height.value() as i64, // TODO potential overflow :-/
+            round: vote.round as i64,
+            block_id: vote.block_id.as_ref().map(|block_id| BlockId {
+                hash: block_id.hash.as_bytes().to_vec(),
+                parts_header: block_id.parts.as_ref().map(PartsSetHeader::from),
+            }),
+            timestamp: Some(TimeMsg::from(vote.timestamp)),
+            validator_address: vote.validator_address.as_bytes().to_vec(),
+            validator_index: vote.validator_index as i64, // TODO potential overflow :-/
+            signature: vote.signature.as_bytes().to_vec(),
+        }
+    }
+}
+
+impl block::ParseHeight for Vote {
+    fn parse_block_height(&self) -> Result<block::Height, Error> {
+        block::Height::try_from(self.height)
+    }
+}
+
+pub const AMINO_NAME: &str = "tendermint/remotesigner/SignVoteRequest";
+pub static AMINO_PREFIX: Lazy<Vec<u8>> = Lazy::new(|| compute_prefix(AMINO_NAME));
+
+#[derive(Clone, PartialEq, Message)]
+#[amino_name = "tendermint/remotesigner/SignVoteRequest"]
+pub struct SignVoteRequest {
+    #[prost_amino(message, tag = "1")]
+    pub vote: Option<Vote>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+#[amino_name = "tendermint/remotesigner/SignedVoteResponse"]
+pub struct SignedVoteResponse {
+    #[prost_amino(message, tag = "1")]
+    pub vote: Option<Vote>,
+    #[prost_amino(message, tag = "2")]
+    pub err: Option<RemoteError>,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub struct CanonicalVote {
+    #[prost_amino(uint32, tag = "1")]
+    pub vote_type: u32,
+    #[prost_amino(sfixed64)]
+    pub height: i64,
+    #[prost_amino(sfixed64)]
+    pub round: i64,
+    #[prost_amino(message)]
+    pub block_id: Option<CanonicalBlockId>,
+    #[prost_amino(message)]
+    pub timestamp: Option<TimeMsg>,
+    #[prost_amino(string)]
+    pub chain_id: String,
+}
+
+impl TendermintRequest for SignVoteRequest {
+    fn build_response(self, error: Option<RemoteError>) -> rpc::Response {
+        let response = if let Some(e) = error {
+            SignedVoteResponse {
+                vote: None,
+                err: Some(e),
+            }
+        } else {
+            SignedVoteResponse {
+                vote: self.vote,
+                err: None,
+            }
+        };
+
+        rpc::Response::SignedVote(response)
+    }
+}
+
+impl chain::ParseId for CanonicalVote {
+    fn parse_chain_id(&self) -> Result<chain::Id, Error> {
+        self.chain_id.parse()
+    }
+}
+
+impl block::ParseHeight for CanonicalVote {
+    fn parse_block_height(&self) -> Result<block::Height, Error> {
+        block::Height::try_from(self.height)
+    }
+}
+
+impl CanonicalVote {
+    pub fn new(vote: Vote, chain_id: &str) -> CanonicalVote {
+        CanonicalVote {
+            vote_type: vote.vote_type,
+            chain_id: chain_id.to_string(),
+            block_id: match vote.block_id {
+                Some(bid) => Some(CanonicalBlockId {
+                    hash: bid.hash,
+                    parts_header: match bid.parts_header {
+                        Some(psh) => Some(CanonicalPartSetHeader {
+                            hash: psh.hash,
+                            total: psh.total,
+                        }),
+                        None => None,
+                    },
+                }),
+                None => None,
+            },
+            height: vote.height,
+            round: vote.round,
+            timestamp: match vote.timestamp {
+                None => Some(TimeMsg {
+                    seconds: -62_135_596_800,
+                    nanos: 0,
+                }),
+                Some(t) => Some(t),
+            },
+        }
+    }
+}
+
+impl SignableMsg for SignVoteRequest {
+    fn sign_bytes<B>(&self, chain_id: chain::Id, sign_bytes: &mut B) -> Result<bool, EncodeError>
+    where
+        B: BufMut,
+    {
+        let mut svr = self.clone();
+        if let Some(ref mut vo) = svr.vote {
+            vo.signature = vec![];
+        }
+        let vote = svr.vote.unwrap();
+        let cv = CanonicalVote::new(vote, chain_id.as_str());
+
+        cv.encode_length_delimited(sign_bytes)?;
+
+        Ok(true)
+    }
+    fn set_signature(&mut self, sig: &ed25519::Signature) {
+        if let Some(ref mut vt) = self.vote {
+            vt.signature = sig.as_ref().to_vec();
+        }
+    }
+    fn validate(&self) -> Result<(), validate::Error> {
+        match self.vote {
+            Some(ref v) => v.validate_basic(),
+            None => Err(MissingConsensusMessage),
+        }
+    }
+    fn consensus_state(&self) -> Option<consensus::State> {
+        match self.vote {
+            Some(ref v) => Some(consensus::State {
+                height: match block::Height::try_from(v.height) {
+                    Ok(h) => h,
+                    Err(_err) => return None, // TODO(tarcieri): return an error?
+                },
+                round: v.round,
+                step: 6,
+                block_id: {
+                    match v.block_id {
+                        Some(ref b) => match b.parse_block_id() {
+                            Ok(id) => Some(id),
+                            Err(_) => None,
+                        },
+                        None => None,
+                    }
+                },
+            }),
+            None => None,
+        }
+    }
+    fn height(&self) -> Option<i64> {
+        self.vote.as_ref().map(|vote| vote.height)
+    }
+    fn msg_type(&self) -> Option<SignedMsgType> {
+        self.vote.as_ref().and_then(|vote| vote.msg_type())
+    }
+}
+
+impl ConsensusMessage for Vote {
+    fn validate_basic(&self) -> Result<(), validate::Error> {
+        if self.msg_type().is_none() {
+            return Err(InvalidMessageType);
+        }
+        if self.height < 0 {
+            return Err(NegativeHeight);
+        }
+        if self.round < 0 {
+            return Err(NegativeRound);
+        }
+        if self.validator_index < 0 {
+            return Err(NegativeValidatorIndex);
+        }
+        if self.validator_address.len() != VALIDATOR_ADDR_SIZE {
+            return Err(InvalidValidatorAddressSize);
+        }
+
+        self.block_id
+            .as_ref()
+            .map_or(Ok(()), ConsensusMessage::validate_basic)
+
+        // signature will be missing as the KMS provides it
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::PartsSetHeader;
+    use super::*;
+    use crate::amino_types::message::AminoMessage;
+    use crate::amino_types::SignedMsgType;
+    use chrono::{DateTime, Utc};
+
+    #[test]
+    fn test_vote_serialization() {
+        let dt = "2017-12-25T03:00:01.234Z".parse::<DateTime<Utc>>().unwrap();
+        let t = TimeMsg {
+            seconds: dt.timestamp(),
+            nanos: dt.timestamp_subsec_nanos() as i32,
+        };
+        let vote = Vote {
+            vote_type: SignedMsgType::PreVote.to_u32(),
+            height: 12345,
+            round: 2,
+            timestamp: Some(t),
+            block_id: Some(BlockId {
+                hash: b"hash".to_vec(),
+                parts_header: Some(PartsSetHeader {
+                    total: 1_000_000,
+                    hash: b"parts_hash".to_vec(),
+                }),
+            }),
+            validator_address: vec![
+                0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48, 0x2a, 0xf4,
+                0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35,
+            ],
+            validator_index: 56789,
+            signature: vec![],
+            /* signature: vec![130u8, 246, 183, 50, 153, 248, 28, 57, 51, 142, 55, 217, 194, 24,
+             * 134, 212, 233, 100, 211, 10, 24, 174, 179, 117, 41, 65, 141, 134, 149, 239, 65,
+             * 174, 217, 42, 6, 184, 112, 17, 7, 97, 255, 221, 252, 16, 60, 144, 30, 212, 167,
+             * 39, 67, 35, 118, 192, 133, 130, 193, 115, 32, 206, 152, 91, 173, 10], */
+        };
+        let sign_vote_msg = SignVoteRequest { vote: Some(vote) };
+        let mut got = vec![];
+        let _have = sign_vote_msg.encode(&mut got);
+
+        // the following vector is generated via:
+        //
+        // cdc := amino.NewCodec()
+        // privval.RegisterRemoteSignerMsg(cdc)
+        // stamp, _ := time.Parse(time.RFC3339Nano, "2017-12-25T03:00:01.234Z")
+        // data, _ := cdc.MarshalBinaryLengthPrefixed(privval.SignVoteRequest{Vote: &types.Vote{
+        //     Type:             types.PrevoteType, // pre-vote
+        //     Height:           12345,
+        //     Round:            2,
+        //     Timestamp:        stamp,
+        //     BlockID: types.BlockID{
+        //         Hash: []byte("hash"),
+        //         PartsHeader: types.PartSetHeader{
+        //             Total: 1000000,
+        //             Hash:  []byte("parts_hash"),
+        //         },
+        //     },
+        //     ValidatorAddress: []byte{0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21,
+        // 0xf2, 0x48, 0x2a, 0xf4, 0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35},     ValidatorIndex:
+        // 56789, }})
+        // fmt.Println(strings.Join(strings.Split(fmt.Sprintf("%v",data), " "), ", "))
+
+        let want = vec![
+            78, 243, 244, 18, 4, 10, 72, 8, 1, 16, 185, 96, 24, 2, 34, 24, 10, 4, 104, 97, 115,
+            104, 18, 16, 8, 192, 132, 61, 18, 10, 112, 97, 114, 116, 115, 95, 104, 97, 115, 104,
+            42, 11, 8, 177, 211, 129, 210, 5, 16, 128, 157, 202, 111, 50, 20, 163, 178, 204, 221,
+            113, 134, 241, 104, 95, 33, 242, 72, 42, 244, 251, 52, 70, 168, 75, 53, 56, 213, 187,
+            3,
+        ];
+        let svr = SignVoteRequest::decode(got.as_ref()).unwrap();
+        println!("got back: {:?}", svr);
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_sign_bytes_compatibility() {
+        let cv = CanonicalVote::new(Vote::default(), "");
+        let mut got = vec![];
+        // SignBytes are encoded using MarshalBinary and not MarshalBinaryBare
+        cv.encode_length_delimited(&mut got).unwrap();
+        let want = vec![
+            0xd, 0x2a, 0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+        ];
+        assert_eq!(got, want);
+
+        // with proper (fixed size) height and round (PreCommit):
+        {
+            let mut vt_precommit = Vote::default();
+            vt_precommit.height = 1;
+            vt_precommit.round = 1;
+            vt_precommit.vote_type = SignedMsgType::PreCommit.to_u32(); // precommit
+            println!("{:?}", vt_precommit);
+            let cv_precommit = CanonicalVote::new(vt_precommit, "");
+            let got = AminoMessage::bytes_vec(&cv_precommit);
+            let want = vec![
+                0x8,  // (field_number << 3) | wire_type
+                0x2,  // PrecommitType
+                0x11, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+                0x19, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // round
+                0x2a, // (field_number << 3) | wire_type
+                // remaining fields (timestamp):
+                0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+            ];
+            assert_eq!(got, want);
+        }
+        // with proper (fixed size) height and round (PreVote):
+        {
+            let mut vt_prevote = Vote::default();
+            vt_prevote.height = 1;
+            vt_prevote.round = 1;
+            vt_prevote.vote_type = SignedMsgType::PreVote.to_u32();
+
+            let cv_prevote = CanonicalVote::new(vt_prevote, "");
+
+            let got = AminoMessage::bytes_vec(&cv_prevote);
+
+            let want = vec![
+                0x8,  // (field_number << 3) | wire_type
+                0x1,  // PrevoteType
+                0x11, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+                0x19, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // round
+                0x2a, // (field_number << 3) | wire_type
+                // remaining fields (timestamp):
+                0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+            ];
+            assert_eq!(got, want);
+        }
+        // with proper (fixed size) height and round (msg typ missing):
+        {
+            let mut vt_no_type = Vote::default();
+            vt_no_type.height = 1;
+            vt_no_type.round = 1;
+
+            let cv = CanonicalVote::new(vt_no_type, "");
+            let got = AminoMessage::bytes_vec(&cv);
+
+            let want = vec![
+                0x11, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+                0x19, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // round
+                // remaining fields (timestamp):
+                0x2a, 0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff, 0x1,
+            ];
+            assert_eq!(got, want);
+        }
+        // containing non-empty chain_id:
+        {
+            let mut no_vote_type2 = Vote::default();
+            no_vote_type2.height = 1;
+            no_vote_type2.round = 1;
+
+            let with_chain_id = CanonicalVote::new(no_vote_type2, "test_chain_id");
+            got = AminoMessage::bytes_vec(&with_chain_id);
+            let want = vec![
+                0x11, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  // height
+                0x19, // (field_number << 3) | wire_type
+                0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, // round
+                // remaining fields:
+                0x2a, // (field_number << 3) | wire_type
+                0xb, 0x8, 0x80, 0x92, 0xb8, 0xc3, 0x98, 0xfe, 0xff, 0xff, 0xff,
+                0x1,  // timestamp
+                0x32, // (field_number << 3) | wire_type
+                0xd, 0x74, 0x65, 0x73, 0x74, 0x5f, 0x63, 0x68, 0x61, 0x69, 0x6e, 0x5f, 0x69,
+                0x64, // chainID
+            ];
+            assert_eq!(got, want);
+        }
+    }
+
+    #[test]
+    fn test_vote_rountrip_with_sig() {
+        let dt = "2017-12-25T03:00:01.234Z".parse::<DateTime<Utc>>().unwrap();
+        let t = TimeMsg {
+            seconds: dt.timestamp(),
+            nanos: dt.timestamp_subsec_nanos() as i32,
+        };
+        let vote = Vote {
+            validator_address: vec![
+                0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48, 0x2a, 0xf4,
+                0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35,
+            ],
+            validator_index: 56789,
+            height: 12345,
+            round: 2,
+            timestamp: Some(t),
+            vote_type: 0x01,
+            block_id: Some(BlockId {
+                hash: b"hash".to_vec(),
+                parts_header: Some(PartsSetHeader {
+                    total: 1_000_000,
+                    hash: b"parts_hash".to_vec(),
+                }),
+            }),
+            // signature: None,
+            signature: vec![
+                130u8, 246, 183, 50, 153, 248, 28, 57, 51, 142, 55, 217, 194, 24, 134, 212, 233,
+                100, 211, 10, 24, 174, 179, 117, 41, 65, 141, 134, 149, 239, 65, 174, 217, 42, 6,
+                184, 112, 17, 7, 97, 255, 221, 252, 16, 60, 144, 30, 212, 167, 39, 67, 35, 118,
+                192, 133, 130, 193, 115, 32, 206, 152, 91, 173, 10,
+            ],
+        };
+        let mut got = vec![];
+        let _have = vote.encode(&mut got);
+        let v = Vote::decode(got.as_ref()).unwrap();
+
+        assert_eq!(v, vote);
+        // SignVoteRequest
+        {
+            let svr = SignVoteRequest { vote: Some(vote) };
+            let mut got = vec![];
+            let _have = svr.encode(&mut got);
+
+            let svr2 = SignVoteRequest::decode(got.as_ref()).unwrap();
+            assert_eq!(svr, svr2);
+        }
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let encoded = vec![
+            78, 243, 244, 18, 4, 10, 72, 8, 1, 16, 185, 96, 24, 2, 34, 24, 10, 4, 104, 97, 115,
+            104, 18, 16, 8, 192, 132, 61, 18, 10, 112, 97, 114, 116, 115, 95, 104, 97, 115, 104,
+            42, 11, 8, 177, 211, 129, 210, 5, 16, 128, 157, 202, 111, 50, 20, 163, 178, 204, 221,
+            113, 134, 241, 104, 95, 33, 242, 72, 42, 244, 251, 52, 70, 168, 75, 53, 56, 213, 187,
+            3,
+        ];
+        let dt = "2017-12-25T03:00:01.234Z".parse::<DateTime<Utc>>().unwrap();
+        let t = TimeMsg {
+            seconds: dt.timestamp(),
+            nanos: dt.timestamp_subsec_nanos() as i32,
+        };
+        let vote = Vote {
+            validator_address: vec![
+                0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48, 0x2a, 0xf4,
+                0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35,
+            ],
+            validator_index: 56789,
+            height: 12345,
+            round: 2,
+            timestamp: Some(t),
+            vote_type: 0x01,
+            block_id: Some(BlockId {
+                hash: b"hash".to_vec(),
+                parts_header: Some(PartsSetHeader {
+                    total: 1_000_000,
+                    hash: b"parts_hash".to_vec(),
+                }),
+            }),
+            signature: vec![],
+        };
+        let want = SignVoteRequest { vote: Some(vote) };
+        match SignVoteRequest::decode(encoded.as_ref()) {
+            Ok(have) => {
+                assert_eq!(have, want);
+            }
+            Err(err) => panic!(err.to_string()),
+        }
+    }
+}

--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -1,12 +1,15 @@
 //! `tmkms ledger` CLI (sub)commands
 
-use crate::{chain, prelude::*};
+use crate::{
+    amino_types::{
+        vote::{SignVoteRequest, Vote},
+        SignableMsg, SignedMsgType,
+    },
+    chain,
+    prelude::*,
+};
 use abscissa_core::{Command, Options, Runnable};
 use std::{path::PathBuf, process};
-use tendermint::amino_types::{
-    vote::{SignVoteRequest, Vote},
-    SignableMsg, SignedMsgType,
-};
 
 /// `ledger` subcommand
 #[derive(Command, Debug, Options, Runnable)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ compile_error!(
      yubihsm, ledgertm, softsign (e.g. --features=yubihsm)"
 );
 
+pub mod amino_types;
 pub mod application;
 pub mod chain;
 pub mod client;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,7 +14,7 @@ use std::{
     process::{Child, Command},
 };
 use tempfile::NamedTempFile;
-use tendermint::amino_types::{self, *};
+use tmkms::amino_types::{self, *};
 use tmkms::connection::{
     secret_connection::{self, SecretConnection},
     unix::UnixConnection,


### PR DESCRIPTION
Vendors all Amino types from the `tendermint` crate, so we can continue supporting Amino even though it's been removed from the upstream crate in favor of Protobufs.