### PR TITLE
Refactor RPC `Request` type

### DIFF
--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -8,6 +8,7 @@ use crate::{
 use abscissa_core::{Command, Runnable};
 use clap::{Parser, Subcommand};
 use std::{path::PathBuf, process};
+use tendermint::Vote;
 use tendermint_proto as proto;
 
 /// `ledger` subcommand
@@ -61,7 +62,7 @@ impl Runnable for InitCommand {
             ..Default::default()
         };
         println!("{vote:?}");
-        let sign_vote_req = SignableMsg::try_from(vote).unwrap();
+        let sign_vote_req = SignableMsg::from(Vote::try_from(vote).unwrap());
         let to_sign = sign_vote_req
             .signable_bytes(config.validator[0].chain_id.clone())
             .unwrap();

--- a/src/privval.rs
+++ b/src/privval.rs
@@ -107,6 +107,18 @@ impl SignableMsg {
     }
 }
 
+impl From<Proposal> for SignableMsg {
+    fn from(proposal: Proposal) -> Self {
+        Self::Proposal(proposal)
+    }
+}
+
+impl From<Vote> for SignableMsg {
+    fn from(vote: Vote) -> Self {
+        Self::Vote(vote)
+    }
+}
+
 impl TryFrom<proto::types::Proposal> for SignableMsg {
     type Error = Error;
 
@@ -205,7 +217,7 @@ impl TryFrom<SignedMsgCode> for SignedMsgType {
 #[cfg(test)]
 mod tests {
     use super::{chain, proto, SignableMsg, SignedMsgType};
-    use tendermint::Time;
+    use tendermint::{Proposal, Time, Vote};
 
     fn example_chain_id() -> chain::Id {
         chain::Id::try_from("test_chain_id").unwrap()
@@ -220,7 +232,7 @@ mod tests {
         }
     }
 
-    fn example_proposal() -> proto::types::Proposal {
+    fn example_proposal() -> Proposal {
         proto::types::Proposal {
             r#type: SignedMsgType::Proposal.into(),
             height: 12345,
@@ -230,9 +242,11 @@ mod tests {
             block_id: None,
             signature: vec![],
         }
+        .try_into()
+        .unwrap()
     }
 
-    fn example_vote() -> proto::types::Vote {
+    fn example_vote() -> Vote {
         proto::types::Vote {
             r#type: 0x01,
             height: 500001,
@@ -254,6 +268,8 @@ mod tests {
             extension: vec![],
             extension_signature: vec![],
         }
+        .try_into()
+        .unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Makes the inner types the `tendermint` domain types, rather than the Protobuf types.

This should make it easier to support multiple Protobuf versions.