### PR TITLE
Prometheus exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ tmkms.toml
 *.swp
 
 \.idea/
+/state
+/secrets
+\.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ca34107f97baef6cfb231b32f36115781856b8f8208e8c580e0bcaea374842"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 
 [[package]]
 name = "ccm"
@@ -358,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "core-foundation"
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6053ff46b5639ceb91756a85a4c8914668393a03170efd79c8884a529d80656"
+checksum = "f8a6eee2d5d0d113f015688310da018bd1d864d86bd567c8fca9c266889e1bfa"
 
 [[package]]
 name = "ecdsa"
@@ -1232,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
 dependencies = [
  "http",
  "hyper",
@@ -1380,9 +1380,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures 0.2.5",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1594,15 +1597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
 name = "overload"
@@ -1720,15 +1714,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1885,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c473049631c233933d6286c88bbb7be30e62ec534cf99a9ae0079211f7fa603"
+checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
 dependencies = [
  "dtoa",
  "itoa",
@@ -2285,10 +2279,10 @@ dependencies = [
  "serde",
  "serde_json",
  "simple-hyper-client",
- "time 0.3.11",
+ "time 0.3.17",
  "tokio-native-tls",
  "url 1.7.2",
- "uuid 1.2.1",
+ "uuid 1.2.2",
 ]
 
 [[package]]
@@ -2654,7 +2648,7 @@ dependencies = [
  "subtle",
  "subtle-encoding",
  "tendermint-proto",
- "time 0.3.11",
+ "time 0.3.17",
  "zeroize",
 ]
 
@@ -2714,7 +2708,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "subtle-encoding",
- "time 0.3.11",
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -2743,7 +2737,7 @@ dependencies = [
  "tendermint-config",
  "tendermint-proto",
  "thiserror",
- "time 0.3.11",
+ "time 0.3.17",
  "tokio",
  "tracing",
  "url 2.3.1",
@@ -2814,22 +2808,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny_http"
@@ -2840,7 +2842,7 @@ dependencies = [
  "ascii",
  "chunked_transfer",
  "log",
- "time 0.3.11",
+ "time 0.3.17",
  "url 2.3.1",
 ]
 
@@ -2878,7 +2880,7 @@ dependencies = [
  "hkd32",
  "hkdf 0.12.3",
  "hyper",
- "hyper-rustls 0.23.0",
+ "hyper-rustls 0.23.1",
  "k256",
  "ledger",
  "once_cell",
@@ -2907,7 +2909,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "url 2.3.1",
- "uuid 1.2.1",
+ "uuid 1.2.2",
  "wait-timeout",
  "yubihsm",
  "zeroize",
@@ -3169,9 +3171,9 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom 0.2.8",
  "serde",
@@ -3522,9 +3524,9 @@ dependencies = [
  "signature",
  "subtle",
  "thiserror",
- "time 0.3.11",
+ "time 0.3.17",
  "tiny_http",
- "uuid 1.2.1",
+ "uuid 1.2.2",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6053ff46b5639ceb91756a85a4c8914668393a03170efd79c8884a529d80656"
+
+[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1625,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1797,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c473049631c233933d6286c88bbb7be30e62ec534cf99a9ae0079211f7fa603"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-text-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-text-encode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2311,6 +2363,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,6 +2791,7 @@ dependencies = [
  "k256",
  "ledger",
  "once_cell",
+ "prometheus-client",
  "prost",
  "prost-amino",
  "prost-amino-derive",
@@ -2752,6 +2814,7 @@ dependencies = [
  "tendermint-proto",
  "tendermint-rpc",
  "thiserror",
+ "tokio",
  "url 2.3.1",
  "uuid 1.1.2",
  "wait-timeout",
@@ -2772,6 +2835,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ eyre = "0.6"
 getrandom = "0.2"
 hkd32 = { version = "0.7", default-features = false, features = ["mnemonic"] }
 hkdf = "0.12"
-hyper = { version = "0.14", optional = true }
+hyper = { version = "0.14", optional = true, features = ["server", "http2", "http1", "tcp"] }
 hyper-rustls = { version = "0.23", optional = true, features = ["webpki-roots"] }
 k256 = { version = "0.11", features = ["ecdsa", "sha256"] }
 ledger = { version = "0.2", optional = true }
@@ -61,6 +61,10 @@ wait-timeout = "0.2"
 yubihsm = { version = "0.41", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
 
+
+prometheus-client = { version = "0.18.0", optional = true }
+tokio = { version = "1", features = ["signal"], optional = true }
+
 [dev-dependencies]
 abscissa_core = { version = "0.6", features = ["testing"] }
 byteorder = "1"
@@ -72,6 +76,7 @@ tx-signer = ["abscissa_tokio", "hyper", "hyper-rustls", "stdtx", "tendermint-rpc
 yubihsm-mock = ["yubihsm/mockhsm"]
 yubihsm-server = ["yubihsm/http-server", "rpassword"]
 fortanixdsm = ["elliptic-curve", "sdkms", "url", "uuid"]
+prometheus = ["prometheus-client", "hyper", "abscissa_tokio", "tokio"]
 
 # Enable integer overflow checks in release builds for security reasons
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ yubihsm-server = ["yubihsm/http-server", "rpassword"]
 fortanixdsm = ["elliptic-curve", "sdkms", "url", "uuid"]
 prometheus = ["prometheus-client", "hyper", "abscissa_tokio", "tokio"]
 
+
 # Enable integer overflow checks in release builds for security reasons
 [profile.release]
 overflow-checks = true

--- a/README.promeheus.md
+++ b/README.promeheus.md
@@ -1,0 +1,82 @@
+# Prometheus exporter 
+
+Prometheus is a free software application used for event monitoring and alerting. It records real-time metrics in a time series database (allowing for high dimensionality) built using a HTTP pull model, with flexible queries and real-time alerting.   
+
+
+## Compiling `tmkms` with Prometheus support
+
+Refer the main README.md for compiling `tmkms`
+from source code. You will need the prerequisities mentioned as indicated above.
+
+There are two ways to install `tmkms` with Prometheus, you need to pass the `--features=prometheus,<signer-feature, i.e. softsign, etc>` parameter to cargo.  
+
+
+### Compiling from source code (via git)
+
+`tmkms` can be compiled directly from the git repository source code using the
+following method.
+
+```
+$ git clone https://github.com/iqlusioninc/tmkms.git && cd tmkms
+[...]
+$ cargo build --release --features=prometheus,softsign
+```
+
+If successful, this will produce a `tmkms` executable located at
+`./target/release/tmkms`
+
+### Installing with the `cargo install` command
+
+With Rust (1.40+) installed, you can install tmkms with the following:
+
+```
+cargo install tmkms --features=prometheus,softsign
+```
+
+Or to install a specific version (recommended):
+
+```
+cargo install tmkms --features=prometheus,softsign --version=0.4.0
+```
+
+This command installs `tmkms` directly from packages hosted on Rust's
+[crates.io] service. Package authenticity is verified via the
+[crates.io index] (itself a git repository) and by SHA-256 digests of
+released artifacts.
+
+### Configuring `tmkms` for initial setup
+
+In order to perform setup, `tmkms` needs a  configuration with desired endpoint url and port.
+
+This configuration should be placed in a file called: `tmkms.toml`.
+You can specifty the path to the config with either `-c /path/to/tmkms.toml` or else tmkms will look in the current working directory for the same file.
+
+example: 
+
+```toml
+
+...
+[prometheus]
+bind_address="127.0.0.1:9100"
+...
+
+
+```
+
+with the above configuration, metrics can be read with 
+
+```
+curl http://localhost:9100
+
+
+# HELP proposal Counts proposals, per chain.
+# TYPE proposal counter
+# HELP pre-vote Counts pre-votes, per chain.
+# TYPE pre-vote counter
+# HELP pre-commit Counts pre-commits, per chain.
+# TYPE pre-commit counter
+# HELP double-sign Counts double-signs, local knowledge, per chain.
+# TYPE double-sign counter
+# EOF
+
+```

--- a/src/application.rs
+++ b/src/application.rs
@@ -49,7 +49,7 @@ impl Application for KmsApplication {
         #[allow(unused_mut)]
         let mut components = self.framework_components(command)?;
 
-        #[cfg(feature = "tx-signer")]
+        #[cfg(any(feature = "tx-signer", feature = "prometheus"))]
         components.push(Box::new(abscissa_tokio::TokioComponent::new()?));
 
         let mut component_registry = self.state.components_mut();

--- a/src/commands/init/config_builder.rs
+++ b/src/commands/init/config_builder.rs
@@ -47,6 +47,9 @@ impl ConfigBuilder {
         #[cfg(feature = "tx-signer")]
         self.add_tx_signer_config();
 
+        #[cfg(feature = "prometheus")]
+        self.add_prometheus_config();
+
         self.contents
     }
 
@@ -177,6 +180,13 @@ impl ConfigBuilder {
     fn add_fortanixdsm_provider_config(&mut self) {
         self.add_str("### Fortanix DSM Signer Configuration\n\n");
         self.add_template_with_chain_id(include_str!("templates/keyring/fortanixdsm.toml"));
+    }
+
+    /// Add `[prometheus]` configuration
+    #[cfg(feature = "prometheus")]
+    fn add_prometheus_config(&mut self) {
+        self.add_str("### Prometheus exporter Configuration\n\n");
+        self.add_str(include_str!("templates/prometheus.toml"));
     }
 
     /// Append a template to the config file, substituting `$KMS_HOME`

--- a/src/commands/init/templates/prometheus.toml
+++ b/src/commands/init/templates/prometheus.toml
@@ -1,0 +1,3 @@
+[prometheus]
+bind_address="127.0.0.1:9100"
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,9 @@ pub mod provider;
 pub mod tx_signer;
 pub mod validator;
 
+#[cfg(feature = "prometheus")]
+pub mod prometheus;
+
 pub use self::validator::*;
 
 #[cfg(feature = "tx-signer")]
@@ -39,4 +42,9 @@ pub struct KmsConfig {
     #[cfg(feature = "tx-signer")]
     #[serde(default)]
     pub tx_signer: Vec<TxSignerConfig>,
+
+    ///Prometheus's configuration
+    #[cfg(feature = "prometheus")]
+    #[serde(default)]
+    pub prometheus: self::prometheus::PrometheusConfig,
 }

--- a/src/config/prometheus.rs
+++ b/src/config/prometheus.rs
@@ -1,0 +1,10 @@
+//! Prometeus's configuration
+
+use serde::Deserialize;
+
+///Prometheus configuration
+#[derive(Clone, Deserialize, Debug, Default)]
+pub struct PrometheusConfig {
+    ///Prometheus metrics export bind address
+    pub bind_address: Option<String>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,9 @@ pub mod tx_signer;
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;
 
+#[cfg(feature = "prometheus")]
+pub mod prometheus;
+
 pub use crate::application::KmsApplication;
 
 // Map type used within this application

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -50,43 +50,55 @@ enum MetricType {
 pub struct Labels {
     method: MetricType,
     chain: String,
+    other: Vec<String>,
 }
 
 impl Labels {
     ///Create pre commit metric's label
-    pub fn sign_pre_commit(chain: &str) -> Self {
-        Labels {
+    pub fn sign_pre_commit(chain: &str){
+        let label_set = Labels {
             method: MetricType::PreCommits,
             chain: chain.to_owned(),
-        }
+            other: vec![],
+        };
+        SIGN_PRE_COMMIT_METRIC.get_or_create(&label_set).inc();
     }
     ///Create pre vote metric's label
-    pub fn sign_pre_vote(chain: &str) -> Self {
-        Labels {
+    pub fn sign_pre_vote(chain: &str){
+        let label_set = Labels {
             method: MetricType::PreVotes,
             chain: chain.to_owned(),
-        }
+            other: vec![],
+        };
+        SIGN_PRE_VOTE_METRIC.get_or_create(&label_set).inc();
     }
     ///Create proposal metric's label
-    pub fn sign_proposal(chain: &str) -> Self {
-        Labels {
+    pub fn sign_proposal(chain: &str){
+        let label_set = Labels {
             method: MetricType::Proposals,
             chain: chain.to_owned(),
-        }
+            other: vec![],
+        };
+        SIGN_PROPOSAL_METRIC.get_or_create(&label_set).inc();
     }
     ///Create double sign metric's label
-    pub fn double_sign(chain: &str) -> Self {
-        Labels {
+    pub fn double_sign(chain: &str, other: String){
+        let label_set = Labels {
             method: MetricType::DoubleSign,
             chain: chain.to_owned(),
-        }
+            other: vec![other],
+        };
+        DOUBLE_SIGN_METRIC.get_or_create(&label_set).inc();
     }
     ///Create double sign metric's label
-    pub fn state_errors(chain: &str) -> Self {
-        Labels {
+    pub fn state_errors(chain: &str, other: String) {
+        let label_set = Labels {
             method: MetricType::StateErrors,
             chain: chain.to_owned(),
-        }
+            other: vec![other],
+        };
+
+        STATE_ERRORS_METRIC.get_or_create(&label_set).inc();
     }
 }
 

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -150,7 +150,7 @@ impl PrometheusComponent {
 
         let registry = PrometheusComponent::setup_registry();
 
-        info!("Starting Prometheus metrics endpoint at http://{addr} ...");
+        info!("Starting Prometheus metrics endpoint at http://{} ...", addr);
         inner_start_metrics_server(addr, registry).await
     }
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -28,11 +28,11 @@ static SIGN_PRE_VOTE_METRIC: Lazy<Family<Labels, Counter>> =
 static SIGN_PRE_COMMIT_METRIC: Lazy<Family<Labels, Counter>> =
     Lazy::new(Family::<Labels, Counter<u64>>::default);
 
-/// Pre Commit metric    
+/// Double Sign error metric    
 static DOUBLE_SIGN_METRIC: Lazy<Family<Labels, Counter>> =
     Lazy::new(Family::<Labels, Counter<u64>>::default);
 
-/// Pre Commit metric    
+/// All inclusive state errors metric    
 static STATE_ERRORS_METRIC: Lazy<Family<Labels, Counter>> =
     Lazy::new(Family::<Labels, Counter<u64>>::default);
 
@@ -81,7 +81,7 @@ impl Labels {
         };
         SIGN_PROPOSAL_METRIC.get_or_create(&label_set).inc();
     }
-    ///Create double sign metric's label
+    ///Create double sign error metric's label
     pub fn double_sign(chain: &str, other: String) {
         let label_set = Labels {
             method: MetricType::DoubleSign,
@@ -90,7 +90,7 @@ impl Labels {
         };
         DOUBLE_SIGN_METRIC.get_or_create(&label_set).inc();
     }
-    ///Create double sign metric's label
+    ///Create all inclusive errors metric's label
     pub fn state_errors(chain: &str, other: String) {
         let label_set = Labels {
             method: MetricType::StateErrors,
@@ -150,7 +150,10 @@ impl PrometheusComponent {
 
         let registry = PrometheusComponent::setup_registry();
 
-        info!("Starting Prometheus metrics endpoint at http://{} ...", addr);
+        info!(
+            "Starting Prometheus metrics endpoint at http://{} ...",
+            addr
+        );
         inner_start_metrics_server(addr, registry).await
     }
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -1,0 +1,174 @@
+//! Prometheus export metrics endpoint and exported statistics
+
+use std::{future::Future, io, net::SocketAddr, pin::Pin, sync::Arc};
+
+use abscissa_core::{tracing::info, Component, FrameworkError, FrameworkErrorKind};
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use once_cell::sync::Lazy;
+use prometheus_client::{
+    encoding::text::encode,
+    metrics::{counter::Counter, family::Family},
+};
+use prometheus_client::{encoding::text::Encode, registry::Registry};
+use std::str::FromStr;
+use tokio::signal::unix::{signal, SignalKind};
+
+///Proposal Metric
+pub static SIGN_PROPOSAL_METRIC: Lazy<Family<Labels, Counter>> =
+    Lazy::new(|| Family::<Labels, Counter<u64>>::default());
+
+/// Pre Vote metric
+pub static SIGN_PRE_VOTE_METRIC: Lazy<Family<Labels, Counter>> =
+    Lazy::new(|| Family::<Labels, Counter<u64>>::default());
+
+/// Pre Commit metric    
+pub static SIGN_PRE_COMMIT_METRIC: Lazy<Family<Labels, Counter>> =
+    Lazy::new(|| Family::<Labels, Counter<u64>>::default());
+
+/// Pre Commit metric    
+pub static DOUBLE_SIGN_METRIC: Lazy<Family<Labels, Counter>> =
+    Lazy::new(|| Family::<Labels, Counter<u64>>::default());
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Encode)]
+enum MetricType {
+    PreCommits,
+    Proposals,
+    PreVotes,
+    DoubleSign,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Encode)]
+///Label definition
+pub struct Labels {
+    method: MetricType,
+    chain: String,
+}
+
+impl Labels {
+    ///Create pre commit metric's label
+    pub fn sign_pre_commit(chain: &str) -> Self {
+        Labels {
+            method: MetricType::PreCommits,
+            chain: chain.to_owned(),
+        }
+    }
+    ///Create pre vote metric's label
+    pub fn sign_pre_vote(chain: &str) -> Self {
+        Labels {
+            method: MetricType::PreVotes,
+            chain: chain.to_owned(),
+        }
+    }
+    ///Create proposal metric's label
+    pub fn sign_proposal(chain: &str) -> Self {
+        Labels {
+            method: MetricType::Proposals,
+            chain: chain.to_owned(),
+        }
+    }
+    ///Create double sign metric's label
+    pub fn double_sign(chain: &str) -> Self {
+        Labels {
+            method: MetricType::DoubleSign,
+            chain: chain.to_owned(),
+        }
+    }
+}
+
+///Prometheus exporter Component, encapsulates functionality
+#[derive(Component, Debug, Default)]
+pub struct PrometheusComponent;
+
+impl PrometheusComponent {
+    /// Run loop for Prometeus export endpoint
+    pub async fn run_and_block(&self, bind_address: &str) -> Result<(), FrameworkError> {
+        let addr = SocketAddr::from_str(bind_address).map_err(|e| {
+            FrameworkErrorKind::ConfigError
+                .context(format!("bind_address[{}] Error:{}", bind_address, e))
+        })?;
+
+        let mut registry = <Registry>::default();
+
+        registry.register(
+            "proposal",
+            "Counts proposals, per chain",
+            Box::new(SIGN_PROPOSAL_METRIC.clone()),
+        );
+
+        registry.register(
+            "pre-vote",
+            "Counts pre-votes, per chain",
+            Box::new(SIGN_PRE_VOTE_METRIC.clone()),
+        );
+        registry.register(
+            "pre-commit",
+            "Counts pre-commits, per chain",
+            Box::new(SIGN_PRE_COMMIT_METRIC.clone()),
+        );
+        registry.register(
+            "double-sign",
+            "Counts double-signs, local knowledge, per chain",
+            Box::new(DOUBLE_SIGN_METRIC.clone()),
+        );
+
+        info!("Starting Prometheus metrics endpoint at http://{addr} ...");
+        inner_start_metrics_server(addr, registry).await
+    }
+}
+
+/// Start a HTTP server to report metrics.
+async fn inner_start_metrics_server(
+    metrics_addr: SocketAddr,
+    registry: Registry,
+) -> Result<(), FrameworkError> {
+    let mut shutdown_stream = signal(SignalKind::terminate())
+        .map_err(|e| FrameworkErrorKind::ConfigError.context(format!("{}", e)))?;
+
+    let registry = Arc::new(registry);
+    Server::bind(&metrics_addr)
+        .serve(make_service_fn(move |_conn| {
+            let registry = registry.clone();
+            async move {
+                let handler = make_handler(registry);
+                Ok::<_, io::Error>(service_fn(handler))
+            }
+        }))
+        .with_graceful_shutdown(async move {
+            shutdown_stream.recv().await;
+        })
+        .await
+        .map_err(|e| {
+            FrameworkErrorKind::ConfigError
+                .context(format!("Prometheus graceful shutdown error:{}", e))
+                .into()
+        })
+}
+
+/// This function returns a HTTP handler
+fn make_handler(
+    registry: Arc<Registry>,
+) -> impl Fn(Request<Body>) -> Pin<Box<dyn Future<Output = std::io::Result<Response<Body>>> + Send>>
+{
+    // This closure accepts a request and responds with the OpenMetrics encoding of our metrics.
+    move |_req: Request<Body>| {
+        let reg = registry.clone();
+        Box::pin(async move {
+            let mut buf = Vec::new();
+
+            encode(&mut buf, &reg.clone()).map(|_| {
+                let body = Body::from(buf);
+
+                Response::builder()
+                    .header(
+                        hyper::header::CONTENT_TYPE,
+                        "application/openmetrics-text; version=1.0.0; charset=utf-8",
+                    )
+                    .body(body)
+                    .unwrap()
+            })
+        })
+    }
+}

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -18,19 +18,23 @@ use tokio::signal::unix::{signal, SignalKind};
 
 ///Proposal Metric
 pub static SIGN_PROPOSAL_METRIC: Lazy<Family<Labels, Counter>> =
-    Lazy::new(|| Family::<Labels, Counter<u64>>::default());
+    Lazy::new(Family::<Labels, Counter<u64>>::default);
 
 /// Pre Vote metric
 pub static SIGN_PRE_VOTE_METRIC: Lazy<Family<Labels, Counter>> =
-    Lazy::new(|| Family::<Labels, Counter<u64>>::default());
+    Lazy::new(Family::<Labels, Counter<u64>>::default);
 
 /// Pre Commit metric    
 pub static SIGN_PRE_COMMIT_METRIC: Lazy<Family<Labels, Counter>> =
-    Lazy::new(|| Family::<Labels, Counter<u64>>::default());
+    Lazy::new(Family::<Labels, Counter<u64>>::default);
 
 /// Pre Commit metric    
 pub static DOUBLE_SIGN_METRIC: Lazy<Family<Labels, Counter>> =
-    Lazy::new(|| Family::<Labels, Counter<u64>>::default());
+    Lazy::new(Family::<Labels, Counter<u64>>::default);
+
+/// Pre Commit metric    
+pub static STATE_ERRORS_METRIC: Lazy<Family<Labels, Counter>> =
+    Lazy::new(Family::<Labels, Counter<u64>>::default);
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Encode)]
 enum MetricType {
@@ -38,6 +42,7 @@ enum MetricType {
     Proposals,
     PreVotes,
     DoubleSign,
+    StateErrors,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Encode)]
@@ -73,6 +78,13 @@ impl Labels {
     pub fn double_sign(chain: &str) -> Self {
         Labels {
             method: MetricType::DoubleSign,
+            chain: chain.to_owned(),
+        }
+    }
+    ///Create double sign metric's label
+    pub fn state_errors(chain: &str) -> Self {
+        Labels {
+            method: MetricType::StateErrors,
             chain: chain.to_owned(),
         }
     }
@@ -112,6 +124,11 @@ impl PrometheusComponent {
             "double-sign",
             "Counts double-signs, local knowledge, per chain",
             Box::new(DOUBLE_SIGN_METRIC.clone()),
+        );
+        registry.register(
+            "state-errors",
+            "Counts state-errors, local knowledge, per chain",
+            Box::new(STATE_ERRORS_METRIC.clone()),
         );
 
         info!("Starting Prometheus metrics endpoint at http://{addr} ...");


### PR DESCRIPTION
## In brief
This change adds Prometheus metrics exports for observability. Expose session stats counters, such as _PreCommits_,_Proposals_, _PreVotes_ in addition to errors _StateErrors_ (all inclusive errors, including DoubleSign ) and _DoubleSign_ (by itself). 

## What's the usecase?
To pause signing in double signing possibility, to avoid slashing