### PR TITLE
iana-time-zone vulnerable to use after free in MacOS / iOS implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.44"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf7d67cf4a22adc5be66e75ebdf769b3f2ea032041437a7061f97a63dad4b"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",


### PR DESCRIPTION
## Describe the bugs: 🐛
In iana-time-zone v0.1.43 a use-after-free bug in the MacOS / iOS implementation was introduced. The copied system time zone was released before its name was copied. If the system time zone was changed between the call of `CFRelease` and `str::to_owned()`, random memory would be copied.

GHSA-3fg9-hcq5-vxrc
CWE-416
