### PR TITLE
Added option to read hashed private key as input in softsign feature

### DIFF
--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -42,7 +42,8 @@ pub fn open_secret_connection(
     socket.set_read_timeout(Some(timeout))?;
     socket.set_write_timeout(Some(timeout))?;
 
-    let connection = match SecretConnection::new(socket, identity_key, protocol_version) {
+    let connection = match SecretConnection::new(socket, identity_key.try_into()?, protocol_version)
+    {
         Ok(conn) => conn,
         Err(error) => match error.detail() {
             TmError::Crypto(_) => fail!(CryptoError, format!("{error}")),

--- a/src/ed25519_keypair.rs
+++ b/src/ed25519_keypair.rs
@@ -1,0 +1,78 @@
+//! Ed25519 KeyPair can be different type based on the private key.
+//! Original form (seed key) or Expanded form (hashed seed key aka expanded secret key).
+
+use crate::error::{Error, ErrorKind::*};
+use abscissa_core::format_err;
+use ed25519::Signature;
+use ed25519_dalek as ed25519;
+
+/// KeyPair defines different representations of an Ed25519 private+public key pair.
+pub enum KeyPair {
+    /// Original defines the classic interpretation of a private key (also known as the seed key)
+    /// and the public key, as defined in the ed25519_dalek library.
+    Original(ed25519::Keypair),
+    /// Expanded defines the expanded secret key plus public key representation of the key pair.
+    Expanded(ExpandedPair),
+}
+
+/// ExpandedPair is an Ed25519 key representation format where the secret key is the hashed
+/// private key also known as the expanded secret key.
+pub struct ExpandedPair {
+    /// secret contains the expanded secret key
+    pub secret: ed25519::ExpandedSecretKey,
+    /// public contains the public key
+    pub public: ed25519::PublicKey,
+}
+
+impl From<&KeyPair> for ed25519::PublicKey {
+    fn from(value: &KeyPair) -> Self {
+        match value {
+            KeyPair::Original(keypair) => keypair.public,
+            KeyPair::Expanded(keypair) => keypair.public,
+        }
+    }
+}
+
+impl From<&KeyPair> for tendermint_p2p::secret_connection::PublicKey {
+    fn from(value: &KeyPair) -> Self {
+        tendermint_p2p::secret_connection::PublicKey::Ed25519(value.into())
+    }
+}
+
+impl TryFrom<KeyPair> for ed25519::Keypair {
+    type Error = Error;
+
+    fn try_from(value: KeyPair) -> Result<Self, Self::Error> {
+        match value {
+            KeyPair::Original(keypair) => Ok(keypair),
+            KeyPair::Expanded(_) => {
+                Err(format_err!(InvalidKey, "key is not an ed25519 seed (private) key").into())
+            }
+        }
+    }
+}
+
+impl From<&KeyPair> for tendermint::PublicKey {
+    fn from(value: &KeyPair) -> Self {
+        match value {
+            KeyPair::Original(keypair) => tendermint::PublicKey::Ed25519(keypair.public),
+            KeyPair::Expanded(keypair) => tendermint::PublicKey::Ed25519(keypair.public),
+        }
+    }
+}
+
+impl signature::Signer<Signature> for KeyPair {
+    fn sign(&self, msg: &[u8]) -> Signature {
+        match self {
+            KeyPair::Original(keypair) => keypair.sign(msg),
+            KeyPair::Expanded(keypair) => keypair.secret.sign(msg, &keypair.public),
+        }
+    }
+
+    fn try_sign(&self, msg: &[u8]) -> Result<Signature, signature::Error> {
+        match self {
+            KeyPair::Original(keypair) => keypair.try_sign(msg),
+            KeyPair::Expanded(keypair) => Ok(keypair.secret.sign(msg, &keypair.public)),
+        }
+    }
+}

--- a/src/key_utils.rs
+++ b/src/key_utils.rs
@@ -8,12 +8,15 @@ use std::{
 };
 
 use ed25519_dalek as ed25519;
-use ed25519_dalek::SECRET_KEY_LENGTH;
+use ed25519_dalek::{
+    EXPANDED_SECRET_KEY_LENGTH, KEYPAIR_LENGTH, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH,
+};
 use k256::ecdsa;
 use rand_core::{OsRng, RngCore};
 use subtle_encoding::base64;
 use zeroize::Zeroizing;
 
+use crate::ed25519_keypair::{ExpandedPair, KeyPair};
 use crate::{
     error::{Error, ErrorKind::*},
     prelude::*,
@@ -48,14 +51,67 @@ pub fn load_base64_secret(path: impl AsRef<Path>) -> Result<Zeroizing<Vec<u8>>, 
 }
 
 /// Load a Base64-encoded Ed25519 secret key
-pub fn load_base64_ed25519_key(path: impl AsRef<Path>) -> Result<ed25519::Keypair, Error> {
-    let key_bytes = load_base64_secret(path)?;
+pub fn load_base64_ed25519_key(path: impl AsRef<Path>) -> Result<KeyPair, Error> {
+    let mut key_bytes = load_base64_secret(path)?;
+    const EXPANDED_KEYPAIR_LENGTH: usize = EXPANDED_SECRET_KEY_LENGTH + PUBLIC_KEY_LENGTH;
 
-    let secret = ed25519::SecretKey::from_bytes(&key_bytes)
-        .map_err(|e| format_err!(InvalidKey, "invalid Ed25519 key: {}", e))?;
+    match key_bytes.len() {
+        // original softsign private key only.
+        SECRET_KEY_LENGTH => {
+            let secret = ed25519::SecretKey::from_bytes(&key_bytes)
+                .map_err(|e| format_err!(InvalidKey, "invalid Ed25519 key: {}", e))?;
 
-    let public = ed25519::PublicKey::from(&secret);
-    Ok(ed25519::Keypair { secret, public })
+            let public = ed25519::PublicKey::from(&secret);
+            Ok(KeyPair::Original(ed25519::Keypair { secret, public }))
+        }
+        // private key and public key, possibly from a priv_validator_key.json's priv_key field.
+        KEYPAIR_LENGTH => {
+            let secret = ed25519::SecretKey::from_bytes(&key_bytes[0..32])
+                .map_err(|e| format_err!(InvalidKey, "invalid Ed25519 key: {}", e))?;
+
+            let public = ed25519::PublicKey::from(&secret);
+            if public.to_bytes() != key_bytes[32..64] {
+                return Err(Error::from(format_err!(
+                    InvalidKey,
+                    "cannot verify public key from seed key"
+                )));
+            } else {
+                info!(
+                    "Verified public key {}",
+                    String::from_utf8(base64::encode(public.to_bytes())).unwrap()
+                );
+            }
+            Ok(KeyPair::Original(ed25519::Keypair { secret, public }))
+        }
+        // expanded secret key and public key from a YubiHSM-exported.
+        EXPANDED_KEYPAIR_LENGTH => {
+            // Reverse lower key order because YubiHSM is little-endian.
+            key_bytes[00..32].reverse();
+
+            let secret = ed25519::ExpandedSecretKey::from_bytes(&key_bytes[00..64])
+                .map_err(|e| format_err!(InvalidKey, "invalid Ed25519 expanded key: {}", e))?;
+
+            let public = ed25519::PublicKey::from(&secret);
+
+            // Validate public key
+            if public.to_bytes() != key_bytes[64..96] {
+                return Err(Error::from(format_err!(
+                    InvalidKey,
+                    "cannot verify public key from expanded secret key"
+                )));
+            } else {
+                info!(
+                    "Verified public key {}",
+                    String::from_utf8(base64::encode(public.to_bytes())).unwrap()
+                );
+            }
+            Ok(KeyPair::Expanded(ExpandedPair { secret, public }))
+        }
+        _ => Err(Error::from(format_err!(
+            InvalidKey,
+            "input key-pair has invalid length"
+        ))),
+    }
 }
 
 /// Load a Base64-encoded Secp256k1 secret key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod client;
 pub mod commands;
 pub mod config;
 pub mod connection;
+pub mod ed25519_keypair;
 pub mod error;
 pub mod key_utils;
 pub mod keyring;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -295,7 +295,7 @@ impl io::Read for ProtocolTester {
 
 /// Get the Ed25519 signing keypair used by the tests
 fn test_ed25519_keypair() -> ed25519::Keypair {
-    tmkms::key_utils::load_base64_ed25519_key(signing_key_path(&KeyType::Consensus)).unwrap()
+    tmkms::key_utils::load_base64_ed25519_key(signing_key_path(&KeyType::Consensus)).unwrap().try_into().unwrap()
 }
 
 /// Get the Secp256k1 signing keypair used by the tests


### PR DESCRIPTION
# Overview
As a temporary solution for networks like Injective that require faster signing turnaround than what the YubiHSM key can provide, the softsign feature was extended with the option to read the "expanded secret key" from the file system instead of the regular seed key (or private key as people call it).

The `yubihsm-unwrap` command's output file can be directly fed into the defined `path` field in the configuration and the key-loading mechanism will automatically see which type of key was presented.

It also verifies the private key for good measure in cases where this is possible and prints an entry into the log for the end-user.

`yubihsm-unwrap` command PR: https://github.com/Yubico/yubihsm-shell/pull/323 .

# How it is done
I've replaced the private key loading mechanism's return type from `ed25519::KeyPair` to a custom-made `KeyPair` that can hold either the regular seed key or the expanded secret key with the corresponding private key. The custom struct has enough conversion traits that throughout the codebase only minimal modifications were needed to integrate it.

### Why not just use the expanded key and completely get rid of the seed key?
This is a valid question since the seed key is not necessary for signing. (RFC8032 defines the first 32 bytes of the hash of the seed key as the private key.)
In the codebase, the Ed25519 seed key loading mechanism is used elsewhere too. For example, while opening the TCP connection, the code uses an Ed25519 seed key as the hub secret connection key. There was no point in upsetting parts of the code that work well and it was easier to implement enough `From` traits to overcome the different use.