### PR TITLE
v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.10.0 (UNRELEASED)
+## 0.10.0 (2021-02-16)
 
-This release (to be) is compatible with [tendermint v0.34] or older.
+This release is compatible with [tendermint v0.34] or older.
 
 It includes initial support for "Stargate", an upgrade to Cosmos Hub which
 will enable IBC. It also retains backwards compatibility for all older versions
@@ -18,7 +18,12 @@ For Stargate, configure this value to:
 [[validator]]
 chain_id = "cosmoshub-4"
 protocol_version = "v0.34"
+state_file = "/path/to/cosmoshub-4-state.json"
 ```
+
+Also make sure to update the `state_file` with a new filename
+(e.g. `cosmoshub-4-state.json`) and retain the old state file for `cosmoshub-3`.
+You'll need the old state file if a chain rollback is required!
 
 ### Added
 - Tendermint v0.34 signing compatibility ([#211])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,7 +2111,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tmkms"
-version = "0.10.0-beta2"
+version = "0.10.0"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Tendermint Key Management System: provides isolated, optionally HSM-backed
 signing key management for Tendermint applications including validators,
 oracles, IBC relayers, and other transaction signing applications
 """
-version     = "0.10.0-beta2"
+version     = "0.10.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 repository  = "https://github.com/iqlusioninc/tmkms/"


### PR DESCRIPTION
This release is compatible with [tendermint v0.34] or older.

It includes initial support for [Stargate](https://stargate.cosmos.network/), an upgrade to Cosmos Hub which will enable IBC. It also retains backwards compatibility for all older versions of Tendermint via the `[validator.protocol_version]` setting in `tmkms.toml`.

For Stargate, configure this value to:

```toml
[[validator]]
chain_id = "cosmoshub-4"
protocol_version = "v0.34"
state_file = "/path/to/cosmoshub-4-state.json"
```

Also make sure to update the `state_file` with a new filename (e.g. `cosmoshub-4-state.json`) and retain the old state file for `cosmoshub-3`. You'll need the old state file if a chain rollback is required!

### Added
- Tendermint v0.34 signing compatibility ([#211])

### Changed
- rpc: add support for protobuf-encoded messages ([#201])
- tx-signer: retry failed transactions up to 3 times ([#213])
- Use `consensus::State` serializers from `tendermint-rs` ([#232])
- Use `tendermint-p2p` crate for secret connection ([#234], [#290])
- Bump `stdtx` to v0.4 ([#249])
- Bump `tendermint-rs` to v0.18 ([#290])
- Bump `tokio` to v1.0 ([#290])
- Bump `yubihsm` crate dependency to v0.38 ([#289])
- MSRV 1.46+ ([#249])

[tendermint v0.34]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0340
[#201]: https://github.com/iqlusioninc/tmkms/pull/201
[#211]: https://github.com/iqlusioninc/tmkms/pull/211
[#213]: https://github.com/iqlusioninc/tmkms/pull/213
[#232]: https://github.com/iqlusioninc/tmkms/pull/232
[#234]: https://github.com/iqlusioninc/tmkms/pull/234
[#249]: https://github.com/iqlusioninc/tmkms/pull/249
[#289]: https://github.com/iqlusioninc/tmkms/pull/289
[#290]: https://github.com/iqlusioninc/tmkms/pull/290