### PR TITLE
Handle `null` block ID in serialized state file

### DIFF
--- a/src/chain/state/encoding.rs
+++ b/src/chain/state/encoding.rs
@@ -24,7 +24,6 @@ pub struct EncodedState {
     pub step: i8,
 
     /// Block ID being proposed (if available)
-    #[serde(with = "tendermint_proto::serializers::optional")]
     pub block_id: Option<block::Id>,
 }
 


### PR DESCRIPTION
The proto serializer does not appear to handle this case(?)