### PR TITLE
fix broken Cosmos Validators FAQ link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ limitations under the License.
 [//]: # (general links)
 
 [Tendermint]: https://tendermint.com/
-[Cosmos Validators]: https://cosmos.network/docs/gaia/validators/validator-faq.html
+[Cosmos Validators]: https://hub.cosmos.network/main/validators/validator-faq
 [YubiHSM2]: https://github.com/iqlusioninc/tmkms/blob/main/README.yubihsm.md
 [Ledger]: https://www.ledger.com/
 [ed25519-dalek]: https://github.com/dalek-cryptography/ed25519-dalek


### PR DESCRIPTION
Replaced the outdated and broken link to the Cosmos Validators FAQ in the README with the updated URL: https://hub.cosmos.network/main/validators/validator-faq, ensuring users have access to the correct validator documentation.