### PR TITLE
Bump `signature` crate dependency to v1.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
 dependencies = [
  "digest",
  "rand_core 0.6.3",


### PR DESCRIPTION
This release reports `source` error information in the `Display` impl, which should be helpful in diagnosing #415.