### PR TITLE
Add version command to print the cargo version.

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,6 +6,7 @@ pub mod ledger;
 #[cfg(feature = "softsign")]
 pub mod softsign;
 pub mod start;
+pub mod version;
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;
 
@@ -16,7 +17,7 @@ pub use self::softsign::SoftsignCommand;
 #[cfg(feature = "yubihsm")]
 pub use self::yubihsm::YubihsmCommand;
 
-pub use self::{init::InitCommand, start::StartCommand};
+pub use self::{init::InitCommand, start::StartCommand, version::VersionCommand};
 
 use crate::config::{KmsConfig, CONFIG_ENV_VAR, CONFIG_FILE_NAME};
 use abscissa_core::{Command, Configurable, Runnable};
@@ -41,6 +42,9 @@ pub enum KmsCommand {
 
     /// start the KMS application"
     Start(StartCommand),
+
+    /// display the version
+    Version(VersionCommand),
 
     /// subcommands for YubiHSM2
     #[cfg(feature = "yubihsm")]

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,0 +1,18 @@
+//! Provide the version
+
+use crate::prelude::*;
+use abscissa_core::Command;
+use clap::Parser;
+use std::{option_env, process};
+
+/// The `version` command
+#[derive(Command, Debug, Default, Parser)]
+pub struct VersionCommand {}
+
+impl Runnable for VersionCommand {
+    /// Run the KMS
+    fn run(&self) {
+        println!("{}", option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"));
+        process::exit(0);
+    }
+}

--- a/tests/cli/mod.rs
+++ b/tests/cli/mod.rs
@@ -9,6 +9,7 @@ use std::{
 use super::KMS_EXE_PATH;
 
 mod init;
+mod version;
 
 #[cfg(feature = "yubihsm")]
 mod yubihsm;

--- a/tests/cli/version.rs
+++ b/tests/cli/version.rs
@@ -5,9 +5,7 @@ use std::{ffi::OsStr, str};
 
 #[test]
 fn test_versionx() {
-    let result = cli::run(&[
-        OsStr::new("version"),
-    ]);
+    let result = cli::run(&[OsStr::new("version")]);
 
     assert!(result.status.success());
     let stdout = str::from_utf8(&result.stdout).unwrap().trim().to_owned();

--- a/tests/cli/version.rs
+++ b/tests/cli/version.rs
@@ -4,7 +4,7 @@ use crate::cli;
 use std::{ffi::OsStr, str};
 
 #[test]
-fn test_versionx() {
+fn test_version() {
     let result = cli::run(&[OsStr::new("version")]);
 
     assert!(result.status.success());

--- a/tests/cli/version.rs
+++ b/tests/cli/version.rs
@@ -1,0 +1,15 @@
+//! Integration tests for the `version` subcommand
+
+use crate::cli;
+use std::{ffi::OsStr, str};
+
+#[test]
+fn test_versionx() {
+    let result = cli::run(&[
+        OsStr::new("version"),
+    ]);
+
+    assert!(result.status.success());
+    let stdout = str::from_utf8(&result.stdout).unwrap().trim().to_owned();
+    assert!(stdout.eq(option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")));
+}


### PR DESCRIPTION
This adds a command `tmkms version` which simply prints out the version number as per the cargo information (or "unknown" if that is not available).  It is useful for tools that want to check which version of the code is running.

(The version is available in the logs from startup, but logs rotate so this is often practically unavailable.)