### PR TITLE
Rust 2021 edition upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
-name        = "tmkms"
+name = "tmkms"
 description = """
 Tendermint Key Management System: provides isolated, optionally HSM-backed
 signing key management for Tendermint applications including validators,
 oracles, IBC relayers, and other transaction signing applications
 """
-version     = "0.11.0-pre.3"
-authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
-license     = "Apache-2.0"
-repository  = "https://github.com/iqlusioninc/tmkms/"
-readme      = "README.md"
-categories  = ["cryptography"]
-keywords    = ["cosmos", "ed25519", "kms", "key-management", "yubihsm"]
-edition     = "2018"
+version = "0.11.0-pre.3"
+authors = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
+license = "Apache-2.0"
+repository = "https://github.com/iqlusioninc/tmkms/"
+readme = "README.md"
+categories = ["cryptography::cryptocurrencies"]
+keywords = ["cosmos", "ed25519", "kms", "key-management", "yubihsm"]
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 abscissa_core = "=0.6.0-pre.1"

--- a/src/amino_types/block_id.rs
+++ b/src/amino_types/block_id.rs
@@ -1,7 +1,6 @@
 use super::validate::{self, ConsensusMessage, Error::*};
 use eyre::eyre;
 use prost_amino_derive::Message;
-use std::convert::TryInto;
 use tendermint::{
     block::{self, parts},
     hash::{Hash, SHA256_HASH_SIZE},

--- a/src/amino_types/ed25519.rs
+++ b/src/amino_types/ed25519.rs
@@ -1,7 +1,6 @@
 use super::compute_prefix;
 use once_cell::sync::Lazy;
 use prost_amino_derive::Message;
-use std::convert::TryFrom;
 use tendermint::public_key::{Ed25519, PublicKey};
 
 // Note:On the golang side this is generic in the sense that it could everything that implements
@@ -54,7 +53,6 @@ mod tests {
     use super::*;
     use ed25519_dalek::PUBLIC_KEY_LENGTH;
     use prost_amino::Message;
-    use std::convert::TryInto;
 
     #[test]
     fn test_empty_pubkey_msg() {

--- a/src/amino_types/message.rs
+++ b/src/amino_types/message.rs
@@ -1,5 +1,4 @@
 use prost_amino::encoding::encoded_len_varint;
-use std::convert::TryInto;
 
 /// Extend the original prost_amino::Message trait with a few helper functions in order to
 /// reduce boiler-plate code (and without modifying the prost-amino dependency).

--- a/src/amino_types/proposal.rs
+++ b/src/amino_types/proposal.rs
@@ -15,7 +15,6 @@ use once_cell::sync::Lazy;
 use prost::Message as _;
 use prost_amino::{EncodeError, Message};
 use prost_amino_derive::Message;
-use std::convert::TryFrom;
 use tendermint::{block, chain, consensus, error};
 use tendermint_proto::types as proto_types;
 

--- a/src/amino_types/vote.rs
+++ b/src/amino_types/vote.rs
@@ -15,7 +15,6 @@ use once_cell::sync::Lazy;
 use prost::Message as _;
 use prost_amino::{error::EncodeError, Message};
 use prost_amino_derive::Message;
-use std::convert::TryFrom;
 use tendermint::{block, chain, consensus, error::Error, vote};
 use tendermint_proto::types as proto_types;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,6 @@
 //! KMS integration test
 
 use std::{
-    convert::TryFrom,
     fs,
     io::{self, Cursor, Read, Write},
     net::{TcpListener, TcpStream},


### PR DESCRIPTION
Bumps the `edition` in `Cargo.toml` to `2021`.

Removes `TryFrom`/`TryInto` imports.