### PR TITLE
Add `SignableMsg::add_*_signature`; log extension sigs

### DIFF
--- a/src/privval.rs
+++ b/src/privval.rs
@@ -129,6 +129,38 @@ impl SignableMsg {
             },
         }
     }
+
+    /// Add a consensus signature to this message.
+    pub fn add_consensus_signature(&mut self, signature: impl Into<tendermint::Signature>) {
+        match self {
+            SignableMsg::Proposal(proposal) => {
+                proposal.signature = Some(signature.into());
+            }
+            SignableMsg::Vote(vote) => {
+                vote.signature = Some(signature.into());
+            }
+        }
+    }
+
+    /// Add an extension signature to this message.
+    pub fn add_extension_signature(
+        &mut self,
+        signature: impl Into<tendermint::Signature>,
+    ) -> Result<(), Error> {
+        match self {
+            SignableMsg::Vote(vote) => {
+                if vote.extension.is_empty() {
+                    return Err(Error::protocol(
+                        "can't add signature to empty extension".into(),
+                    ));
+                }
+
+                vote.extension_signature = Some(signature.into());
+                Ok(())
+            }
+            _ => Err(Error::invalid_message_type()),
+        }
+    }
 }
 
 impl From<Proposal> for SignableMsg {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -3,7 +3,7 @@
 // TODO: docs for everything
 #![allow(missing_docs)]
 
-use crate::{keyring::Signature, privval::SignableMsg};
+use crate::privval::SignableMsg;
 use prost::Message as _;
 use std::io::Read;
 use tendermint::{chain, Proposal, Vote};
@@ -128,28 +128,21 @@ impl Response {
             }),
         }
     }
+}
 
-    /// Construct a signed response from a [`SignableMsg`] and a [`Signature`].
-    pub fn sign(msg: SignableMsg, sig: Signature) -> Result<Response, Error> {
+impl From<SignableMsg> for Response {
+    fn from(msg: SignableMsg) -> Response {
         match msg {
             SignableMsg::Proposal(proposal) => {
-                let mut proposal = proto::types::Proposal::from(proposal);
-                proposal.signature = sig.to_vec();
-                Ok(Response::SignedProposal(
-                    proto::privval::SignedProposalResponse {
-                        proposal: Some(proposal),
-                        error: None,
-                    },
-                ))
-            }
-            SignableMsg::Vote(vote) => {
-                let mut vote = proto::types::Vote::from(vote);
-                vote.signature = sig.to_vec();
-                Ok(Response::SignedVote(proto::privval::SignedVoteResponse {
-                    vote: Some(vote),
+                Response::SignedProposal(proto::privval::SignedProposalResponse {
+                    proposal: Some(proposal.into()),
                     error: None,
-                }))
+                })
             }
+            SignableMsg::Vote(vote) => Response::SignedVote(proto::privval::SignedVoteResponse {
+                vote: Some(vote.into()),
+                error: None,
+            }),
         }
     }
 }


### PR DESCRIPTION
Moves the methods for adding signatures to a `SignableMsg` onto the type itself:

- `SignableMsg::add_consensus_signature`
- `SignableMsg::add_extension_signature`

This helps keep as much of the signature-related logic on the `SignableMsg` type itself, rather than spread out elsewhere.

Also, adds logging every time an extension signature is computed, so we can confirm it isn't being computed for chains which aren't using it.