### PR TITLE
feat(softsign): expanded secret key can be used for signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,6 +2411,7 @@ dependencies = [
  "cosmrs",
  "ed25519",
  "ed25519-consensus",
+ "ed25519-dalek",
  "elliptic-curve",
  "eyre",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"
 yubihsm = { version = "0.42", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
+ed25519-dalek = { version = "2.1.1", features = ["hazmat"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.7", features = ["testing"] }

--- a/src/keyring/ed25519/signing_key.rs
+++ b/src/keyring/ed25519/signing_key.rs
@@ -1,3 +1,4 @@
+use ed25519_dalek::hazmat::{ExpandedSecretKey, raw_sign};
 use super::{Signature, VerifyingKey};
 use crate::error::{Error, ErrorKind};
 use signature::Signer;
@@ -6,60 +7,89 @@ use signature::Signer;
 type SigningKeyBytes = [u8; SigningKey::BYTE_SIZE];
 
 /// Ed25519 signing key.
-#[derive(Clone, Debug)]
-pub struct SigningKey(ed25519_consensus::SigningKey);
+pub enum SigningKey {
+    /// Ed25519 signing key.
+    Ed25519(ed25519_consensus::SigningKey),
+    /// Ed25519 expanded signing key.
+    Ed25519Expanded(ExpandedSecretKey),
+}
 
 impl SigningKey {
     /// Size of an encoded Ed25519 signing key in bytes.
     pub const BYTE_SIZE: usize = 32;
 
+    /// Size of an Ed25519 expanded signing key in bytes.
+    pub const EXPANDED_BYTE_SIZE: usize = 64;
+
+    /// Size of an Ed25519 public key in bytes.
+    pub const PUBLIC_KEY_BYTE_SIZE: usize = 32;
+
     /// Borrow the serialized signing key as bytes.
     pub fn as_bytes(&self) -> &SigningKeyBytes {
-        self.0.as_bytes()
+        match &self {
+            SigningKey::Ed25519(signing_key) => signing_key.as_bytes(),
+            SigningKey::Ed25519Expanded(_) => panic!("unexpected expanded signing key"),
+        }
     }
 
     /// Get the verifying key for this signing key.
     pub fn verifying_key(&self) -> VerifyingKey {
-        VerifyingKey(self.0.verification_key())
+        match &self {
+            SigningKey::Ed25519(signing_key) => VerifyingKey(signing_key.verification_key()),
+            SigningKey::Ed25519Expanded(signing_key) => Into::<ed25519_dalek::VerifyingKey>::into(signing_key).as_bytes().as_slice().try_into().unwrap(),
+        }
     }
 }
 
 impl From<SigningKeyBytes> for SigningKey {
     fn from(bytes: SigningKeyBytes) -> Self {
-        Self(bytes.into())
+        SigningKey::Ed25519(bytes.into())
     }
 }
 
 impl From<SigningKey> for ed25519_consensus::SigningKey {
     fn from(signing_key: SigningKey) -> ed25519_consensus::SigningKey {
-        signing_key.0
+        match signing_key {
+            SigningKey::Ed25519(signing_key) => signing_key,
+            SigningKey::Ed25519Expanded(_) => panic!("unexpected expanded signing key"),
+        }
     }
 }
 
 impl From<&SigningKey> for tendermint_p2p::secret_connection::PublicKey {
     fn from(signing_key: &SigningKey) -> tendermint_p2p::secret_connection::PublicKey {
-        Self::from(&signing_key.0)
+        match signing_key {
+            SigningKey::Ed25519(signing_key) => Self::from(signing_key),
+            SigningKey::Ed25519Expanded(signing_key) => {
+                let dalek_verifying_key: ed25519_dalek::VerifyingKey = signing_key.into();
+                let ed25519_consenus_verification_key: ed25519_consensus::VerificationKey = dalek_verifying_key.as_bytes().as_slice().try_into().unwrap();
+                ed25519_consenus_verification_key.into()
+            },
+        }
     }
 }
 
 impl From<ed25519_consensus::SigningKey> for SigningKey {
     fn from(signing_key: ed25519_consensus::SigningKey) -> SigningKey {
-        SigningKey(signing_key)
+        SigningKey::Ed25519(signing_key)
     }
 }
 
 impl From<tendermint::private_key::Ed25519> for SigningKey {
     fn from(signing_key: tendermint::private_key::Ed25519) -> SigningKey {
-        signing_key
+        SigningKey::Ed25519(signing_key
             .as_bytes()
             .try_into()
-            .expect("invalid Ed25519 signing key")
+            .expect("invalid Ed25519 signing key"))
     }
 }
 
 impl Signer<Signature> for SigningKey {
     fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
-        Ok(self.0.sign(msg).to_bytes().into())
+        match self {
+            SigningKey::Ed25519(signing_key) => Ok(signing_key.sign(msg).to_bytes().into()),
+            SigningKey::Ed25519Expanded(signing_key) => Ok(raw_sign::<sha2::Sha512>(signing_key, msg, &signing_key.into())),
+        }
     }
 }
 
@@ -67,9 +97,20 @@ impl TryFrom<&[u8]> for SigningKey {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        slice
-            .try_into()
-            .map(Self)
-            .map_err(|_| ErrorKind::InvalidKey.into())
+        if slice.len() == SigningKey::BYTE_SIZE {
+            slice
+                .try_into()
+                .map(|e| SigningKey::Ed25519(e))
+                .map_err(|_| ErrorKind::InvalidKey.into()
+            )
+        } else if slice.len() == SigningKey::EXPANDED_BYTE_SIZE || slice.len() == (SigningKey::EXPANDED_BYTE_SIZE + SigningKey::PUBLIC_KEY_BYTE_SIZE) {
+            slice[0..SigningKey::EXPANDED_BYTE_SIZE]
+                .try_into()
+                .map(|e| SigningKey::Ed25519Expanded(e))
+                .map_err(|_| ErrorKind::InvalidKey.into()
+                )
+        } else {
+            Err(ErrorKind::InvalidKey.context(format!("invalid Ed25519 key size {}", slice.len())).into())
+        }
     }
 }


### PR DESCRIPTION
This is a reimplementation of #742.

Unfortunately, ed25519_consensus doesn't support signing with the expanded secret key, so I had to rely on ed25519-dalek. The new version of that crate hid the ExpandedSecretKey struct behind the hazmat feature, and other crates seem not to support signing with the expanded secret key. (Everyone's hashing internally.)

It is unfortunate that, in some cases, the YubiHSM latency is prohibitively high. This is still the least painful way of using secrets exported from YubiHSMs.
