### PR TITLE
Fixed tmkms keys import -t for priv_validator

### DIFF
--- a/src/commands/yubihsm/keys/import.rs
+++ b/src/commands/yubihsm/keys/import.rs
@@ -25,8 +25,8 @@ pub struct ImportCommand {
     #[options(short = "w", long = "wrapkey", help = "wrap key to decrypt with")]
     pub wrap_key_id: Option<u16>,
 
-    /// Type of key to import (either `wrap`, `priv_validator`, or `base64`, default `wrap`)
-    #[options(short = "t", help = "type of key to import (wrap, base64 or priv_validator)")]
+    /// Type of key to import (either `wrap`, `json`, or `base64`, default `wrap`)
+    #[options(short = "t", help = "type of key to import (wrap, base64 or json)")]
     pub key_type: Option<String>,
 
     /// Label for imported key (only applicable to `priv_validator` keys)
@@ -47,7 +47,7 @@ impl Runnable for ImportCommand {
 
         match self.key_type.as_deref() {
             Some("wrap") => self.import_wrapped(&contents),
-            Some("priv_validator") => self.import_priv_validator_json(&contents),
+            Some("json") => self.import_priv_validator_json(&contents),
             Some("base64") => self.import_base64(&contents),
             Some(other) => {
                 status_err!("invalid key type: {}", other);

--- a/src/commands/yubihsm/keys/import.rs
+++ b/src/commands/yubihsm/keys/import.rs
@@ -25,8 +25,8 @@ pub struct ImportCommand {
     #[options(short = "w", long = "wrapkey", help = "wrap key to decrypt with")]
     pub wrap_key_id: Option<u16>,
 
-    /// Type of key to import (either `wrap`, `json`, or `base64`, default `wrap`)
-    #[options(short = "t", help = "type of key to import (wrap or priv_validator)")]
+    /// Type of key to import (either `wrap`, `priv_validator`, or `base64`, default `wrap`)
+    #[options(short = "t", help = "type of key to import (wrap, base64 or priv_validator)")]
     pub key_type: Option<String>,
 
     /// Label for imported key (only applicable to `priv_validator` keys)
@@ -47,14 +47,14 @@ impl Runnable for ImportCommand {
 
         match self.key_type.as_deref() {
             Some("wrap") => self.import_wrapped(&contents),
-            Some("json") => self.import_priv_validator_json(&contents),
+            Some("priv_validator") => self.import_priv_validator_json(&contents),
             Some("base64") => self.import_base64(&contents),
             Some(other) => {
                 status_err!("invalid key type: {}", other);
                 process::exit(1);
             }
             None => {
-                if self.path.ends_with("priv_validator.json") {
+                if self.path.ends_with("priv_validator_key.json") {
                     self.import_priv_validator_json(&contents)
                 } else {
                     self.import_wrapped(&contents)


### PR DESCRIPTION
For now, `tmkms keys import -t priv_validator` results in an error:

```
$ tmkms yubihsm keys import -t priv_validator ~/priv_validator.json
error: invalid key type: priv_validator
```

I've renamed the `json` label to `priv_validator` to match the description.

Also it seems like the `priv_validator.json` file is now `priv_validator_key.json` (at least on Persistence on core-1 and on Sentinel on sentinelhub-2 it's this way)