### PR TITLE
[WIP] Support for signing raw bytes with consensus keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,8 +2472,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.40.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c40e13d39ca19082d8a7ed22de7595979350319833698f8b1080f29620a094"
+source = "git+https://github.com/rach-id/tendermint-rs.git?branch=rachid/generate-latest-v38-protos#d7ce755d56826e8c5fbe1d059fb5ab1e2cab7c5b"
 dependencies = [
  "bytes",
  "flex-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ overflow-checks = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[patch.crates-io.tendermint-proto]
+git = "https://github.com/rach-id/tendermint-rs.git"
+branch = "rachid/generate-latest-v38-protos"

--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -3,7 +3,7 @@
 use crate::{
     chain,
     prelude::*,
-    privval::{SignableMsg, SignedMsgType},
+    privval::{ConsensusMsg, ConsensusMsgType},
 };
 use abscissa_core::{Command, Runnable};
 use clap::{Parser, Subcommand};
@@ -58,11 +58,11 @@ impl Runnable for InitCommand {
         let vote = proto::types::Vote {
             height: self.height.unwrap(),
             round: self.round.unwrap() as i32,
-            r#type: SignedMsgType::Proposal.into(),
+            r#type: ConsensusMsgType::Proposal.into(),
             ..Default::default()
         };
         println!("{vote:?}");
-        let sign_vote_req = SignableMsg::from(Vote::try_from(vote).unwrap());
+        let sign_vote_req = ConsensusMsg::from(Vote::try_from(vote).unwrap());
         let to_sign = sign_vote_req
             .canonical_bytes(config.validator[0].chain_id.clone())
             .unwrap();

--- a/src/keyring/signature.rs
+++ b/src/keyring/signature.rs
@@ -2,6 +2,7 @@
 
 pub use super::ed25519;
 pub use k256::ecdsa;
+use tendermint_proto as proto;
 
 /// Cryptographic signature used for block signing
 pub enum Signature {
@@ -37,5 +38,14 @@ impl From<ed25519::Signature> for Signature {
 impl From<Signature> for tendermint::Signature {
     fn from(sig: Signature) -> tendermint::Signature {
         sig.to_vec().try_into().expect("signature should be valid")
+    }
+}
+
+impl From<Signature> for proto::privval::SignedRawBytesResponse {
+    fn from(sig: Signature) -> Self {
+        proto::privval::SignedRawBytesResponse {
+            signature: sig.to_vec(),
+            error: None,
+        }
     }
 }

--- a/src/privval.rs
+++ b/src/privval.rs
@@ -20,9 +20,9 @@ const PRECOMMIT_CODE: SignedMsgCode = 0x02;
 /// Code for precommits.
 const PROPOSAL_CODE: SignedMsgCode = 0x20;
 
-/// Trait for signed messages.
+/// Signable Tendermint/CometBFT consensus messages.
 #[derive(Debug)]
-pub enum SignableMsg {
+pub enum ConsensusMsg {
     /// Proposals
     Proposal(Proposal),
 
@@ -30,11 +30,11 @@ pub enum SignableMsg {
     Vote(Vote),
 }
 
-impl SignableMsg {
+impl ConsensusMsg {
     /// Get the signed message type.
-    pub fn msg_type(&self) -> SignedMsgType {
+    pub fn msg_type(&self) -> ConsensusMsgType {
         match self {
-            Self::Proposal(_) => SignedMsgType::Proposal,
+            Self::Proposal(_) => ConsensusMsgType::Proposal,
             Self::Vote(vote) => vote.vote_type.into(),
         }
     }
@@ -56,7 +56,7 @@ impl SignableMsg {
             Self::Proposal(proposal) => {
                 let canonical = proto::types::CanonicalProposal {
                     chain_id: chain_id.to_string(),
-                    r#type: SignedMsgType::Proposal.into(),
+                    r#type: ConsensusMsgType::Proposal.into(),
                     height: proposal.height.into(),
                     block_id: proposal.block_id.map(Into::into),
                     pol_round: proposal
@@ -135,10 +135,10 @@ impl SignableMsg {
     /// Add a consensus signature to this message.
     pub fn add_consensus_signature(&mut self, signature: impl Into<tendermint::Signature>) {
         match self {
-            SignableMsg::Proposal(proposal) => {
+            ConsensusMsg::Proposal(proposal) => {
                 proposal.signature = Some(signature.into());
             }
-            SignableMsg::Vote(vote) => {
+            ConsensusMsg::Vote(vote) => {
                 vote.signature = Some(signature.into());
             }
         }
@@ -150,7 +150,7 @@ impl SignableMsg {
         signature: impl Into<tendermint::Signature>,
     ) -> Result<(), Error> {
         match self {
-            SignableMsg::Vote(vote) => {
+            ConsensusMsg::Vote(vote) => {
                 vote.extension_signature = Some(signature.into());
                 Ok(())
             }
@@ -159,19 +159,19 @@ impl SignableMsg {
     }
 }
 
-impl From<Proposal> for SignableMsg {
+impl From<Proposal> for ConsensusMsg {
     fn from(proposal: Proposal) -> Self {
         Self::Proposal(proposal)
     }
 }
 
-impl From<Vote> for SignableMsg {
+impl From<Vote> for ConsensusMsg {
     fn from(vote: Vote) -> Self {
         Self::Vote(vote)
     }
 }
 
-impl TryFrom<proto::types::Proposal> for SignableMsg {
+impl TryFrom<proto::types::Proposal> for ConsensusMsg {
     type Error = Error;
 
     fn try_from(proposal: proto::types::Proposal) -> Result<Self, Self::Error> {
@@ -179,7 +179,7 @@ impl TryFrom<proto::types::Proposal> for SignableMsg {
     }
 }
 
-impl TryFrom<proto::types::Vote> for SignableMsg {
+impl TryFrom<proto::types::Vote> for ConsensusMsg {
     type Error = Error;
 
     fn try_from(vote: proto::types::Vote) -> Result<Self, Self::Error> {
@@ -187,13 +187,13 @@ impl TryFrom<proto::types::Vote> for SignableMsg {
     }
 }
 
-/// [`SignedMsgType`] is a type of signed message in the consensus.
+/// [`ConsensusMsgType`] is a type of signed message in the consensus.
 ///
 /// Adapted from:
 /// <https://github.com/cometbft/cometbft/blob/27d2a18/proto/tendermint/types/types.proto#L13>
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(i32)]
-pub enum SignedMsgType {
+pub enum ConsensusMsgType {
     /// Unknown message types.
     Unknown = UNKNOWN_CODE,
 
@@ -207,7 +207,7 @@ pub enum SignedMsgType {
     Proposal = PROPOSAL_CODE,
 }
 
-impl SignedMsgType {
+impl ConsensusMsgType {
     /// Is the message type unknown?
     pub fn is_unknown(self) -> bool {
         self == Self::Unknown
@@ -219,25 +219,25 @@ impl SignedMsgType {
     }
 }
 
-impl From<SignedMsgType> for SignedMsgCode {
-    fn from(msg_type: SignedMsgType) -> SignedMsgCode {
+impl From<ConsensusMsgType> for SignedMsgCode {
+    fn from(msg_type: ConsensusMsgType) -> SignedMsgCode {
         msg_type.code()
     }
 }
 
-impl From<SignedMsgType> for proto::types::SignedMsgType {
-    fn from(msg_type: SignedMsgType) -> proto::types::SignedMsgType {
+impl From<ConsensusMsgType> for proto::types::SignedMsgType {
+    fn from(msg_type: ConsensusMsgType) -> proto::types::SignedMsgType {
         match msg_type {
-            SignedMsgType::Unknown => proto::types::SignedMsgType::Unknown,
-            SignedMsgType::Prevote => proto::types::SignedMsgType::Prevote,
-            SignedMsgType::Precommit => proto::types::SignedMsgType::Precommit,
-            SignedMsgType::Proposal => proto::types::SignedMsgType::Proposal,
+            ConsensusMsgType::Unknown => proto::types::SignedMsgType::Unknown,
+            ConsensusMsgType::Prevote => proto::types::SignedMsgType::Prevote,
+            ConsensusMsgType::Precommit => proto::types::SignedMsgType::Precommit,
+            ConsensusMsgType::Proposal => proto::types::SignedMsgType::Proposal,
         }
     }
 }
 
-impl From<proto::types::SignedMsgType> for SignedMsgType {
-    fn from(proto: proto::types::SignedMsgType) -> SignedMsgType {
+impl From<proto::types::SignedMsgType> for ConsensusMsgType {
+    fn from(proto: proto::types::SignedMsgType) -> ConsensusMsgType {
         match proto {
             proto::types::SignedMsgType::Unknown => Self::Unknown,
             proto::types::SignedMsgType::Prevote => Self::Prevote,
@@ -247,16 +247,16 @@ impl From<proto::types::SignedMsgType> for SignedMsgType {
     }
 }
 
-impl From<vote::Type> for SignedMsgType {
-    fn from(vote_type: vote::Type) -> SignedMsgType {
+impl From<vote::Type> for ConsensusMsgType {
+    fn from(vote_type: vote::Type) -> ConsensusMsgType {
         match vote_type {
-            vote::Type::Prevote => SignedMsgType::Prevote,
-            vote::Type::Precommit => SignedMsgType::Precommit,
+            vote::Type::Prevote => ConsensusMsgType::Prevote,
+            vote::Type::Precommit => ConsensusMsgType::Precommit,
         }
     }
 }
 
-impl TryFrom<SignedMsgCode> for SignedMsgType {
+impl TryFrom<SignedMsgCode> for ConsensusMsgType {
     type Error = Error;
 
     fn try_from(code: SignedMsgCode) -> Result<Self, Self::Error> {
@@ -268,7 +268,7 @@ impl TryFrom<SignedMsgCode> for SignedMsgType {
 
 #[cfg(test)]
 mod tests {
-    use super::{chain, proto, SignableMsg, SignedMsgType};
+    use super::{chain, proto, ConsensusMsg, ConsensusMsgType};
     use tendermint::{Proposal, Time, Vote};
 
     fn example_chain_id() -> chain::Id {
@@ -286,7 +286,7 @@ mod tests {
 
     fn example_proposal() -> Proposal {
         proto::types::Proposal {
-            r#type: SignedMsgType::Proposal.into(),
+            r#type: ConsensusMsgType::Proposal.into(),
             height: 12345,
             round: 1,
             timestamp: Some(example_timestamp()),
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn serialize_canonical_proposal() {
-        let signable_msg = SignableMsg::from(example_proposal());
+        let signable_msg = ConsensusMsg::from(example_proposal());
         let signable_bytes = signable_msg.canonical_bytes(example_chain_id()).unwrap();
         assert_eq!(
             signable_bytes.as_ref(),
@@ -341,7 +341,7 @@ mod tests {
 
     #[test]
     fn serialize_canonical_vote() {
-        let signable_msg = SignableMsg::from(example_vote());
+        let signable_msg = ConsensusMsg::from(example_vote());
         let signable_bytes = signable_msg.canonical_bytes(example_chain_id()).unwrap();
         assert_eq!(
             signable_bytes.as_ref(),

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -3,7 +3,7 @@
 // TODO: docs for everything
 #![allow(missing_docs)]
 
-use crate::privval::SignableMsg;
+use crate::privval::ConsensusMsg;
 use prost::Message as _;
 use std::io::Read;
 use tendermint::{chain, Proposal, Vote};
@@ -21,6 +21,7 @@ pub enum Request {
     /// Sign the given message
     SignProposal(Proposal),
     SignVote(Vote),
+    SignRawBytes(proto::privval::SignRawBytesRequest),
     ShowPublicKey,
     PingRequest,
 }
@@ -72,6 +73,10 @@ impl Request {
                     chain_id,
                 },
             )) => (Request::SignProposal(proposal.try_into()?), chain_id),
+            Some(proto::privval::message::Sum::SignRawBytesRequest(req)) => {
+                let chain_id = req.chain_id.clone();
+                (Request::SignRawBytes(req), chain_id)
+            }
             Some(proto::privval::message::Sum::PubKeyRequest(req)) => {
                 (Request::ShowPublicKey, req.chain_id)
             }
@@ -92,16 +97,16 @@ impl Request {
         Ok(req)
     }
 
-    /// Convert this request into a [`SignableMsg`].
+    /// Convert this request into a [`ConsensusMsg`].
     ///
     /// The expected `chain::Id` is used to validate the request.
-    pub fn into_signable_msg(self) -> Result<SignableMsg, Error> {
+    pub fn into_consensus_msg(self) -> Result<ConsensusMsg, Error> {
         match self {
             Self::SignProposal(proposal) => Ok(proposal.into()),
             Self::SignVote(vote) => Ok(vote.into()),
             _ => fail!(
                 ErrorKind::InvalidMessageError,
-                "expected a signable message type: {:?}",
+                "expected a consensus message type: {:?}",
                 self
             ),
         }
@@ -114,6 +119,7 @@ pub enum Response {
     /// Signature response
     SignedVote(proto::privval::SignedVoteResponse),
     SignedProposal(proto::privval::SignedProposalResponse),
+    SignedRawBytes(proto::privval::SignedRawBytesResponse),
     Ping(proto::privval::PingResponse),
     PublicKey(proto::privval::PubKeyResponse),
 }
@@ -127,6 +133,9 @@ impl Response {
             Response::SignedProposal(resp) => {
                 proto::privval::message::Sum::SignedProposalResponse(resp)
             }
+            Response::SignedRawBytes(resp) => {
+                proto::privval::message::Sum::SignedRawBytesResponse(resp)
+            }
             Response::Ping(resp) => proto::privval::message::Sum::PingResponse(resp),
             Response::PublicKey(resp) => proto::privval::message::Sum::PubKeyResponse(resp),
         };
@@ -134,16 +143,16 @@ impl Response {
         Ok(buf)
     }
 
-    /// Construct an error response for a given [`SignableMsg`].
-    pub fn error(msg: SignableMsg, error: proto::privval::RemoteSignerError) -> Response {
+    /// Construct an error response for a given [`ConsensusMsg`].
+    pub fn error(msg: ConsensusMsg, error: proto::privval::RemoteSignerError) -> Response {
         match msg {
-            SignableMsg::Proposal(_) => {
+            ConsensusMsg::Proposal(_) => {
                 Response::SignedProposal(proto::privval::SignedProposalResponse {
                     proposal: None,
                     error: Some(error),
                 })
             }
-            SignableMsg::Vote(_) => Response::SignedVote(proto::privval::SignedVoteResponse {
+            ConsensusMsg::Vote(_) => Response::SignedVote(proto::privval::SignedVoteResponse {
                 vote: None,
                 error: Some(error),
             }),
@@ -151,16 +160,16 @@ impl Response {
     }
 }
 
-impl From<SignableMsg> for Response {
-    fn from(msg: SignableMsg) -> Response {
+impl From<ConsensusMsg> for Response {
+    fn from(msg: ConsensusMsg) -> Response {
         match msg {
-            SignableMsg::Proposal(proposal) => {
+            ConsensusMsg::Proposal(proposal) => {
                 Response::SignedProposal(proto::privval::SignedProposalResponse {
                     proposal: Some(proposal.into()),
                     error: None,
                 })
             }
-            SignableMsg::Vote(vote) => Response::SignedVote(proto::privval::SignedVoteResponse {
+            ConsensusMsg::Vote(vote) => Response::SignedVote(proto::privval::SignedVoteResponse {
                 vote: Some(vote.into()),
                 error: None,
             }),

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,9 +6,10 @@ use crate::{
     connection::{tcp, unix::UnixConnection, Connection},
     error::{Error, ErrorKind::*},
     prelude::*,
-    privval::SignableMsg,
+    privval::ConsensusMsg,
     rpc::{Request, Response},
 };
+use prost::Message;
 use std::{os::unix::net::UnixStream, time::Instant};
 use tendermint::{consensus, TendermintKey};
 use tendermint_config::net;
@@ -104,8 +105,10 @@ impl Session {
 
         let response = match request {
             Request::SignProposal(_) | Request::SignVote(_) => {
-                self.sign(request.into_signable_msg()?)?
+                self.sign_consensus_msg(request.into_consensus_msg()?)?
             }
+            Request::SignRawBytes(req) => self.sign_raw(req)?,
+
             // non-signable requests:
             Request::PingRequest => Response::Ping(proto::privval::PingResponse {}),
             Request::ShowPublicKey => self.get_public_key()?,
@@ -122,9 +125,10 @@ impl Session {
         Ok(true)
     }
 
-    /// Perform a digital signature operation
-    fn sign(&mut self, mut signable_msg: SignableMsg) -> Result<Response, Error> {
-        self.check_max_height(&signable_msg)?;
+    /// Sign a Tendermint/CometBFT consensus message, checking the height against the last signed
+    /// height to avoid double signing.
+    fn sign_consensus_msg(&mut self, mut msg: ConsensusMsg) -> Result<Response, Error> {
+        self.check_max_height(&msg)?;
 
         let registry = chain::REGISTRY.get();
 
@@ -134,27 +138,27 @@ impl Session {
                 panic!("chain '{}' missing from registry!", &self.config.chain_id);
             });
 
-        if let Some(remote_err) = self.update_consensus_state(chain, &signable_msg)? {
+        if let Some(remote_err) = self.update_consensus_state(chain, &msg)? {
             // In the event of double signing we send a response to notify the validator
-            return Ok(Response::error(signable_msg, remote_err));
+            return Ok(Response::error(msg, remote_err));
         }
 
         // TODO(tarcieri): support for non-default public keys
         let public_key = None;
         let chain_id = self.config.chain_id.clone();
-        let canonical_msg = signable_msg.canonical_bytes(chain_id.clone())?;
+        let canonical_msg = msg.canonical_bytes(chain_id.clone())?;
 
         let started_at = Instant::now();
         let consensus_sig = chain.keyring.sign(public_key, &canonical_msg)?;
-        signable_msg.add_consensus_signature(consensus_sig);
-        self.log_signing_request(&signable_msg, started_at).unwrap();
+        msg.add_consensus_signature(consensus_sig);
+        self.log_signing_request(&msg, started_at).unwrap();
 
         // Add extension signature if the message is a precommit for a non-empty block ID.
         if chain.sign_extensions {
-            if let Some(extension_msg) = signable_msg.extension_bytes(chain_id)? {
+            if let Some(extension_msg) = msg.extension_bytes(chain_id)? {
                 let started_at = Instant::now();
                 let extension_sig = chain.keyring.sign(public_key, &extension_msg)?;
-                signable_msg.add_extension_signature(extension_sig)?;
+                msg.add_extension_signature(extension_sig)?;
 
                 info!(
                     "[{}@{}] signed vote extension ({} ms)",
@@ -165,12 +169,54 @@ impl Session {
             }
         }
 
-        Ok(signable_msg.into())
+        Ok(msg.into())
+    }
+
+    /// Sign a raw (non-consensus) message.
+    fn sign_raw(&mut self, req: proto::privval::SignRawBytesRequest) -> Result<Response, Error> {
+        /// Domain separation prefix to prevent confusion with consensus message signatures.
+        const PREFIX: &[u8] = b"COMET::RAW_BYTES::SIGN";
+
+        ensure!(
+            req.chain_id == self.config.chain_id.as_str(),
+            ChainIdError,
+            "got unexpected chain ID: {} (expecting: {})",
+            &req.chain_id,
+            &self.config.chain_id,
+        );
+
+        assert_eq!(self.config.chain_id.as_str(), &req.chain_id);
+
+        let registry = chain::REGISTRY.get();
+
+        let chain = registry
+            .get_chain(&self.config.chain_id)
+            .unwrap_or_else(|| {
+                panic!("chain '{}' missing from registry!", &self.config.chain_id);
+            });
+
+        let mut signable_bytes = Vec::from(PREFIX);
+        req.encode_length_delimited(&mut signable_bytes)?;
+
+        // TODO(tarcieri): support for non-default public keys
+        let public_key = None;
+        let started_at = Instant::now();
+        let sig = chain.keyring.sign(public_key, &signable_bytes)?;
+
+        info!(
+            "[{}@{}] signed raw bytes: {} ({} ms)",
+            &self.config.chain_id,
+            &self.config.addr,
+            &req.unique_id,
+            started_at.elapsed().as_millis(),
+        );
+
+        Ok(Response::SignedRawBytes(sig.into()))
     }
 
     /// If a max block height is configured, ensure the block we're signing
     /// doesn't exceed it
-    fn check_max_height(&mut self, signable_msg: &SignableMsg) -> Result<(), Error> {
+    fn check_max_height(&mut self, signable_msg: &ConsensusMsg) -> Result<(), Error> {
         if let Some(max_height) = self.config.max_height {
             let height = signable_msg.height();
 
@@ -192,7 +238,7 @@ impl Session {
     fn update_consensus_state(
         &mut self,
         chain: &Chain,
-        signable_msg: &SignableMsg,
+        signable_msg: &ConsensusMsg,
     ) -> Result<Option<proto::privval::RemoteSignerError>, Error> {
         let msg_type = signable_msg.msg_type();
         let request_state = signable_msg.consensus_state();
@@ -245,7 +291,7 @@ impl Session {
     /// Write an INFO logline about a signing request
     fn log_signing_request(
         &self,
-        signable_msg: &SignableMsg,
+        signable_msg: &ConsensusMsg,
         started_at: Instant,
     ) -> Result<(), Error> {
         let msg_type = signable_msg.msg_type();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -20,7 +20,7 @@ use tmkms::{
     config::provider::KeyType,
     connection::unix::UnixConnection,
     keyring::ed25519,
-    privval::{SignableMsg, SignedMsgType},
+    privval::{ConsensusMsg, ConsensusMsgType},
 };
 
 /// Integration tests for the KMS command-line interface
@@ -155,7 +155,7 @@ impl KmsProcess {
         "#,
             &peer_id.to_string(), port, signing_key_path(key_type), key_type
         )
-        .unwrap();
+            .unwrap();
 
         config_file
     }
@@ -184,7 +184,7 @@ impl KmsProcess {
             key_type = "{key_type}"
         "#
         )
-        .unwrap();
+            .unwrap();
 
         config_file
     }
@@ -340,7 +340,7 @@ fn handle_and_sign_proposal(key_type: KeyType) {
 
     ProtocolTester::apply(&key_type, |mut pt| {
         let proposal = proto::types::Proposal {
-            r#type: SignedMsgType::Proposal.into(),
+            r#type: ConsensusMsgType::Proposal.into(),
             height: 12345,
             round: 1,
             timestamp: Some(t),
@@ -349,7 +349,7 @@ fn handle_and_sign_proposal(key_type: KeyType) {
             signature: vec![],
         };
 
-        let signable_msg = SignableMsg::try_from(proposal.clone()).unwrap();
+        let signable_msg = ConsensusMsg::try_from(proposal.clone()).unwrap();
 
         let request = proto::privval::SignProposalRequest {
             proposal: Some(proposal),
@@ -435,7 +435,7 @@ fn handle_and_sign_vote(key_type: KeyType) {
             extension_signature: vec![],
         };
 
-        let signable_msg = SignableMsg::try_from(vote_msg.clone()).unwrap();
+        let signable_msg = ConsensusMsg::try_from(vote_msg.clone()).unwrap();
 
         let vote = proto::privval::SignVoteRequest {
             vote: Some(vote_msg),
@@ -522,7 +522,7 @@ fn exceed_max_height(key_type: KeyType) {
             extension_signature: vec![],
         };
 
-        let signable_msg = SignableMsg::try_from(vote_msg.clone()).unwrap();
+        let signable_msg = ConsensusMsg::try_from(vote_msg.clone()).unwrap();
 
         let vote = proto::privval::SignVoteRequest {
             vote: Some(vote_msg),


### PR DESCRIPTION
Implements support for the cometbft/cometbft#5126 interface for signing arbitrary domain-separated messages using a validator's consensus key