### PR TITLE
Tendermint v0.34 signing compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ prerequisites for support.
 
 You will need the following prerequisites:
 
-- **Rust** (stable; **1.41+**): https://rustup.rs/
+- **Rust** (stable; **1.44+**): https://rustup.rs/
 - **C compiler**: e.g. gcc, clang
 - **pkg-config**
 - **libusb** (1.0+). Install instructions for common platforms:

--- a/src/amino_types/signature.rs
+++ b/src/amino_types/signature.rs
@@ -1,4 +1,5 @@
 use super::validate;
+use crate::config::validator::ProtocolVersion;
 use bytes::BufMut;
 use ed25519_dalek as ed25519;
 use prost_amino::{DecodeError, EncodeError};
@@ -10,6 +11,7 @@ pub trait SignableMsg {
     fn sign_bytes<B: BufMut>(
         &self,
         chain_id: chain::Id,
+        version: ProtocolVersion,
         sign_bytes: &mut B,
     ) -> Result<bool, EncodeError>;
 

--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -6,6 +6,7 @@ use crate::{
         SignableMsg, SignedMsgType,
     },
     chain,
+    config::validator::ProtocolVersion,
     prelude::*,
 };
 use abscissa_core::{Command, Options, Runnable};
@@ -64,7 +65,11 @@ impl Runnable for InitCommand {
         let sign_vote_req = SignVoteRequest { vote: Some(vote) };
         let mut to_sign = vec![];
         sign_vote_req
-            .sign_bytes(config.validator[0].chain_id, &mut to_sign)
+            .sign_bytes(
+                config.validator[0].chain_id,
+                ProtocolVersion::Legacy,
+                &mut to_sign,
+            )
             .unwrap();
 
         let _sig = chain.keyring.sign_ed25519(None, &to_sign).unwrap();

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -29,7 +29,41 @@ pub struct ValidatorConfig {
     pub max_height: Option<tendermint::block::Height>,
 
     /// Version of Secret Connection protocol to use when connecting
-    pub protocol_version: secret_connection::Version,
+    pub protocol_version: ProtocolVersion,
+}
+
+/// Protocol version (based on the Tendermint version)
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[allow(non_camel_case_types)]
+pub enum ProtocolVersion {
+    /// Tendermint v0.34
+    #[serde(rename = "v0.34")]
+    V0_34,
+
+    /// Tendermint v0.33
+    #[serde(rename = "v0.33")]
+    V0_33,
+
+    /// Pre-Tendermint v0.33
+    #[serde(rename = "legacy")]
+    Legacy,
+}
+
+impl ProtocolVersion {
+    /// Are messages encoded using Protocol Buffers?
+    pub fn is_protobuf(self) -> bool {
+        !matches!(self, ProtocolVersion::V0_33 | ProtocolVersion::Legacy)
+    }
+}
+
+impl From<ProtocolVersion> for secret_connection::Version {
+    fn from(version: ProtocolVersion) -> secret_connection::Version {
+        match version {
+            ProtocolVersion::V0_34 => secret_connection::Version::V0_34,
+            ProtocolVersion::V0_33 => secret_connection::Version::V0_33,
+            ProtocolVersion::Legacy => secret_connection::Version::Legacy,
+        }
+    }
 }
 
 /// Default value for the `ValidatorConfig` reconnect field

--- a/src/connection/secret_connection/protocol.rs
+++ b/src/connection/secret_connection/protocol.rs
@@ -8,7 +8,6 @@ use crate::{
 use ed25519_dalek as ed25519;
 use prost::Message as _;
 use prost_amino::Message as _;
-use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use tendermint_proto as proto;
 use x25519_dalek::PublicKey as EphemeralPublic;
@@ -17,19 +16,16 @@ use x25519_dalek::PublicKey as EphemeralPublic;
 const PUBLIC_KEY_SIZE: usize = 32;
 
 /// Protocol version (based on the Tendermint version)
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
 pub enum Version {
     /// Tendermint v0.34
-    #[serde(rename = "v0.34")]
     V0_34,
 
     /// Tendermint v0.33
-    #[serde(rename = "v0.33")]
     V0_33,
 
     /// Pre-Tendermint v0.33
-    #[serde(rename = "legacy")]
     Legacy,
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -5,7 +5,8 @@
 
 use crate::{
     amino_types,
-    connection::secret_connection::{Version, DATA_MAX_SIZE},
+    config::validator::ProtocolVersion,
+    connection::secret_connection::DATA_MAX_SIZE,
     error::{Error, ErrorKind},
     prelude::*,
 };
@@ -29,7 +30,7 @@ pub enum Request {
 
 impl Request {
     /// Read a request from the given readable
-    pub fn read(conn: &mut impl Read, protocol_version: Version) -> Result<Self, Error> {
+    pub fn read(conn: &mut impl Read, protocol_version: ProtocolVersion) -> Result<Self, Error> {
         let msg = read_msg(conn)?;
 
         if protocol_version.is_protobuf() {
@@ -117,7 +118,7 @@ pub enum Response {
 
 impl Response {
     /// Encode response to bytes
-    pub fn encode(self, protocol_version: Version) -> Result<Vec<u8>, Error> {
+    pub fn encode(self, protocol_version: ProtocolVersion) -> Result<Vec<u8>, Error> {
         if protocol_version.is_protobuf() {
             let mut buf = Vec::new();
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -43,7 +43,7 @@ impl Session {
                     &config.secret_key,
                     peer_id,
                     config.timeout,
-                    config.protocol_version,
+                    config.protocol_version.into(),
                 )?;
 
                 info!(
@@ -146,7 +146,11 @@ impl Session {
         }
 
         let mut to_sign = vec![];
-        request.sign_bytes(self.config.chain_id, &mut to_sign)?;
+        request.sign_bytes(
+            self.config.chain_id,
+            self.config.protocol_version,
+            &mut to_sign,
+        )?;
 
         let started_at = Instant::now();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,10 +14,13 @@ use std::{
     process::{Child, Command},
 };
 use tempfile::NamedTempFile;
-use tmkms::amino_types::{self, *};
-use tmkms::connection::{
-    secret_connection::{self, SecretConnection},
-    unix::UnixConnection,
+use tmkms::{
+    amino_types::{self, *},
+    config::validator::ProtocolVersion,
+    connection::{
+        secret_connection::{self, SecretConnection},
+        unix::UnixConnection,
+    },
 };
 
 /// Integration tests for the KMS command-line interface
@@ -342,7 +345,8 @@ fn test_handle_and_sign_proposal() {
         let p_req = proposal::SignedProposalResponse::decode(resp.as_ref())
             .expect("decoding proposal failed");
         let mut sign_bytes: Vec<u8> = vec![];
-        spr.sign_bytes(chain_id.into(), &mut sign_bytes).unwrap();
+        spr.sign_bytes(chain_id.into(), ProtocolVersion::Legacy, &mut sign_bytes)
+            .unwrap();
 
         let prop: amino_types::proposal::Proposal = p_req
             .proposal
@@ -404,7 +408,8 @@ fn test_handle_and_sign_vote() {
 
         let v_resp = vote::SignedVoteResponse::decode(resp.as_ref()).expect("decoding vote failed");
         let mut sign_bytes: Vec<u8> = vec![];
-        svr.sign_bytes(chain_id.into(), &mut sign_bytes).unwrap();
+        svr.sign_bytes(chain_id.into(), ProtocolVersion::Legacy, &mut sign_bytes)
+            .unwrap();
 
         let vote_msg: amino_types::vote::Vote = v_resp
             .vote
@@ -470,7 +475,8 @@ fn test_exceed_max_height() {
 
         let v_resp = vote::SignedVoteResponse::decode(resp.as_ref()).expect("decoding vote failed");
         let mut sign_bytes: Vec<u8> = vec![];
-        svr.sign_bytes(chain_id.into(), &mut sign_bytes).unwrap();
+        svr.sign_bytes(chain_id.into(), ProtocolVersion::Legacy, &mut sign_bytes)
+            .unwrap();
 
         let vote_msg: amino_types::vote::Vote = v_resp
             .vote


### PR DESCRIPTION
Adds initial (quick-and-dirty) support for Protobuf signing.

Based on this branch:

https://github.com/tomtau/tmkms/tree/fix/tmkms-alpha-proto