### PR TITLE
docs: fix 404 status URL

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,4 @@
-# https://github.com/RustSec/cargo-audit/blob/master/audit.toml.example
+# https://github.com/rustsec/rustsec/blob/main/cargo-audit/audit.toml.example
 
 [advisories]
 ignore = [


### PR DESCRIPTION
Replaced the outdated and broken link 