### PR TITLE
Rename and refactor `SignableMsg::signable_bytes`

### DIFF
--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -62,9 +62,8 @@ impl Runnable for InitCommand {
         };
         println!("{vote:?}");
         let sign_vote_req = SignableMsg::Vote(vote);
-        let mut to_sign = vec![];
-        sign_vote_req
-            .sign_bytes(config.validator[0].chain_id.clone(), &mut to_sign)
+        let to_sign = sign_vote_req
+            .signable_bytes(config.validator[0].chain_id.clone())
             .unwrap();
 
         let _sig = chain.keyring.sign(None, &to_sign).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -184,6 +184,12 @@ impl From<serde_json::error::Error> for Error {
     }
 }
 
+impl From<signature::Error> for Error {
+    fn from(other: signature::Error) -> Self {
+        ErrorKind::CryptoError.context(other).into()
+    }
+}
+
 impl From<tendermint::Error> for Error {
     fn from(other: tendermint::error::Error) -> Self {
         ErrorKind::TendermintError.context(other).into()

--- a/src/keyring/signature.rs
+++ b/src/keyring/signature.rs
@@ -5,19 +5,31 @@ pub use k256::ecdsa;
 
 /// Cryptographic signature used for block signing
 pub enum Signature {
+    /// ECDSA signature (e.g secp256k1)
+    Ecdsa(ecdsa::Signature),
+
     ///  ED25519 signature
     Ed25519(ed25519::Signature),
-
-    /// ECDSA signagure (e.g secp256k1)
-    Ecdsa(ecdsa::Signature),
 }
 
 impl Signature {
     /// Serialize this signature as a byte vector.
     pub fn to_vec(&self) -> Vec<u8> {
         match self {
-            Self::Ed25519(sig) => sig.to_vec(),
             Self::Ecdsa(sig) => sig.to_vec(),
+            Self::Ed25519(sig) => sig.to_vec(),
         }
+    }
+}
+
+impl From<ecdsa::Signature> for Signature {
+    fn from(sig: ecdsa::Signature) -> Signature {
+        Self::Ecdsa(sig)
+    }
+}
+
+impl From<ed25519::Signature> for Signature {
+    fn from(sig: ed25519::Signature) -> Signature {
+        Self::Ed25519(sig)
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -139,9 +139,7 @@ impl Session {
             return Ok(signable_msg.error(remote_err));
         }
 
-        let mut to_sign = vec![];
-        signable_msg.sign_bytes(self.config.chain_id.clone(), &mut to_sign)?;
-
+        let to_sign = signable_msg.signable_bytes(self.config.chain_id.clone())?;
         let started_at = Instant::now();
 
         // TODO(ismail): figure out which key to use here instead of taking the only key

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -365,28 +365,27 @@ fn handle_and_sign_proposal(key_type: KeyType) {
             other => panic!("unexpected message type in response: {other:?}"),
         };
 
-        let mut sign_bytes: Vec<u8> = vec![];
-        signable_msg
-            .sign_bytes(chain_id.parse().unwrap(), &mut sign_bytes)
+        let signable_bytes = signable_msg
+            .signable_bytes(chain_id.parse().unwrap())
             .unwrap();
 
         let prop = response
             .proposal
             .expect("proposal should be embedded but none was found");
 
-        let msg: &[u8] = sign_bytes.as_slice();
-
         let r = match key_type {
             KeyType::Account => {
                 let signature =
                     k256::ecdsa::Signature::try_from(prop.signature.as_slice()).unwrap();
-                test_secp256k1_keypair().1.verify(msg, &signature)
+                test_secp256k1_keypair()
+                    .1
+                    .verify(&signable_bytes, &signature)
             }
             KeyType::Consensus => {
                 let signature = ed25519::Signature::try_from(prop.signature.as_slice()).unwrap();
                 test_ed25519_keypair()
                     .verifying_key()
-                    .verify(msg, &signature)
+                    .verify(&signable_bytes, &signature)
             }
         };
         assert!(r.is_ok());
@@ -449,9 +448,8 @@ fn handle_and_sign_vote(key_type: KeyType) {
             other => panic!("unexpected message type in response: {other:?}"),
         };
 
-        let mut sign_bytes: Vec<u8> = vec![];
-        signable_msg
-            .sign_bytes(chain_id.parse().unwrap(), &mut sign_bytes)
+        let signable_bytes = signable_msg
+            .signable_bytes(chain_id.parse().unwrap())
             .unwrap();
 
         let vote_msg: proto::types::Vote = request
@@ -461,18 +459,18 @@ fn handle_and_sign_vote(key_type: KeyType) {
         let sig: Vec<u8> = vote_msg.signature;
         assert_ne!(sig.len(), 0);
 
-        let msg: &[u8] = sign_bytes.as_slice();
-
         let r = match key_type {
             KeyType::Account => {
                 let signature = k256::ecdsa::Signature::try_from(sig.as_slice()).unwrap();
-                test_secp256k1_keypair().1.verify(msg, &signature)
+                test_secp256k1_keypair()
+                    .1
+                    .verify(&signable_bytes, &signature)
             }
             KeyType::Consensus => {
                 let signature = ed25519::Signature::try_from(sig.as_slice()).unwrap();
                 test_ed25519_keypair()
                     .verifying_key()
-                    .verify(msg, &signature)
+                    .verify(&signable_bytes, &signature)
             }
         };
         assert!(r.is_ok());
@@ -537,9 +535,8 @@ fn exceed_max_height(key_type: KeyType) {
             other => panic!("unexpected message type in response: {other:?}"),
         };
 
-        let mut sign_bytes: Vec<u8> = vec![];
-        signable_msg
-            .sign_bytes(chain_id.parse().unwrap(), &mut sign_bytes)
+        let signable_bytes = signable_msg
+            .signable_bytes(chain_id.parse().unwrap())
             .unwrap();
 
         let vote_msg = response
@@ -549,18 +546,18 @@ fn exceed_max_height(key_type: KeyType) {
         let sig: Vec<u8> = vote_msg.signature;
         assert_ne!(sig.len(), 0);
 
-        let msg: &[u8] = sign_bytes.as_slice();
-
         let r = match key_type {
             KeyType::Account => {
                 let signature = k256::ecdsa::Signature::try_from(sig.as_slice()).unwrap();
-                test_secp256k1_keypair().1.verify(msg, &signature)
+                test_secp256k1_keypair()
+                    .1
+                    .verify(&signable_bytes, &signature)
             }
             KeyType::Consensus => {
                 let signature = ed25519::Signature::try_from(sig.as_slice()).unwrap();
                 test_ed25519_keypair()
                     .verifying_key()
-                    .verify(msg, &signature)
+                    .verify(&signable_bytes, &signature)
             }
         };
         assert!(r.is_ok());


### PR DESCRIPTION
The previous method name was `sign_bytes`, which as was noted in #273 is unclear to whether the resulting bytes have an appended signature.

The new name indicates that the message can be signed, but has not yet been signed.

Additionally, this commit does a bit of refactoring to eliminate some duplicated code within the method.

Closes #273