### PR TITLE
Pin tendermint-rs deps to v0.23.1 for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,11 @@ stdtx = { version = "0.5", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = { version = "0.23", features = ["secp256k1"] }
-tendermint-config = "0.23"
-tendermint-rpc = { version = "0.23", optional = true, features = ["http-client"] }
-tendermint-proto = "0.23"
-tendermint-p2p = { version = "0.23 ", features = ["amino"] }
+tendermint = { version = "=0.23.1", features = ["secp256k1"] }
+tendermint-config = "=0.23.1"
+tendermint-rpc = { version = "=0.23.1", optional = true, features = ["http-client"] }
+tendermint-proto = "=0.23.1"
+tendermint-p2p = { version = "=0.23.1 ", features = ["amino"] }
 thiserror = "1"
 wait-timeout = "0.2"
 yubihsm = { version = "=0.40.0-pre", features = ["secp256k1", "setup", "usb"], optional = true }


### PR DESCRIPTION
As per the tendermint-rs versioning (https://github.com/informalsystems/tendermint-rs#versioning), we're now focusing on the v0.24.0 release for compatibility with Tendermint v0.35.x, so any further breaking changes to the v0.23.x series of tendermint-rs need to be released as patch versions.

This pins your tendermint-rs deps to v0.23.1 for now until we can ensure that v0.23.2 (informalsystems/tendermint-rs#1043) does not break anything.