### PR TITLE
v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.14.0 (2024-03-28)
+
+NOTE: this release adds a new `sign_extensions` configuration option in
+`tmkms.toml` which needs to be configured for any `[[chain]]` which uses
+extension signing. For an example of how to configure it,
+[see `tmkms.toml.example`](https://github.com/iqlusioninc/tmkms/blob/621bd41/tmkms.toml.example#L19).
+
+### Added
+- Optional `sign_extensions` field to `[[chain]]` config ([#882])
+
+### Changed
+- Always sign extension even when it's empty ([#857], [#867])
+- Bump tendermint-rs dependencies to v0.35; cosmrs v0.16 ([#881])
+
+### Fixed
+- Unused imports and future clippy warnings ([#883])
+
+[#857]: https://github.com/iqlusioninc/tmkms/pull/857
+[#867]: https://github.com/iqlusioninc/tmkms/pull/867
+[#881]: https://github.com/iqlusioninc/tmkms/pull/881
+[#882]: https://github.com/iqlusioninc/tmkms/pull/882
+[#883]: https://github.com/iqlusioninc/tmkms/pull/883
+
 ## 0.13.1 (2024-01-18)
 ### Added
 - `CanonicalVoteExtension` signature support ([#837])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,7 +2401,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tmkms"
-version = "0.14.0-pre.2"
+version = "0.14.0"
 dependencies = [
  "abscissa_core",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Tendermint Key Management System: provides isolated, optionally HSM-backed
 signing key management for Tendermint applications including validators,
 oracles, IBC relayers, and other transaction signing applications
 """
-version = "0.14.0-pre.2"
+version = "0.14.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms/"


### PR DESCRIPTION
NOTE: this release adds a new `sign_extensions` configuration option in `tmkms.toml` which needs to be configured for any `[[chain]]` which uses extension signing. For an example of how to configure it, [see `tmkms.toml.example`](https://github.com/iqlusioninc/tmkms/blob/621bd41/tmkms.toml.example#L19).

### Added
- Optional `sign_extensions` field to `[[chain]]` config ([#882])

### Changed
- Always sign extension even when it's empty ([#857], [#867])
- Bump tendermint-rs dependencies to v0.35; cosmrs v0.16 ([#881])

### Fixed
- Unused imports and future clippy warnings ([#883])

[#857]: https://github.com/iqlusioninc/tmkms/pull/857
[#867]: https://github.com/iqlusioninc/tmkms/pull/867
[#881]: https://github.com/iqlusioninc/tmkms/pull/881
[#882]: https://github.com/iqlusioninc/tmkms/pull/882
[#883]: https://github.com/iqlusioninc/tmkms/pull/883