### PR TITLE
Use `tendermint::{Vote, Proposal}` for `SignMsg`

### DIFF
--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -61,7 +61,7 @@ impl Runnable for InitCommand {
             ..Default::default()
         };
         println!("{vote:?}");
-        let sign_vote_req = SignableMsg::Vote(vote);
+        let sign_vote_req = SignableMsg::try_from(vote).unwrap();
         let to_sign = sign_vote_req
             .signable_bytes(config.validator[0].chain_id.clone())
             .unwrap();

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -60,11 +60,11 @@ impl Request {
             Self::SignProposal(proto::privval::SignProposalRequest {
                 proposal: Some(proposal),
                 chain_id,
-            }) => (SignableMsg::Proposal(proposal), chain_id),
+            }) => (SignableMsg::try_from(proposal)?, chain_id),
             Self::SignVote(proto::privval::SignVoteRequest {
                 vote: Some(vote),
                 chain_id,
-            }) => (SignableMsg::Vote(vote), chain_id),
+            }) => (SignableMsg::try_from(vote)?, chain_id),
             _ => fail!(
                 ErrorKind::InvalidMessageError,
                 "expected a signable message type: {:?}",
@@ -82,7 +82,6 @@ impl Request {
             expected_chain_id
         );
 
-        signable_msg.validate()?;
         Ok(signable_msg)
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -153,7 +153,7 @@ impl Session {
     /// doesn't exceed it
     fn check_max_height(&mut self, signable_msg: &SignableMsg) -> Result<(), Error> {
         if let Some(max_height) = self.config.max_height {
-            let height = signable_msg.height()?;
+            let height = signable_msg.height();
 
             if height > max_height {
                 fail!(
@@ -175,8 +175,8 @@ impl Session {
         chain: &Chain,
         signable_msg: &SignableMsg,
     ) -> Result<Option<proto::privval::RemoteSignerError>, Error> {
-        let msg_type = signable_msg.msg_type()?;
-        let request_state = signable_msg.consensus_state()?;
+        let msg_type = signable_msg.msg_type();
+        let request_state = signable_msg.consensus_state();
         let mut chain_state = chain.state.lock().unwrap();
 
         match chain_state.update_consensus_state(request_state.clone()) {
@@ -232,8 +232,8 @@ impl Session {
         signable_msg: &SignableMsg,
         started_at: Instant,
     ) -> Result<(), Error> {
-        let msg_type = signable_msg.msg_type()?;
-        let request_state = signable_msg.consensus_state()?;
+        let msg_type = signable_msg.msg_type();
+        let request_state = signable_msg.consensus_state();
 
         info!(
             "[{}@{}] signed {:?}:{} at h/r/s {} ({} ms)",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -348,7 +348,7 @@ fn handle_and_sign_proposal(key_type: KeyType) {
             signature: vec![],
         };
 
-        let signable_msg = SignableMsg::Proposal(proposal.clone());
+        let signable_msg = SignableMsg::try_from(proposal.clone()).unwrap();
 
         let request = proto::privval::SignProposalRequest {
             proposal: Some(proposal),
@@ -434,7 +434,7 @@ fn handle_and_sign_vote(key_type: KeyType) {
             extension_signature: vec![],
         };
 
-        let signable_msg = SignableMsg::Vote(vote_msg.clone());
+        let signable_msg = SignableMsg::try_from(vote_msg.clone()).unwrap();
 
         let vote = proto::privval::SignVoteRequest {
             vote: Some(vote_msg),
@@ -521,7 +521,7 @@ fn exceed_max_height(key_type: KeyType) {
             extension_signature: vec![],
         };
 
-        let signable_msg = SignableMsg::Vote(vote_msg.clone());
+        let signable_msg = SignableMsg::try_from(vote_msg.clone()).unwrap();
 
         let vote = proto::privval::SignVoteRequest {
             vote: Some(vote_msg),


### PR DESCRIPTION
Uses `tendermint-rs` domain types to assist in parsing and validating that signable message types are well-formed.

This avoids duplicating validation logic within TMKMS.