### PR TITLE
Fix `tmkms ledger init` by using `-H` for height

### DIFF
--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -33,7 +33,7 @@ pub struct InitCommand {
     pub config: Option<PathBuf>,
 
     /// block height
-    #[clap(short = 'h', long = "height")]
+    #[clap(short = 'H', long = "height")]
     pub height: Option<i64>,
 
     /// block round


### PR DESCRIPTION
Previously it panicked because `-h` conflicted with help

Closes #579