### PR TITLE
Bump tendermint-rs to v0.17 (and more); MSRV 1.46+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.45.0 # MSRV
+          - 1.46.0 # MSRV
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -95,7 +95,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.45.0 # MSRV
+          - 1.46.0 # MSRV
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -273,7 +273,7 @@ jobs:
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.0 # MSRV
+          toolchain: 1.46.0 # MSRV
           override: true
 
       - name: Install libudev-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73d4de4f7724e5fe70addfb2bd37c2abd2f95084a429d7773b0b9645499b4272"
 dependencies = [
- "crypto-mac 0.10.0",
+ "crypto-mac",
  "dbl",
 ]
 
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.1.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d9162b7289a46e86208d6af2c686ca5bfde445878c41a458a9fac706252d0b"
+checksum = "c5d82796b70971fbb603900a5edc797a4d9be0f9ec1257f83a1dba0aa374e3e9"
 
 [[package]]
 name = "core-foundation"
@@ -414,16 +414,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
@@ -457,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d658711a12632b5574c8d5b3fc5d2f0d2f87b9fbf9237ee0f759b88bb6bdec"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -467,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d3514d243331d8acde56bfcf45d0147aabbda853c2f49dce081ea85f9a7220"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
@@ -481,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f63c369ef0c17ad17585d31d5f2bf10dece2710bf0766e01db57a6f9849a2e"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote",
@@ -500,6 +490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f59c66c30bb7445c8320a5f9233e437e3572368099f25532a59054328899b4"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,12 +509,12 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.8.5"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87bf8bfb05ea8a6f74ddf48c7d1774851ba77bbe51ac984fdfa6c30310e1ff5f"
+checksum = "41fbdb4ff710acb4db8ca29f93b897529ea6d6a45626d5183b47e012aa6ae7e4"
 dependencies = [
  "elliptic-curve",
- "hmac 0.9.0",
+ "hmac",
  "signature",
 ]
 
@@ -552,16 +551,16 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.6.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396db09c483e7fca5d4fdb9112685632b3e76c9a607a2649c1bf904404a01366"
+checksum = "0fe963e4221e6518695d10fdd47558a0a1e8edcbb87faba1dc7a15052f63dc72"
 dependencies = [
  "bitvec",
- "const-oid",
  "digest",
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core",
  "subtle",
  "zeroize",
@@ -888,7 +887,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68c4bfcead3bb33ccdc3e531879c7ddc44c952f44373f92d54485185335fda7"
 dependencies = [
- "hmac 0.10.1",
+ "hmac",
  "once_cell",
  "rand_core",
  "sha2",
@@ -902,17 +901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
  "digest",
- "hmac 0.10.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
-dependencies = [
- "crypto-mac 0.9.1",
- "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -921,7 +910,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
- "crypto-mac 0.10.0",
+ "crypto-mac",
  "digest",
 ]
 
@@ -1077,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.5.10"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3934640b1efbc660af5889d041854b6985d403771dc4d5fee984e13e8f82f313"
+checksum = "e443f962f64bcd3753b09e9d6c3733986a81e49b2a36c3c2faaedbe2c3a8e7dd"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
@@ -1342,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.5.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280ed58e7e5f3052b6e2f596fa40c7eff4c27c4b6b6deecb5d685ba5c2080980"
+checksum = "39f37a291d378ba3291c1fa4e925edb6729c8593d4c6064be79e4a4c12fa2d97"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1353,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06de0548166c258c22bb6bdcff3074eac4b07125040aa74db3f61db87fe5f275"
+checksum = "ea33960aac2200d19a5c9ab06a11ebd48a37a23144496632c358182e6765d80b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1367,7 +1356,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
 dependencies = [
- "crypto-mac 0.10.0",
+ "crypto-mac",
 ]
 
 [[package]]
@@ -1433,6 +1422,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
+dependencies = [
+ "der",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1966,9 +1964,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stdtx"
-version = "0.4.0-pre"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb28d154121d5216d10cbd3ec7ddbc0d0c95e4bba8f541b6743dd7a34279a2f"
+checksum = "db4639a1229588301569d505b8fc4a1e17492b777cde120ce296b4880a71e24d"
 dependencies = [
  "ecdsa",
  "eyre",
@@ -1986,15 +1984,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "subtle-encoding"
@@ -2056,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.17.0-rc3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469c73d90e4f6ae15f68e2475db9e7cd3ebcf71321d30910acefa92b83c70804"
+checksum = "b700d694c42ed7ed61f4d66f742820fc0b903877893d0b095ee1c80eeb5474e8"
 dependencies = [
  "anomaly",
  "async-trait",
@@ -2089,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-p2p"
-version = "0.17.0-rc3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9c878e0b802847b36db51cb69f6d3ad0d7ff1cb49254596adbec010e760e2a"
+checksum = "34868f1af44e6285c709e3dfbccfb049b1675c36c38a3193d499ee51938d9107"
 dependencies = [
  "chacha20poly1305",
  "ed25519-dalek",
@@ -2114,9 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.17.0-rc3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e38abad428d9414b61b20a252441a04dff48daf68e9562352f10201df5a3cb6"
+checksum = "4a8d65c9235cbb53d87c4b4d9d1c139fbc0b0f585d92643cd625c71c9975ccd1"
 dependencies = [
  "anomaly",
  "bytes",
@@ -2133,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.17.0-rc3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503c9c219e578a862a7dc0e9af8766c98a86e3cb7d4cc6f369dfce4e475d0001"
+checksum = "ee0799c05f8e2a074593ab22d5eb088c432b666e856f6d3c2e58c338e73272e4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2144,6 +2142,7 @@ dependencies = [
  "getrandom",
  "http",
  "hyper",
+ "pin-project 1.0.2",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -2152,6 +2151,7 @@ dependencies = [
  "tendermint-proto",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -2694,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a705a6b1f039104fa38e1efba2dd273e8873aabe0fcadd8a76df948ffc2e906"
+checksum = "c1a94c32e288e71c5dfb4851b91ce0d997e8ad96b0ce4db28ab108f406df6124"
 dependencies = [
  "aes",
  "anomaly",
@@ -2710,7 +2710,7 @@ dependencies = [
  "ed25519",
  "ed25519-dalek",
  "harp",
- "hmac 0.10.1",
+ "hmac",
  "k256",
  "log",
  "p256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hkd32 = { version = "0.5", default-features = false, features = ["mnemonic"] }
 hkdf = "0.10.0"
 hyper = { version = "0.13", optional = true }
 hyper-rustls = { version = "0.21", optional = true }
-k256 = { version = "0.5", features = ["ecdsa", "sha256"] }
+k256 = { version = "0.7", features = ["ecdsa", "sha256"] }
 ledger = { version = "0.2", optional = true }
 once_cell = "1.5"
 prost = "0.6"
@@ -35,17 +35,17 @@ serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
 signature = { version = "1.2", features = ["std"] }
-stdtx = { version = "=0.4.0-pre", optional = true, features = ["amino"] }
+stdtx = { version = "0.4", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = { version = "=0.17.0-rc3", features = ["secp256k1"] }
-tendermint-rpc = { version = "=0.17.0-rc3", optional = true, features = ["http-client"] }
-tendermint-proto = "=0.17.0-rc3"
-tendermint-p2p = { version = "=0.17.0-rc3", features = ["amino"] }
+tendermint = { version = "0.17", features = ["secp256k1"] }
+tendermint-rpc = { version = "0.17", optional = true, features = ["http-client"] }
+tendermint-proto = "0.17"
+tendermint-p2p = { version = "0.17", features = ["amino"] }
 thiserror = "1"
 wait-timeout = "0.2"
-yubihsm = { version = "0.35", features = ["secp256k1", "setup", "usb"], optional = true }
+yubihsm = { version = "0.37", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ prerequisites for support.
 
 You will need the following prerequisites:
 
-- **Rust** (stable; **1.45+**): https://rustup.rs/
+- **Rust** (stable; **1.46+**): https://rustup.rs/
 - **C compiler**: e.g. gcc, clang
 - **pkg-config**
 - **libusb** (1.0+). Install instructions for common platforms:
@@ -117,7 +117,7 @@ If successful, this will produce a `tmkms` executable located at
 
 ### Installing with the `cargo install` command
 
-With Rust (1.45+) installed, you can install tmkms with the following:
+With Rust (1.46+) installed, you can install tmkms with the following:
 
 ```
 cargo install tmkms --features=yubihsm
@@ -230,7 +230,7 @@ limitations under the License.
 [build-link]: https://github.com/iqlusioninc/tmkms/actions
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/tmkms/blob/develop/LICENSE
-[rustc-image]: https://img.shields.io/badge/rustc-1.45+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.46+-blue.svg
 
 [//]: # (general links)
 

--- a/src/keyring/providers/softsign.rs
+++ b/src/keyring/providers/softsign.rs
@@ -112,7 +112,7 @@ fn load_secp256k1_key(config: &SoftsignConfig) -> Result<ecdsa::SigningKey, Erro
 
     let key_bytes = key_utils::load_base64_secret(&config.path)?;
 
-    let secret_key = ecdsa::SigningKey::new(key_bytes.as_slice()).map_err(|e| {
+    let secret_key = ecdsa::SigningKey::from_bytes(key_bytes.as_slice()).map_err(|e| {
         format_err!(
             ConfigError,
             "can't decode account key base64 from {}: {}",

--- a/src/tx_signer.rs
+++ b/src/tx_signer.rs
@@ -305,7 +305,7 @@ impl TxSigner {
 
         let response = match self.rpc_client.broadcast_tx_commit(amino_tx).await {
             Ok(resp) => {
-                self.last_tx = LastTx::Response(resp.clone());
+                self.last_tx = LastTx::Response(Box::new(resp.clone()));
                 resp
             }
             Err(e) => {

--- a/src/tx_signer/last_tx.rs
+++ b/src/tx_signer/last_tx.rs
@@ -9,7 +9,7 @@ pub enum LastTx {
     None,
 
     /// Tendermint RPC response
-    Response(tx_commit::Response),
+    Response(Box<tx_commit::Response>),
 
     /// Error broadcasting the previous transaction
     Error(tendermint_rpc::error::Error),


### PR DESCRIPTION
Also bumps related dependencies:

- `k256` v0.7
- `stdtx` v0.4
- `yubihsm` v0.37