### PR TITLE
Refactor `signing` module into `privval`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
 tendermint = { version = "0.34", features = ["secp256k1"] }
 tendermint-config = "0.34"
-tendermint-proto = "0.34"
 tendermint-p2p = "0.34"
+tendermint-proto = "0.34"
 thiserror = "1"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }

--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -3,7 +3,7 @@
 use crate::{
     chain,
     prelude::*,
-    signing::{SignableMsg, SignedMsgType},
+    privval::{SignableMsg, SignedMsgType},
 };
 use abscissa_core::{Command, Runnable};
 use clap::{Parser, Subcommand};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,9 @@ pub mod error;
 pub mod key_utils;
 pub mod keyring;
 pub mod prelude;
+pub mod privval;
 pub mod rpc;
 pub mod session;
-pub mod signing;
 
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19,7 +19,7 @@ use tmkms::{
     config::provider::KeyType,
     connection::unix::UnixConnection,
     keyring::ed25519,
-    signing::{SignableMsg, SignedMsgType},
+    privval::{SignableMsg, SignedMsgType},
 };
 
 /// Integration tests for the KMS command-line interface


### PR DESCRIPTION
Factors response-handling operations from `SignedMsg` into the `Response` type and removes the (unused) sign method.

This decouples `privval` from response handling and reduces its responsibilities to canonical message serialization and consensus state extraction, making it easier to potentially extract into a separate crate in the future.