### PR TITLE
Bump tendermint to v0.23.3; k256 to v0.10

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,15 +2,8 @@
 
 [advisories]
 ignore = [
-    "RUSTSEC-2019-0031",
-    "RUSTSEC-2019-0036",
-    "RUSTSEC-2020-0016",
-    "RUSTSEC-2020-0031",
-    "RUSTSEC-2020-0036",
-    "RUSTSEC-2020-0071",
-    "RUSTSEC-2020-0159",
-    "RUSTSEC-2021-0060",
-    "RUSTSEC-2021-0059",
-    "RUSTSEC-2021-0064",
-    "RUSTSEC-2021-0073"
+    "RUSTSEC-2019-0036", # failure: type confusion if __private_get_type_id__ is overridden
+    "RUSTSEC-2020-0036", # failure is officially deprecated/unmaintained
+    "RUSTSEC-2020-0071", # time: potential segfault in `localtime_r` invocations
+    "RUSTSEC-2020-0159", # chrono: potential segfault in `localtime_r` invocations
 ] # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ascii"
@@ -171,15 +171,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "bip32"
-version = "0.2.2"
+name = "base64ct"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d0f0fc59c7ba0333eed9dcc1b6980baa7b7a4dc7c6c5885994d0674f7adf34"
+checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
+
+[[package]]
+name = "bip32"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873faa4363bfc54c36a48321da034c92a0645a363eed34d948683ffc1706e37f"
 dependencies = [
  "bs58",
- "hkd32",
  "hmac 0.11.0",
  "k256",
+ "once_cell",
+ "pbkdf2",
+ "rand_core 0.6.3",
  "ripemd160",
  "sha2",
  "subtle",
@@ -366,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "core-foundation"
@@ -389,8 +397,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 [[package]]
 name = "cosmos-sdk-proto"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb5204c6ddc4352c74297638b5561f2929d6334866c156e5f3c75e1e1a1436a"
+source = "git+https://github.com/cosmos/cosmos-rust.git#92feb24d2c8c3c111c06db2f9e51160e2dc34d86"
 dependencies = [
  "prost",
  "prost-types",
@@ -400,8 +407,7 @@ dependencies = [
 [[package]]
 name = "cosmrs"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31147fe89e547e74e2692e4bec35387e1ea406fe8cfb14c0ea177b58fd2a8a9"
+source = "git+https://github.com/cosmos/cosmos-rust.git#92feb24d2c8c3c111c06db2f9e51160e2dc34d86"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",
@@ -430,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -538,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e98c534e9c8a0483aa01d6f6913bc063de254311bd267c9cf535e9b70e15b2"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
  "const-oid",
 ]
@@ -556,13 +562,13 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
 dependencies = [
  "der",
  "elliptic-curve",
- "hmac 0.11.0",
+ "rfc6979",
  "signature",
 ]
 
@@ -597,16 +603,17 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "decb3a27ea454a5f23f96eb182af0671c12694d64ecc33dada74edd1301f6cfc"
 dependencies = [
  "crypto-bigint",
+ "der",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
  "rand_core 0.6.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -645,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -845,9 +852,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -960,7 +967,6 @@ checksum = "84f2a5541afe0725f0b95619d6af614f48c1b176385b8aa30918cfb8c4bfafc8"
 dependencies = [
  "hmac 0.11.0",
  "once_cell",
- "pbkdf2 0.8.0",
  "rand_core 0.6.3",
  "sha2",
  "zeroize",
@@ -1181,13 +1187,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.6"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
+checksum = "7511aa19fa182a8a4885760c4e5675b17173b02ae86ec5d376d34f5278c874b9"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
  "sha3",
 ]
@@ -1469,23 +1476,25 @@ checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "p256"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
+checksum = "d0e0c5310031b5d4528ac6534bccc1446c289ac45c47b277d5aa91089c5f74fa"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "sec1",
  "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23bc88c404ccc881c8a1ad62ba5cd7d336a64ecbf46de4874f2ad955f67b157"
+checksum = "755d8266e41f57bd8562ed9b6e93cdcf73ead050e1e8c3a27ea3871b6643a20c"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "sec1",
 ]
 
 [[package]]
@@ -1493,15 +1502,6 @@ name = "paste"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
-
-[[package]]
-name = "pbkdf2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
-dependencies = [
- "crypto-mac 0.11.1",
-]
 
 [[package]]
 name = "pbkdf2"
@@ -1579,12 +1579,13 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
  "der",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -1829,6 +1830,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint",
+ "hmac 0.11.0",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353775f96a1f400edcca737f843cb201af3645912e741e64456a257c770173e8"
+checksum = "3c2d4912d369fb95a351c221475657970678d344d70c1a788223f6e74d1e3732"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -1955,6 +1967,19 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2166,21 +2191,23 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
+ "base64ct",
  "der",
 ]
 
 [[package]]
 name = "stdtx"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123383f1c5d90b591e7e273c90fbe1dcaaffc214f5bd2ab31248b9e4b1d40f25"
+checksum = "32ec69ed4fb770585fdd0e8525e4910aaf3801ba5d001c0a927c617c140f8824"
 dependencies = [
  "ecdsa",
  "eyre",
+ "getrandom 0.2.3",
  "k256",
  "prost-amino",
  "prost-amino-derive",
@@ -2253,13 +2280,12 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02880339f0e89dc7de809cb300a7dbe5e066c71937a7a55472438ae02e4a841b"
+checksum = "a9ef686b8ecd36550d0581f0989c9d8607090b23005df479d8e6ba348b5800b9"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
- "chrono",
  "ed25519",
  "ed25519-dalek",
  "flex-error",
@@ -2279,14 +2305,15 @@ dependencies = [
  "subtle",
  "subtle-encoding",
  "tendermint-proto",
+ "time 0.3.5",
  "zeroize",
 ]
 
 [[package]]
 name = "tendermint-config"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff01e0eacdcfb75e8a1bbbc2d71286f7b6db3eda82c52ad7ca4f619ebb90cc"
+checksum = "ecc127f82e7a8c7337c1f293d65a821380d3407c4c44bc979ef4da0ebc3b31ed"
 dependencies = [
  "flex-error",
  "serde",
@@ -2298,9 +2325,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-p2p"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fb1ca942ff50615ea2abe71761bd931161b8d085790be894046a4dea9b4274"
+checksum = "2eb553a4ca289ff5b4e518a7a8205d45bf995436c6f22a0d84928386772b4903"
 dependencies = [
  "aead",
  "chacha20poly1305",
@@ -2325,12 +2352,11 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b8319fcf0860833eabe3278cf2d94ca20ef04bee6a77d892f986026fb1c252"
+checksum = "a9e0a0251fd81bed7420bea0f4d91c2a58f6c9fa34d5b2f70bed0ba8890de5aa"
 dependencies = [
  "bytes 1.1.0",
- "chrono",
  "flex-error",
  "num-derive",
  "num-traits",
@@ -2339,20 +2365,20 @@ dependencies = [
  "serde",
  "serde_bytes",
  "subtle-encoding",
+ "time 0.3.5",
 ]
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c88786eeb1b408530fa7a8151aa9639cc04a6210cd8b5fa27aaafbd1e2a091"
+checksum = "626c493e9ced3a9de37583bbd929f4b6dbd49aa513ab9b4776aa44a9332ce9b5"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
- "chrono",
  "flex-error",
  "futures",
- "getrandom 0.1.16",
+ "getrandom 0.2.3",
  "http",
  "hyper",
  "hyper-proxy",
@@ -2367,6 +2393,7 @@ dependencies = [
  "tendermint-config",
  "tendermint-proto",
  "thiserror",
+ "time 0.3.5",
  "tokio",
  "tracing",
  "url",
@@ -2376,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-std-ext"
-version = "0.23.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad0442d855704801e02536dc6f68b11a01423347a6882c06c49b0dfb6b409ec"
+checksum = "81c6ea80f51944c5c2433cf1921629c7ddd215197092f3d945bdefdd7b5d5e24"
 
 [[package]]
 name = "termcolor"
@@ -2436,7 +2463,14 @@ checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "libc",
  "serde",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tiny_http"
@@ -2910,9 +2944,9 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.40.0-pre"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cb5ac2b1e96c7d71e55ee550309cbb392d83dc5c3156bfcfb3b67e518952e2"
+checksum = "6c7ba281142fd52beba6ed6e67752bdb93242dd7520908a1d93054bfb4dcc02d"
 dependencies = [
  "aes",
  "bitflags",
@@ -2928,7 +2962,7 @@ dependencies = [
  "log",
  "p256",
  "p384",
- "pbkdf2 0.9.0",
+ "pbkdf2",
  "rand_core 0.6.3",
  "rusb",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ hkd32 = { version = "0.6", default-features = false, features = ["mnemonic"] }
 hkdf = "0.11"
 hyper = { version = "0.14", optional = true }
 hyper-rustls = { version = "0.22", optional = true, features = ["webpki-roots"] }
-k256 = { version = "0.9", features = ["ecdsa", "sha256"] }
+k256 = { version = "0.10", features = ["ecdsa", "sha256"] }
 ledger = { version = "0.2", optional = true }
 once_cell = "1.5"
 prost = "0.9"
@@ -42,18 +42,18 @@ serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
 signature = { version = "1.2", features = ["std"] }
-stdtx = { version = "0.5", optional = true }
+stdtx = { version = "0.6", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = { version = "0.23", features = ["secp256k1"] }
-tendermint-config = "0.23"
-tendermint-rpc = { version = "0.23", optional = true, features = ["http-client"] }
-tendermint-proto = "0.23"
-tendermint-p2p = { version = "0.23 ", features = ["amino"] }
+tendermint = { version = "0.23.3", features = ["secp256k1"] }
+tendermint-config = "0.23.3"
+tendermint-rpc = { version = "0.23.3", optional = true, features = ["http-client"] }
+tendermint-proto = "0.23.3"
+tendermint-p2p = { version = "0.23.3", features = ["amino"] }
 thiserror = "1"
 wait-timeout = "0.2"
-yubihsm = { version = "=0.40.0-pre", features = ["secp256k1", "setup", "usb"], optional = true }
+yubihsm = { version = "0.40", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
 
 [dev-dependencies]
@@ -73,3 +73,7 @@ overflow-checks = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+# TODO(tarcieri): release cosmrs v0.4
+[patch.crates-io]
+cosmrs = { git = "https://github.com/cosmos/cosmos-rust.git" }

--- a/src/amino_types/time.rs
+++ b/src/amino_types/time.rs
@@ -21,7 +21,7 @@ pub struct TimeMsg {
 
 impl ParseTimestamp for TimeMsg {
     fn parse_timestamp(&self) -> Result<Time, Error> {
-        Ok(Time::from_unix_timestamp(self.seconds, self.nanos as u32)?)
+        Time::from_unix_timestamp(self.seconds, self.nanos as u32)
     }
 }
 

--- a/src/amino_types/time.rs
+++ b/src/amino_types/time.rs
@@ -1,6 +1,5 @@
 //! Timestamps
 
-use chrono::{TimeZone, Utc};
 use prost_amino_derive::Message;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tendermint::{
@@ -22,7 +21,7 @@ pub struct TimeMsg {
 
 impl ParseTimestamp for TimeMsg {
     fn parse_timestamp(&self) -> Result<Time, Error> {
-        Ok(Utc.timestamp(self.seconds, self.nanos as u32).into())
+        Ok(Time::from_unix_timestamp(self.seconds, self.nanos as u32)?)
     }
 }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -11,22 +11,13 @@ use abscissa_core::{
 pub static APP: AppCell<KmsApplication> = AppCell::new();
 
 /// The `tmkms` application
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct KmsApplication {
     /// Application configuration.
     config: CfgCell<KmsConfig>,
 
     /// Application state.
     state: application::State<Self>,
-}
-
-impl Default for KmsApplication {
-    fn default() -> Self {
-        Self {
-            config: CfgCell::default(),
-            state: application::State::default(),
-        }
-    }
 }
 
 impl Application for KmsApplication {

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -8,7 +8,7 @@ use std::{path::PathBuf, process};
 use crate::{application::APP, config::TxSignerConfig, tx_signer::TxSigner};
 
 /// The `start` command
-#[derive(Command, Debug, Options)]
+#[derive(Command, Debug, Default, Options)]
 pub struct StartCommand {
     /// Path to configuration file
     #[options(short = "c", long = "config", help = "path to tmkms.toml")]
@@ -17,15 +17,6 @@ pub struct StartCommand {
     /// Print debugging information
     #[options(short = "v", long = "verbose", help = "enable verbose debug logging")]
     pub verbose: bool,
-}
-
-impl Default for StartCommand {
-    fn default() -> Self {
-        Self {
-            config: None,
-            verbose: false,
-        }
-    }
 }
 
 impl Runnable for StartCommand {


### PR DESCRIPTION
Also updates:
- `cosmrs` => git (updates not yet released in a crate)
- `stdtx` => v0.6
- `yubihsm` => v0.40