### PR TITLE
Bump `abscissa` to v0.6 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "abscissa_core"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8765c2b40fe3eea4e584ce571121109f30e9c04391e5f3d708bfeb2d3338a3"
+checksum = "6750843603bf31a83accd3c8177f9dbf53a7d64275688fc7371e0a4d9f8628b5"
 dependencies = [
  "abscissa_derive",
  "arc-swap",
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "abscissa_derive"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e0c6a03d059557d471bf54b52325d4dc7a877d1b63120c29a2ae1e7b6ea1c6"
+checksum = "1a3473aa652e90865a06b723102aaa4a54a7d9f2092dbf4582497a61d0537d3f"
 dependencies = [
  "ident_case",
  "proc-macro2",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "abscissa_tokio"
-version = "0.6.0-rc.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b03a31335d0878206678cf11cc03471cbaa565c72f55f43f0fad611a5930d8"
+checksum = "32ce48eff491a0ab32c0e1cadd7ba5221a38dc53438992c5e857ab9b8a3f1a3e"
 dependencies = [
  "abscissa_core",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2021"
 rust-version = "1.56"
 
 [dependencies]
-abscissa_core = "=0.6.0-rc.1"
-abscissa_tokio = { version = "=0.6.0-rc.1", optional = true }
+abscissa_core = "0.6"
+abscissa_tokio = { version = "0.6", optional = true }
 bytes_v0_5 = { version = "0.5", package = "bytes" }
 bytes = "1"
 chrono = "0.4"
@@ -58,7 +58,7 @@ yubihsm = { version = "0.40", features = ["secp256k1", "setup", "usb"], optional
 zeroize = "1"
 
 [dev-dependencies]
-abscissa_core = { version = "=0.6.0-rc.1", features = ["testing"] }
+abscissa_core = { version = "0.6", features = ["testing"] }
 byteorder = "1"
 rand = "0.7"
 


### PR DESCRIPTION
Release notes:

https://github.com/iqlusioninc/abscissa/blob/main/CHANGELOG.md#060-2022-02-11