### PR TITLE
v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (2022-05-24)
+### Added
+- Fortanix DSM signer ([#469])
+- `version` command ([#487])
+
+### Changed
+- Bump `cosmrs` to v0.7 ([#537])
+- Bump `prost` to v0.10 ([#523], [#537])
+- Bump tendermint-rs crates to v0.23.7 ([#537])
+
+[#469]: https://github.com/iqlusioninc/tmkms/pull/469
+[#487]: https://github.com/iqlusioninc/tmkms/pull/487
+[#523]: https://github.com/iqlusioninc/tmkms/pull/523
+[#537]: https://github.com/iqlusioninc/tmkms/pull/537
+
 ## 0.11.0 (2022-02-11)
 ### Added
 - Sentinel config ([#351])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,7 +2648,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tmkms"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Tendermint Key Management System: provides isolated, optionally HSM-backed
 signing key management for Tendermint applications including validators,
 oracles, IBC relayers, and other transaction signing applications
 """
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms/"


### PR DESCRIPTION
### Added
- Fortanix DSM signer ([#469])
- `version` command ([#487])

### Changed
- Bump `cosmrs` to v0.7 ([#537])
- Bump `prost` to v0.10 ([#523], [#537])
- Bump tendermint-rs crates to v0.23.7 ([#537])

[#469]: https://github.com/iqlusioninc/tmkms/pull/469
[#487]: https://github.com/iqlusioninc/tmkms/pull/487
[#523]: https://github.com/iqlusioninc/tmkms/pull/523
[#537]: https://github.com/iqlusioninc/tmkms/pull/537