### PR TITLE
fix(privval): always sign extension

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -149,7 +149,7 @@ impl Session {
         signable_msg.add_consensus_signature(consensus_sig);
         self.log_signing_request(&signable_msg, started_at).unwrap();
 
-        // Add extension signature if there are any extensions defined
+        // Add extension signature if the message is a precommit for a non-empty block ID.
         if let Some(extension_msg) = signable_msg.extension_bytes(chain_id)? {
             let started_at = Instant::now();
             let extension_sig = chain.keyring.sign(public_key, &extension_msg)?;


### PR DESCRIPTION
IFF a vote is a precommit for a non-nil block.

Refs https://github.com/iqlusioninc/tmkms/pull/837, https://github.com/cometbft/cometbft/issues/2357
Fixes https://github.com/iqlusioninc/tmkms/issues/831#issuecomment-1948384671