### PR TITLE
Fix unused imports and future clippy warnings

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -5,7 +5,7 @@ pub mod networks;
 
 use self::{config_builder::ConfigBuilder, networks::Network};
 use crate::{config::CONFIG_FILE_NAME, key_utils, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use clap::Parser;
 use std::{
     fs,

--- a/src/commands/softsign/import.rs
+++ b/src/commands/softsign/import.rs
@@ -1,7 +1,7 @@
 //! `tmkms softsign import` command
 
 use crate::{config::provider::softsign::KeyFormat, key_utils, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use clap::Parser;
 use std::{path::PathBuf, process};
 use tendermint::PrivateKey;

--- a/src/commands/softsign/keygen.rs
+++ b/src/commands/softsign/keygen.rs
@@ -1,7 +1,7 @@
 //! `tmkms softsign keygen` subcommand
 
 use crate::{key_utils, keyring::ed25519, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use clap::Parser;
 use k256::ecdsa;
 use rand_core::{OsRng, RngCore};

--- a/src/commands/yubihsm/detect.rs
+++ b/src/commands/yubihsm/detect.rs
@@ -1,7 +1,7 @@
 //! Detect YubiHSM2s connected via USB
 
 use crate::prelude::*;
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use clap::Parser;
 use std::process;
 use yubihsm::connector::usb::Devices;

--- a/src/commands/yubihsm/keys/export.rs
+++ b/src/commands/yubihsm/keys/export.rs
@@ -1,8 +1,8 @@
 //! Create encrypted backups of YubiHSM2 keys
 
-use super::*;
+use super::DEFAULT_WRAP_KEY;
 use crate::{key_utils, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use clap::Parser;
 use std::{path::PathBuf, process};
 

--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -1,8 +1,8 @@
 //! Generate a new key within the YubiHSM2
 
-use super::*;
+use super::{DEFAULT_DOMAINS, DEFAULT_WRAP_KEY};
 use crate::{config::provider::KeyType, key_utils, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use chrono::{SecondsFormat, Utc};
 use clap::Parser;
 use std::{

--- a/src/commands/yubihsm/keys/import.rs
+++ b/src/commands/yubihsm/keys/import.rs
@@ -1,8 +1,8 @@
 //! Import keys either from encrypted backups or existing plaintext keys
 
-use super::*;
+use super::{DEFAULT_DOMAINS, DEFAULT_WRAP_KEY};
 use crate::{keyring::ed25519, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use clap::Parser;
 use std::{fs, path::PathBuf, process};
 use subtle_encoding::base64;

--- a/src/commands/yubihsm/keys/list.rs
+++ b/src/commands/yubihsm/keys/list.rs
@@ -1,7 +1,7 @@
 //! List keys inside the YubiHSM2
 
 use crate::{chain, keyring, prelude::*, Map};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use clap::Parser;
 use k256::elliptic_curve::generic_array::GenericArray;
 use std::{path::PathBuf, process};

--- a/src/commands/yubihsm/setup.rs
+++ b/src/commands/yubihsm/setup.rs
@@ -1,7 +1,7 @@
 //! Set up a new YubiHSM2 or restore from backup
 
 use crate::prelude::*;
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use chrono::{SecondsFormat, Utc};
 use clap::Parser;
 use getrandom::getrandom;

--- a/src/commands/yubihsm/test.rs
+++ b/src/commands/yubihsm/test.rs
@@ -1,7 +1,7 @@
 //! Test the YubiHSM2 is working by performing signatures successively
 
 use crate::prelude::*;
-use abscissa_core::{Command, Runnable};
+use abscissa_core::Command;
 use clap::Parser;
 use std::{
     path::PathBuf,

--- a/src/connection/unix.rs
+++ b/src/connection/unix.rs
@@ -1,7 +1,6 @@
 //! Unix domain socket connection to a validator
 
 use std::io;
-use std::marker::{Send, Sync};
 
 /// Protocol implementation of the UNIX socket domain connection
 pub struct UnixConnection<IoHandler> {

--- a/tests/cli/yubihsm/keys/generate.rs
+++ b/tests/cli/yubihsm/keys/generate.rs
@@ -12,8 +12,8 @@ fn keys_generate_command_test() {
     args.extend_from_slice(&["-c", super::KMS_CONFIG_PATH]);
 
     let cmd_out = cli::run_successfully(args.as_slice());
-    assert_eq!(true, cmd_out.status.success());
-    assert_eq!(true, cmd_out.stderr.is_empty());
+    assert!(cmd_out.status.success());
+    assert!(cmd_out.stderr.is_empty());
 
     let stdout = str::from_utf8(&cmd_out.stdout).unwrap().trim().to_owned();
     assert!(stdout.contains("Generated"));

--- a/tests/cli/yubihsm/keys/import.rs
+++ b/tests/cli/yubihsm/keys/import.rs
@@ -16,9 +16,9 @@ fn keys_import_priv_validator_test() {
 
     let out = cli::run_successfully(args.as_slice());
 
-    assert_eq!(true, out.status.success());
-    assert_eq!(true, out.stderr.is_empty());
+    assert!(out.status.success());
+    assert!(out.stderr.is_empty());
 
     let message = str::from_utf8(&out.stdout).unwrap().trim().to_owned();
-    assert_eq!(true, message.contains("key 0x0001"));
+    assert!(message.contains("key 0x0001"));
 }

--- a/tests/cli/yubihsm/keys/list.rs
+++ b/tests/cli/yubihsm/keys/list.rs
@@ -13,8 +13,8 @@ fn keys_command_test() {
 
     let out = cli::run_successfully(args.as_slice());
 
-    assert_eq!(true, out.status.success());
-    assert_eq!(true, out.stdout.is_empty());
+    assert!(out.status.success());
+    assert!(out.stdout.is_empty());
 
     let stderr = str::from_utf8(&out.stderr).unwrap().trim().to_owned();
     assert!(stderr.contains("no keys in this YubiHSM"));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -152,7 +152,7 @@ impl KmsProcess {
             path = "{}"
             key_type = "{}"
         "#,
-            &peer_id.to_string(), port, signing_key_path(&key_type), key_type
+            &peer_id.to_string(), port, signing_key_path(key_type), key_type
         )
         .unwrap();
 
@@ -162,7 +162,7 @@ impl KmsProcess {
     /// Create a config file for a UNIX KMS and return its path
     fn create_unix_config(socket_path: &str, key_type: &KeyType) -> NamedTempFile {
         let mut config_file = NamedTempFile::new().unwrap();
-        let key_path = signing_key_path(&key_type);
+        let key_path = signing_key_path(key_type);
         writeln!(
             config_file,
             r#"
@@ -230,9 +230,9 @@ impl ProtocolTester {
     where
         F: FnOnce(ProtocolTester),
     {
-        let tcp_device = KmsProcess::create_tcp(&key_type);
+        let tcp_device = KmsProcess::create_tcp(key_type);
         let tcp_connection = tcp_device.create_connection();
-        let unix_device = KmsProcess::create_unix(&key_type);
+        let unix_device = KmsProcess::create_unix(key_type);
         let unix_connection = unix_device.create_connection();
 
         functor(Self {


### PR DESCRIPTION
Recent nightlies have better diagnostics around unused imports. This fixes all of the current redundant imports.

Additionally it uses `clippy --fix` on nightly to fix some upcoming clippy warnings.