### PR TITLE
Bump `stdtx` to v0.4.0-pre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f29abf4740a4778632fe27a4f681ef5b7a6f659aeba3330ac66f48e20cfa3b7"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1094,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bd112d44d9d870a6819eb505d04dd92b5e4d94bb8c304924a0872ae7016fb5"
 
 [[package]]
 name = "indexmap"
@@ -2060,12 +2076,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stdtx"
-version = "0.3.0"
+version = "0.4.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470756684957fd9ed5060c00641a610e6ab7fae4194f0582e8611c5f6a2cb45b"
+checksum = "7fb28d154121d5216d10cbd3ec7ddbc0d0c95e4bba8f541b6743dd7a34279a2f"
 dependencies = [
- "anomaly",
  "ecdsa 0.8.5",
+ "eyre",
  "k256 0.5.10",
  "prost-amino",
  "prost-amino-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
 signature = { version = "1.2", features = ["std"] }
-stdtx = { version = "0.3", optional = true }
+stdtx = { version = "=0.4.0-pre", optional = true, features = ["amino"] }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"

--- a/src/config/tx_signer.rs
+++ b/src/config/tx_signer.rs
@@ -3,7 +3,7 @@
 use hyper::http::Uri;
 use serde::{de, Deserialize};
 use std::path::PathBuf;
-use stdtx::{Address, TypeName};
+use stdtx::{amino::TypeName, Address};
 use tendermint::{chain, net};
 
 /// Transaction signer (`[tx_signer]`) configuration

--- a/src/error.rs
+++ b/src/error.rs
@@ -216,8 +216,8 @@ impl From<serde_json::error::Error> for Error {
 }
 
 #[cfg(feature = "tx-signer")]
-impl From<stdtx::Error> for Error {
-    fn from(other: stdtx::Error) -> Self {
+impl From<stdtx::error::Report> for Error {
+    fn from(other: stdtx::error::Report) -> Self {
         ErrorKind::StdtxError.context(other).into()
     }
 }

--- a/src/tx_signer/sign_msg.rs
+++ b/src/tx_signer/sign_msg.rs
@@ -7,22 +7,22 @@ use crate::{
     prelude::*,
 };
 use std::collections::BTreeSet as Set;
-use stdtx::{Msg, StdFee, StdSignature, StdTx, TypeName};
+use stdtx::amino;
 
 /// String representation of a message that describes a particular transaction
 /// to be signed by transaction signer
 pub struct SignMsg {
     /// Fee
-    pub fee: StdFee,
+    pub fee: amino::StdFee,
 
     /// Memo
     pub memo: String,
 
     /// Messages
-    msgs: Vec<Msg>,
+    msgs: Vec<amino::Msg>,
 
     /// Message types
-    msg_types: Set<TypeName>,
+    msg_types: Set<amino::TypeName>,
 
     /// String representation
     repr: String,
@@ -32,14 +32,14 @@ impl SignMsg {
     /// Create a new [`SignMsg`] from a [`TxSigningRequest`]
     pub fn new(
         req: &TxSigningRequest,
-        tx_builder: &stdtx::Builder,
+        tx_builder: &amino::Builder,
         sequence: u64,
     ) -> Result<Self, Error> {
         let mut msgs = vec![];
         let mut msg_types = Set::new();
 
         for msg_value in &req.msgs {
-            let msg = stdtx::Msg::from_json_value(tx_builder.schema(), msg_value.clone())?;
+            let msg = amino::Msg::from_json_value(tx_builder.schema(), msg_value.clone())?;
             msg_types.insert(msg.type_name().clone());
             msgs.push(msg);
         }
@@ -75,17 +75,17 @@ impl SignMsg {
     }
 
     /// Serialize a [`StdTx`] after obtaining a signature
-    pub fn to_stdtx(&self, sig: StdSignature) -> StdTx {
-        StdTx::new(&self.msgs, self.fee.clone(), vec![sig], self.memo.clone())
+    pub fn to_stdtx(&self, sig: amino::StdSignature) -> amino::StdTx {
+        amino::StdTx::new(&self.msgs, self.fee.clone(), vec![sig], self.memo.clone())
     }
 
     /// Borrow the signed messages
-    pub fn msgs(&self) -> &[Msg] {
+    pub fn msgs(&self) -> &[amino::Msg] {
         self.msgs.as_slice()
     }
 
     /// Borrow the set of signed message types
-    pub fn msg_types(&self) -> &Set<TypeName> {
+    pub fn msg_types(&self) -> &Set<amino::TypeName> {
         &self.msg_types
     }
 

--- a/src/tx_signer/tx_request.rs
+++ b/src/tx_signer/tx_request.rs
@@ -1,7 +1,7 @@
 //! Transaction signing requests
 
 use serde::Deserialize;
-use stdtx::StdFee;
+use stdtx::amino;
 
 /// Request to sign a transaction request
 #[derive(Clone, Debug, Deserialize)]
@@ -11,7 +11,7 @@ pub struct TxSigningRequest {
     pub chain_id: String,
 
     /// Fee
-    pub fee: StdFee,
+    pub fee: amino::StdFee,
 
     /// Memo
     pub memo: String,


### PR DESCRIPTION
This is the first version that will support protos.

This commit implements the API changes to move Amino-related types out-of-the-way.