### PR TITLE
Bump `cosmrs` to v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339c77a6fbcca87ffeef15d8eb02a00889fbc63ef4fe708ea9493e94566c27f4"
+checksum = "41b6e0c98cdfac47afcf5d2ec7aa4a8cee7e6c89c6b104c9567866a15454f5da"
 dependencies = [
  "prost",
  "prost-types",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "cosmrs"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2419871dbea05ea018853fb47026446b4babb72c9693d62b9bdae4dea921d770"
+checksum = "8413275b23cb5a0734d9d1e3e33f0b5b94547c1e94776dbc3149dbf46588a533"
 dependencies = [
  "bip32",
  "cosmos-sdk-proto",
@@ -1741,12 +1741,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "a07b0857a71a8cb765763950499cae2413c3f9cede1133478c43600d9e146890"
 dependencies = [
  "bytes 1.1.0",
- "prost-derive",
+ "prost-derive 0.10.1",
 ]
 
 [[package]]
@@ -1787,10 +1787,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.9.0"
+name = "prost-derive"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes 1.1.0",
  "prost",
@@ -2426,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a3d617db287955b07e4bf1523b831bf5055e7d3ceab8504174181df40cb143"
+checksum = "3ca881fa4dedd2b46334f13be7fbc8cc1549ba4be5a833fe4e73d1a1baaf7949"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
@@ -2457,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef5088b4f2df8e4dc221da2c37b1018c4d104a40da3027bda70c9f01099783"
+checksum = "f6c56ee93f4e9b7e7daba86d171f44572e91b741084384d0ae00df7991873dfd"
 dependencies = [
  "flex-error",
  "serde",
@@ -2471,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-p2p"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b815d0d41f8769f1dd47c6296e3c67f81c406ab5fb5284fca8b0d389aacf93"
+checksum = "1bbbba11b8b261ec9aaccd546dd31f0e9433838eeac753846a9f3627c39cc35c"
 dependencies = [
  "aead",
  "chacha20poly1305",
@@ -2484,7 +2497,7 @@ dependencies = [
  "hkdf 0.10.0",
  "merlin",
  "prost",
- "prost-derive",
+ "prost-derive 0.10.1",
  "rand_core 0.5.1",
  "sha2",
  "signature",
@@ -2498,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a65da26cc1f24cd53f40d1267372c22d6ce727d9fd40c6c61b879b26154994"
+checksum = "b71f925d74903f4abbdc4af0110635a307b3cb05b175fdff4a7247c14a4d0874"
 dependencies = [
  "bytes 1.1.0",
  "flex-error",
@@ -2516,9 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.23.6"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d62bc0bb8f4dfb0c9919f70d1aaa2e40750a5a82bf810aaf6590b40af70f27"
+checksum = "a13e63f57ee05a1e927887191c76d1b139de9fa40c180b9f8727ee44377242a6"
 dependencies = [
  "async-trait",
  "bytes 1.1.0",
@@ -2680,7 +2693,7 @@ dependencies = [
  "prost",
  "prost-amino",
  "prost-amino-derive",
- "prost-derive",
+ "prost-derive 0.9.0",
  "rand",
  "rand_core 0.6.3",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytes_v0_5 = { version = "0.5", package = "bytes" }
 bytes = "1"
 chrono = "0.4"
 clap = "3"
-cosmrs = "0.6"
+cosmrs = "0.7"
 ed25519-dalek = "1"
 elliptic-curve = { version = "0.11.12", features = ["pkcs8"], optional = true }
 eyre = "0.6"
@@ -34,13 +34,13 @@ hyper-rustls = { version = "0.23", optional = true, features = ["webpki-roots"] 
 k256 = { version = "0.10", features = ["ecdsa", "sha256"] }
 ledger = { version = "0.2", optional = true }
 once_cell = "1.5"
-prost = "0.9"
+prost = "0.10"
 prost-amino = "0.6"
 prost-amino-derive = "0.6"
 prost-derive = "0.9"
 rand_core = { version = "0.6", features = ["std"] }
 rpassword = { version = "6", optional = true }
-sdkms = { version = "0.4.0", optional = true }
+sdkms = { version = "0.4", optional = true }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.9"
@@ -49,11 +49,11 @@ stdtx = { version = "0.6", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = { version = "0.23.5", features = ["secp256k1"] }
-tendermint-config = "0.23.5"
-tendermint-rpc = { version = "0.23.5", optional = true, features = ["http-client"] }
-tendermint-proto = "0.23.5"
-tendermint-p2p = { version = "0.23.5", features = ["amino"] }
+tendermint = { version = "0.23.7", features = ["secp256k1"] }
+tendermint-config = "0.23.7"
+tendermint-rpc = { version = "0.23.7", optional = true, features = ["http-client"] }
+tendermint-proto = "0.23.7"
+tendermint-p2p = { version = "0.23.7", features = ["amino"] }
 thiserror = "1"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "0.8.2", features = ["serde"], optional = true }


### PR DESCRIPTION
Also bumps the following:

- `prost` => v0.10
- tendermint-rs crates => v0.23.7