### PR TITLE
`CanonicalVoteExtension` signature support

### DIFF
--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -64,7 +64,7 @@ impl Runnable for InitCommand {
         println!("{vote:?}");
         let sign_vote_req = SignableMsg::from(Vote::try_from(vote).unwrap());
         let to_sign = sign_vote_req
-            .signable_bytes(config.validator[0].chain_id.clone())
+            .canonical_bytes(config.validator[0].chain_id.clone())
             .unwrap();
 
         let _sig = chain.keyring.sign(None, &to_sign).unwrap();

--- a/src/keyring/signature.rs
+++ b/src/keyring/signature.rs
@@ -33,3 +33,9 @@ impl From<ed25519::Signature> for Signature {
         Self::Ed25519(sig)
     }
 }
+
+impl From<Signature> for tendermint::Signature {
+    fn from(sig: Signature) -> tendermint::Signature {
+        sig.to_vec().try_into().expect("signature should be valid")
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -366,7 +366,7 @@ fn handle_and_sign_proposal(key_type: KeyType) {
         };
 
         let signable_bytes = signable_msg
-            .signable_bytes(chain_id.parse().unwrap())
+            .canonical_bytes(chain_id.parse().unwrap())
             .unwrap();
 
         let prop = response
@@ -449,7 +449,7 @@ fn handle_and_sign_vote(key_type: KeyType) {
         };
 
         let signable_bytes = signable_msg
-            .signable_bytes(chain_id.parse().unwrap())
+            .canonical_bytes(chain_id.parse().unwrap())
             .unwrap();
 
         let vote_msg: proto::types::Vote = request
@@ -536,7 +536,7 @@ fn exceed_max_height(key_type: KeyType) {
         };
 
         let signable_bytes = signable_msg
-            .signable_bytes(chain_id.parse().unwrap())
+            .canonical_bytes(chain_id.parse().unwrap())
             .unwrap();
 
         let vote_msg = response


### PR DESCRIPTION
When present, computes a secondary signature over `Vote::extension`.

Closes #831 #835