### PR TITLE
feat!: CometBFT v1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,7 +379,7 @@ The validator state files use an incompatible syntax from Tendermint KMS v0.5.
 It has been changed to match the conventions used by the rest of Tendermint,
 where integer values are stored in strings rather than JSON integers.
 
-When upgrading, you will need to either *delete existing state files* 
+When upgrading, you will need to either *delete existing state files*
 (they will be recreated automatically), or ensure the integer `height` and
 `round` fields contained within these files are quoted in strings, e.g.
 `{"height":"123456","round":"0",...}`.
@@ -476,7 +476,7 @@ section in the Tendermint KMS YubiHSM docs:
 ## 0.3.0 (2019-01-23)
 
 - Add ability to terminate on SIGTERM or SIGINT
-- Remove `PoisonPillMsg` 
+- Remove `PoisonPillMsg`
 
 
 ## 0.2.4 (2019-01-18)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cipher",
  "cpufeatures",
 ]
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -133,22 +133,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -182,12 +182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -239,9 +239,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "shlex",
 ]
@@ -344,9 +344,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chacha20"
@@ -354,7 +354,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cipher",
  "cpufeatures",
 ]
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -434,7 +434,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -474,6 +474,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "cometbft"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/cometbft/cometbft-rs.git?rev=71af716216216cfdc150cacef5ceae3610a5824b#71af716216216cfdc150cacef5ceae3610a5824b"
+dependencies = [
+ "bytes",
+ "cometbft-proto",
+ "digest 0.10.7",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost 0.13.5",
+ "ripemd",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.9",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "cometbft-config"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/cometbft/cometbft-rs.git?rev=71af716216216cfdc150cacef5ceae3610a5824b#71af716216216cfdc150cacef5ceae3610a5824b"
+dependencies = [
+ "cometbft",
+ "flex-error",
+ "serde",
+ "serde_json",
+ "toml",
+ "url 2.5.4",
+]
+
+[[package]]
+name = "cometbft-proto"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/cometbft/cometbft-rs.git?rev=71af716216216cfdc150cacef5ceae3610a5824b#71af716216216cfdc150cacef5ceae3610a5824b"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "prost 0.13.5",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,8 +557,8 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ac39be7373404accccaede7cc1ec942ccef14f0ca18d209967a756bf1dbb1f"
 dependencies = [
- "prost",
- "tendermint-proto",
+ "prost 0.13.5",
+ "tendermint-proto 0.40.4",
 ]
 
 [[package]]
@@ -521,7 +577,7 @@ dependencies = [
  "serde_json",
  "signature",
  "subtle-encoding",
- "tendermint",
+ "tendermint 0.40.4",
  "thiserror",
 ]
 
@@ -572,7 +628,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
@@ -590,7 +646,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -664,7 +720,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -759,7 +815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -964,18 +1020,18 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
@@ -1019,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "headers"
@@ -1316,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -1346,8 +1402,8 @@ version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
- "bitflags 2.9.0",
- "cfg-if 1.0.0",
+ "bitflags 2.9.1",
+ "cfg-if 1.0.1",
  "libc",
 ]
 
@@ -1356,6 +1412,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1388,7 +1453,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
@@ -1579,6 +1644,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,8 +1696,8 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.0",
- "cfg-if 1.0.0",
+ "bitflags 2.9.1",
+ "cfg-if 1.0.1",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1637,7 +1713,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1796,11 +1872,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
 ]
 
 [[package]]
@@ -1810,7 +1896,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1820,10 +1919,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+dependencies = [
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -1992,18 +2100,18 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2093,7 +2201,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2145,14 +2253,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -2168,7 +2276,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2186,7 +2294,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -2198,7 +2306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -2210,7 +2318,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -2249,7 +2357,7 @@ checksum = "ab0381d1913eeaf4c7bc4094016c9a8de6c1120663afe32a90ff268ad7f80486"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2269,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -2354,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2383,7 +2491,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2393,10 +2501,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f8a10105d0a7c4af0a242e23ed5a12519afe5cc0e68419da441bb5981a6802"
+dependencies = [
+ "bytes",
+ "digest 0.10.7",
+ "ed25519",
+ "flex-error",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost 0.12.6",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.35.0",
+ "time",
+ "zeroize",
 ]
 
 [[package]]
@@ -2414,7 +2549,7 @@ dependencies = [
  "k256",
  "num-traits",
  "once_cell",
- "prost",
+ "prost 0.13.5",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -2424,30 +2559,16 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.40.4",
  "time",
  "zeroize",
 ]
 
 [[package]]
-name = "tendermint-config"
-version = "0.40.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069d1791f9b02a596abcd26eb72003b2e9906c6169a60fa82ffc080dd3a43fda"
-dependencies = [
- "flex-error",
- "serde",
- "serde_json",
- "tendermint",
- "toml",
- "url 2.5.4",
-]
-
-[[package]]
 name = "tendermint-p2p"
-version = "0.40.4"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047c1002b9af811bfc62afef70be329e779a3e7f4a2fd23eebce102d1b63e5f4"
+checksum = "7dbaed086e2104a3996200d9cb36a02a50b2c40fc84feed34018e38c1cd76f30"
 dependencies = [
  "aead",
  "chacha20poly1305",
@@ -2458,15 +2579,33 @@ dependencies = [
  "flume",
  "hkdf",
  "merlin",
- "prost",
+ "prost 0.12.6",
  "rand_core",
  "sha2 0.10.9",
  "signature",
  "subtle",
- "tendermint",
- "tendermint-proto",
+ "tendermint 0.35.0",
+ "tendermint-proto 0.35.0",
  "tendermint-std-ext",
  "zeroize",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff525d5540a9fc535c38dc0d92a98da3ee36fcdfbda99cecb9f3cce5cd4d41d7"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost 0.12.6",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
 ]
 
 [[package]]
@@ -2477,7 +2616,7 @@ checksum = "d2c40e13d39ca19082d8a7ed22de7595979350319833698f8b1080f29620a094"
 dependencies = [
  "bytes",
  "flex-error",
- "prost",
+ "prost 0.13.5",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -2486,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-std-ext"
-version = "0.40.4"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298e90b07eab583fdf4829f4b1b85f0405ea3bfdd3154287064ac8507d3969f1"
+checksum = "21d83875eb543e63a6f4903620af14796c41db1e457478bb7feabf3eac88b09f"
 
 [[package]]
 name = "termcolor"
@@ -2516,7 +2655,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2525,7 +2664,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -2605,9 +2744,13 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "cometbft",
+ "cometbft-config",
+ "cometbft-proto",
  "cosmrs",
  "ed25519",
  "ed25519-consensus",
+ "ed25519-dalek",
  "elliptic-curve",
  "eyre",
  "getrandom 0.2.16",
@@ -2616,8 +2759,7 @@ dependencies = [
  "k256",
  "ledger",
  "once_cell",
- "prost",
- "prost-derive",
+ "prost 0.13.5",
  "rand",
  "rand_core",
  "rpassword",
@@ -2629,10 +2771,7 @@ dependencies = [
  "subtle",
  "subtle-encoding",
  "tempfile",
- "tendermint",
- "tendermint-config",
  "tendermint-p2p",
- "tendermint-proto",
  "thiserror",
  "url 2.5.4",
  "uuid",
@@ -2643,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2667,7 +2806,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2693,9 +2832,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2770,7 +2909,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2902,7 +3041,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -2971,7 +3110,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -2987,7 +3126,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -3009,7 +3148,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3075,7 +3214,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3086,7 +3225,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3119,7 +3258,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3128,7 +3267,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3137,14 +3285,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3154,10 +3319,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3166,10 +3343,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3178,10 +3367,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3190,10 +3391,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -3210,7 +3423,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3239,7 +3452,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -3250,7 +3463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467a4c054be41ff657a6823246b0194cd727fadc3c539b265d7bc125ac6d4884"
 dependencies = [
  "aes",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cbc",
  "ccm",
  "cmac",
@@ -3295,7 +3508,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3315,7 +3528,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -3336,7 +3549,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3352,9 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3369,5 +3582,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,6 @@ dependencies = [
  "cosmrs",
  "ed25519",
  "ed25519-consensus",
- "ed25519-dalek",
  "elliptic-curve",
  "eyre",
  "getrandom 0.2.16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"
 yubihsm = { version = "0.42", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
-ed25519-dalek = { version = "2.1.1", features = ["hazmat"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.8", features = ["testing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ k256 = { version = "0.13", features = ["ecdsa", "sha256"] }
 ledger = { version = "0.2", optional = true }
 once_cell = "1.5"
 prost = "0.13"
-prost-derive = "0.13"
 rand_core = { version = "0.6", features = ["std"] }
 rpassword = { version = "7", optional = true }
 sdkms = { version = "0.5", optional = true }
@@ -43,16 +42,17 @@ signature = { version = "2", features = ["std"] }
 subtle = "2"
 subtle-encoding = { version = "0.5", features = ["bech32-preview"] }
 tempfile = "3"
-tendermint = { version = "0.40", features = ["secp256k1"] }
-tendermint-config = "0.40"
-tendermint-p2p = "0.40"
-tendermint-proto = "0.40"
+cometbft = { git = "https://github.com/cometbft/cometbft-rs.git", rev = "71af716216216cfdc150cacef5ceae3610a5824b", features = ["secp256k1"] }
+cometbft-config = { git = "https://github.com/cometbft/cometbft-rs.git", rev = "71af716216216cfdc150cacef5ceae3610a5824b" }
+cometbft-proto = { git = "https://github.com/cometbft/cometbft-rs.git", rev = "71af716216216cfdc150cacef5ceae3610a5824b" }
+tendermint-p2p = "0.35" # cometbft-rs does not provide p2p crate
 thiserror = "1"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"
 yubihsm = { version = "0.42", features = ["secp256k1", "setup", "usb"], optional = true }
 zeroize = "1"
+ed25519-dalek = { version = "2.1.1", features = ["hazmat"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.8", features = ["testing"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,4 +88,3 @@ USER root
 # Ensure the /harness folder has the right owner
 RUN chown -R developer /harness
 USER developer
-

--- a/README.fortanixdsm.md
+++ b/README.fortanixdsm.md
@@ -1,8 +1,8 @@
-# Fortanix DSM + Tendermint KMS
+# Fortanix DSM + CometBFT KMS
 
 Fortanix Data Security Manager (DSM) provides integrated data security with encryption, multicloud key management, tokenization, and other capabilities from one platform. 
 
-This document describes how to configure Fortanix DSM for production use with Tendermint KMS.
+This document describes how to configure Fortanix DSM for production use with CometBFT KMS.
 
 ## Compiling `tmkms` with Fortanix DSM support
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
- # CometBFT KMS 🔐
-
- THIS IS ALPHA SOFTWARE AND NOT TESTED FOR PRODUCTION USE
+ # CometBFT KMS (prev. Tendermint KMS) 🔐
 
 ![Crate][crate-image]
 ![Build Status][build-image]
@@ -242,9 +240,9 @@ limitations under the License.
 
 [CometBFT]: https://cometbft.com/
 [Cosmos Validators]: https://hub.cosmos.network/main/validators/validator-faq
-[YubiHSM2]: https://github.com/informalsystems/tmkms-cometbft/blob/main/README.yubihsm.md
+[YubiHSM2]: https://github.com/iqlusioninc/tmkms/blob/main/README.yubihsm.md
 [Ledger]: https://www.ledger.com/
 [ed25519-dalek]: https://github.com/dalek-cryptography/ed25519-dalek
 [supported Rust platform]: https://forge.rust-lang.org/platform-support.html
 [libusb]: https://libusb.info/
-[Dockerfile]: https://github.com/informalsystems/tmkms-cometbft/blob/main/Dockerfile
+[Dockerfile]: https://github.com/iqlusioninc/tmkms/blob/main/Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
-# Tendermint KMS 🔐
+ # CometBFT KMS 🔐
 
-[![Crate][crate-image]][crate-link]
-[![Build Status][build-image]][build-link]
-[![Apache 2.0 Licensed][license-image]][license-link]
+ THIS IS ALPHA SOFTWARE AND NOT TESTED FOR PRODUCTION USE
+
+![Crate][crate-image]
+![Build Status][build-image]
+![Apache 2.0 Licensed][license-image]
 ![MSRV][rustc-image]
 
-Key Management System for [Tendermint] applications such as
-[Cosmos Validators].
+Key Management System for [CometBFT] applications such as [Cosmos Validators].
 
-Provides isolated, optionally HSM-backed signing key management for Tendermint
+Provides isolated, optionally HSM-backed signing key management for CometBFT
 applications including validators, oracles, IBC relayers, and other transaction
 signing applications.
 
 ## About
 
 This repository contains `tmkms`, a key management service intended to be deployed
-in conjunction with [Tendermint] applications (ideally on separate physical hosts)
+in conjunction with [CometBFT] applications (ideally on separate physical hosts)
 which provides the following:
 
 - **High-availability** access to validator signing keys
@@ -24,12 +25,12 @@ which provides the following:
 
 ## Status
 
-Tendermint KMS is currently *beta quality*. It has undergone one security audit
+CometBFT KMS is currently *beta quality*. It has undergone one security audit
 with only one low-severity finding.
 
 ### Double Signing / High Availability
 
-Tendermint KMS implements *beta quality* double signing detection.
+CometBFT KMS implements *beta quality* double signing detection.
 It has undergone some testing, however we do not (yet) recommend using the KMS
 in conjunction with multiple simultaneously active validators on the same
 network for prolonged periods of time.
@@ -38,16 +39,17 @@ In particular, there is presently **no double signing defense** in the case
 that multiple KMS instances are running simultaneously and connecting to
 multiple validators on the same network.
 
-## Signing Providers
+### Signing Providers
 
 You **MUST** select one or more signing provider(s) when compiling the KMS,
 passed as the argument to the `--features` flag (see below for more
-instructions on how to build Tendermint KMS).
+instructions on how to build CometBFT KMS).
 
 The following signing backend providers are presently supported:
 
 #### Hardware Security Modules (recommended)
-- [FortanixDSM](./README.fortanixdsm.md) (gated under the `fortanixdsm` cargo feature. See [README.fortanixdsm.md](./README.fortanixdsm.md) 
+
+- [FortanixDSM](./README.fortanixdsm.md) (gated under the `fortanixdsm` cargo feature. See [README.fortanixdsm.md](./README.fortanixdsm.md)
 - [YubiHSM2] (gated under the `yubihsm` cargo feature. See [README.yubihsm.md][yubihsm2] for more info)
 - [Ledger] (gated under the `ledger` cargo feature)
 
@@ -151,7 +153,7 @@ Please look through `tmkms.toml` after it's generated, as various sections
 will require some customization.
 
 The `tmkms init` command also accepts a `-n` or `--networks` argument which can
-be used to specify certain well-known Tendermint chains to initialize:
+be used to specify certain well-known CometBFT chains to initialize:
 
 ```
 $ tmkms init -n cosmoshub,irishub,columbus /path/to/kms/home
@@ -238,11 +240,11 @@ limitations under the License.
 
 [//]: # (general links)
 
-[Tendermint]: https://tendermint.com/
+[CometBFT]: https://cometbft.com/
 [Cosmos Validators]: https://hub.cosmos.network/main/validators/validator-faq
-[YubiHSM2]: https://github.com/iqlusioninc/tmkms/blob/main/README.yubihsm.md
+[YubiHSM2]: https://github.com/informalsystems/tmkms-cometbft/blob/main/README.yubihsm.md
 [Ledger]: https://www.ledger.com/
 [ed25519-dalek]: https://github.com/dalek-cryptography/ed25519-dalek
 [supported Rust platform]: https://forge.rust-lang.org/platform-support.html
 [libusb]: https://libusb.info/
-[Dockerfile]: https://github.com/iqlusioninc/tmkms/blob/main/Dockerfile
+[Dockerfile]: https://github.com/informalsystems/tmkms-cometbft/blob/main/Dockerfile

--- a/README.yubihsm.md
+++ b/README.yubihsm.md
@@ -1,11 +1,11 @@
-# YubiHSM 2 + Tendermint KMS
+# YubiHSM 2 + CometBFT KMS
 
 The [YubiHSM 2] from Yubico is a relatively low-cost solution for online
 key storage featuring support for random key generation, encrypted backup
 and export, and audit logging.
 
 This document describes how to configure a YubiHSM 2 for production use
-with Tendermint KMS.
+with CometBFT KMS.
 
 ## Compiling `tmkms` with YubiHSM support
 
@@ -65,7 +65,7 @@ that YubiHSM 2 support was compiled-in successfully:
 $ tmkms yubihsm help                                                                           127 ↵
 tmkms 0.4.0
 Tony Arcieri <tony@iqlusion.io>, Ismail Khoffi <Ismail.Khoffi@gmail.com>
-Tendermint Key Management System
+CometBFT Key Management System
 
 USAGE:
   tmkms <SUBCOMMAND>
@@ -122,7 +122,7 @@ server which is compatible with Yubico's `yubihsm-connector` service. This
 allows administration of YubiHSMs via `yubihsm-shell` or via `tmkms yubihsm`
 while the KMS is running (i.e. communicating with the YubiHSM2 via USB).
 
-To enable support for this feature, enable it when you compile Tendermint KMS,
+To enable support for this feature, enable it when you compile CometBFT KMS,
 either via:
 
 ```
@@ -194,7 +194,7 @@ to be provisioned with the same initial set of keys from the phrase alone,
 while also creating multiple "roles" within the HSM.
 
 Alternatively Yubico provides the [yubihsm-setup] tool, however the setup
-process internal to `tmkms` provides a "happy path" for Tendermint validator
+process internal to `tmkms` provides a "happy path" for CometBFT validator
 usage, and also operational processes which should be familiar to
 cryptocurrency users.
 
@@ -531,7 +531,7 @@ Generated Secret Connection key: /home/user/.tmkms/secrets/kms-identity.key
 - `chain.key_format.consensus_key_prefix` - set it as a bech32 prefix for validator consensus public key (for example, `cosmosvalconspub` for Cosmos network)
 - `providers.yubihsm.auth.key`, `providers.yubihsm.auth.password` - set it as YubiHSM credentials (if you haven't done it before, the default is 1/password)
 - `validator.addr` - remove the part before @ and the @ symbol itself to avoid mismatch
-- `validator.protocol_version` - set it to Tendermint version used (for example, `0.34` for Cosmos network), otherwise it won't be able to communicate with the node
+- `validator.protocol_version` - set it to CometBFT version used (for example, `0.34` for Cosmos network), otherwise it won't be able to communicate with the node
 
 3. Check that your device is recognized:
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -15,8 +15,8 @@ use crate::{
     keyring::{self, KeyRing},
     prelude::*,
 };
+pub use cometbft::chain::Id;
 use std::{path::PathBuf, sync::Mutex};
-pub use tendermint::chain::Id;
 
 /// Information about a particular Tendermint blockchain network
 pub struct Chain {

--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -12,13 +12,13 @@ use crate::{
     error::{Error, ErrorKind::*},
     prelude::*,
 };
+use cometbft::consensus;
 use std::{
     fs,
     io::{self, prelude::*},
     path::{Path, PathBuf},
 };
 use tempfile::NamedTempFile;
-use tendermint::consensus;
 
 /// State tracking for double signing prevention
 pub struct State {
@@ -209,7 +209,7 @@ impl State {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tendermint::block;
+    use cometbft::block;
 
     const EXAMPLE_BLOCK_ID: &str =
         "26C0A41F3243C6BCD7AD2DFF8A8D83A71D29D307B5326C227F734A1A512FE47D";

--- a/src/chain/state/hook.rs
+++ b/src/chain/state/hook.rs
@@ -5,9 +5,9 @@ use crate::{
     error::{Error, ErrorKind::HookError},
     prelude::*,
 };
+use cometbft::block;
 use serde::Deserialize;
 use std::{process::Command, time::Duration};
-use tendermint::block;
 use wait_timeout::ChildExt;
 
 /// Default timeout to use when a user one is unspecified

--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -7,9 +7,9 @@ use crate::{
 };
 use abscissa_core::{Command, Runnable};
 use clap::{Parser, Subcommand};
+use cometbft::Vote;
+use cometbft_proto as proto;
 use std::{path::PathBuf, process};
-use tendermint::Vote;
-use tendermint_proto as proto;
 
 /// `ledger` subcommand
 #[derive(Command, Debug, Runnable, Subcommand)]
@@ -55,7 +55,7 @@ impl Runnable for InitCommand {
         let registry = chain::REGISTRY.get();
         let chain = registry.get_chain(&chain_id).unwrap();
 
-        let vote = proto::types::Vote {
+        let vote = proto::types::v1::Vote {
             height: self.height.unwrap(),
             round: self.round.unwrap() as i32,
             r#type: SignedMsgType::Proposal.into(),

--- a/src/commands/softsign/import.rs
+++ b/src/commands/softsign/import.rs
@@ -3,9 +3,9 @@
 use crate::{config::provider::softsign::KeyFormat, key_utils, prelude::*};
 use abscissa_core::Command;
 use clap::Parser;
+use cometbft::PrivateKey;
+use cometbft_config::PrivValidatorKey;
 use std::{path::PathBuf, process};
-use tendermint::PrivateKey;
-use tendermint_config::PrivValidatorKey;
 
 /// `import` command: import a `priv_validator.json` formatted key and convert
 /// it into the raw format used by the softsign backend (by default)

--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -5,11 +5,11 @@ use crate::{config::provider::KeyType, key_utils, prelude::*};
 use abscissa_core::Command;
 use chrono::{SecondsFormat, Utc};
 use clap::Parser;
+use cometbft::PublicKey;
 use std::{
     path::{Path, PathBuf},
     process,
 };
-use tendermint::PublicKey;
 
 /// The `yubihsm keys generate` subcommand
 #[derive(Command, Debug, Default, Parser)]

--- a/src/commands/yubihsm/keys/import.rs
+++ b/src/commands/yubihsm/keys/import.rs
@@ -4,10 +4,10 @@ use super::{DEFAULT_DOMAINS, DEFAULT_WRAP_KEY};
 use crate::{keyring::ed25519, prelude::*};
 use abscissa_core::Command;
 use clap::Parser;
+use cometbft::{PrivateKey, PublicKey};
+use cometbft_config::PrivValidatorKey;
 use std::{fs, path::PathBuf, process};
 use subtle_encoding::base64;
-use tendermint::{PrivateKey, PublicKey};
-use tendermint_config::PrivValidatorKey;
 use yubihsm::object;
 use zeroize::Zeroizing;
 

--- a/src/config/provider/yubihsm.rs
+++ b/src/config/provider/yubihsm.rs
@@ -4,9 +4,10 @@ use super::KeyType;
 use crate::{chain, prelude::*};
 use serde::Deserialize;
 use std::{fmt, fs, path::PathBuf, process};
-use tendermint_config::net;
 use yubihsm::Credentials;
 use zeroize::{Zeroize, Zeroizing};
+
+use cometbft_config::net;
 
 /// The (optional) `[providers.yubihsm]` config section
 #[derive(Clone, Deserialize, Debug)]

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -1,9 +1,9 @@
 //! Validator configuration
 
+use cometbft::chain;
+use cometbft_config::net;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use tendermint::chain;
-use tendermint_config::net;
 use tendermint_p2p::secret_connection;
 
 /// Validator configuration
@@ -27,7 +27,7 @@ pub struct ValidatorConfig {
     pub secret_key: Option<PathBuf>,
 
     /// Height at which to stop signing
-    pub max_height: Option<tendermint::block::Height>,
+    pub max_height: Option<cometbft::block::Height>,
 
     /// Version of Secret Connection protocol to use when connecting
     pub protocol_version: ProtocolVersion,

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -2,8 +2,8 @@
 
 use std::{net::TcpStream, path::PathBuf, time::Duration};
 
+use cometbft::node;
 use subtle::ConstantTimeEq;
-use tendermint::node;
 use tendermint_p2p::error::ErrorDetail as TmError;
 use tendermint_p2p::secret_connection::{self, PublicKey, SecretConnection};
 
@@ -55,7 +55,12 @@ pub fn open_secret_connection(
 
     // TODO(tarcieri): move this into `SecretConnection::new`
     if let Some(expected_peer_id) = peer_id {
-        if expected_peer_id.ct_eq(&actual_peer_id).unwrap_u8() == 0 {
+        if expected_peer_id
+            .as_bytes()
+            .ct_eq(actual_peer_id.as_bytes())
+            .unwrap_u8()
+            == 0
+        {
             fail!(
                 VerificationError,
                 "{}:{}: validator peer ID mismatch! (expected {}, got {})",

--- a/src/error.rs
+++ b/src/error.rs
@@ -94,6 +94,10 @@ pub enum ErrorKind {
     #[cfg(feature = "yubihsm")]
     #[error("YubiHSM error")]
     YubihsmError,
+
+    /// Protobuf encoding error
+    #[error("protobuf error")]
+    ProtobufError,
 }
 
 impl ErrorKind {
@@ -190,9 +194,15 @@ impl From<signature::Error> for Error {
     }
 }
 
-impl From<tendermint::Error> for Error {
-    fn from(other: tendermint::error::Error) -> Self {
+impl From<cometbft::Error> for Error {
+    fn from(other: cometbft::error::Error) -> Self {
         ErrorKind::TendermintError.context(other).into()
+    }
+}
+
+impl From<cometbft_proto::Error> for Error {
+    fn from(other: cometbft_proto::Error) -> Self {
+        ErrorKind::ProtobufError.context(other).into()
     }
 }
 

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -14,7 +14,7 @@ use crate::{
     prelude::*,
     Map,
 };
-use tendermint::{account, TendermintKey};
+use cometbft::{account, CometbftKey};
 
 /// File encoding for software-backed secret keys
 pub type SecretKeyEncoding = subtle_encoding::Base64;
@@ -22,10 +22,10 @@ pub type SecretKeyEncoding = subtle_encoding::Base64;
 /// Signing keyring
 pub struct KeyRing {
     /// ECDSA keys in the keyring
-    ecdsa_keys: Map<TendermintKey, ecdsa::Signer>,
+    ecdsa_keys: Map<CometbftKey, ecdsa::Signer>,
 
     /// Ed25519 keys in the keyring
-    ed25519_keys: Map<TendermintKey, ed25519::Signer>,
+    ed25519_keys: Map<CometbftKey, ed25519::Signer>,
 
     /// Formatting configuration when displaying keys (e.g. bech32)
     format: Format,
@@ -48,8 +48,8 @@ impl KeyRing {
         let public_key = signer.public_key();
         let public_key_serialized = self.format.serialize(public_key);
         let key_type = match public_key {
-            TendermintKey::AccountKey(_) => "account",
-            TendermintKey::ConsensusKey(_) => unimplemented!(
+            CometbftKey::AccountKey(_) => "account",
+            CometbftKey::ConsensusKey(_) => unimplemented!(
                 "ECDSA consensus keys unsupported: {:?}",
                 public_key_serialized
             ),
@@ -80,11 +80,11 @@ impl KeyRing {
         let public_key = signer.public_key();
         let public_key_serialized = self.format.serialize(public_key);
         let key_type = match public_key {
-            TendermintKey::AccountKey(_) => unimplemented!(
+            CometbftKey::AccountKey(_) => unimplemented!(
                 "Ed25519 account keys unsupported: {:?}",
                 public_key_serialized
             ),
-            TendermintKey::ConsensusKey(_) => "consensus",
+            CometbftKey::ConsensusKey(_) => "consensus",
         };
 
         info!(
@@ -106,7 +106,7 @@ impl KeyRing {
     }
 
     /// Get the default Ed25519 (i.e. consensus) public key for this keyring
-    pub fn default_pubkey(&self) -> Result<TendermintKey, Error> {
+    pub fn default_pubkey(&self) -> Result<CometbftKey, Error> {
         if !self.ed25519_keys.is_empty() {
             let mut keys = self.ed25519_keys.keys();
 
@@ -129,9 +129,9 @@ impl KeyRing {
     }
 
     /// Get ECDSA public key bytes for a given account ID
-    pub fn get_account_pubkey(&self, account_id: account::Id) -> Option<tendermint::PublicKey> {
+    pub fn get_account_pubkey(&self, account_id: account::Id) -> Option<cometbft::PublicKey> {
         for key in self.ecdsa_keys.keys() {
-            if let TendermintKey::AccountKey(pk) = key {
+            if let CometbftKey::AccountKey(pk) = key {
                 if account_id == account::Id::from(*pk) {
                     return Some(*pk);
                 }
@@ -148,7 +148,7 @@ impl KeyRing {
         msg: &[u8],
     ) -> Result<ecdsa::Signature, Error> {
         for (key, signer) in &self.ecdsa_keys {
-            if let TendermintKey::AccountKey(pk) = key {
+            if let CometbftKey::AccountKey(pk) = key {
                 if account_id == account::Id::from(*pk) {
                     return signer.sign(msg);
                 }
@@ -164,7 +164,7 @@ impl KeyRing {
 
     /// Sign a message using the secret key associated with the given public key
     /// (if it is in our keyring)
-    pub fn sign(&self, public_key: Option<&TendermintKey>, msg: &[u8]) -> Result<Signature, Error> {
+    pub fn sign(&self, public_key: Option<&CometbftKey>, msg: &[u8]) -> Result<Signature, Error> {
         if self.ed25519_keys.len() > 1 || self.ecdsa_keys.len() > 1 {
             fail!(SigningError, "expected only one key in keyring");
         }
@@ -176,8 +176,8 @@ impl KeyRing {
                         InvalidKey,
                         "not in keyring: {}",
                         match public_key {
-                            TendermintKey::AccountKey(pk) => pk.to_bech32(""),
-                            TendermintKey::ConsensusKey(pk) => pk.to_bech32(""),
+                            CometbftKey::AccountKey(pk) => pk.to_bech32(""),
+                            CometbftKey::ConsensusKey(pk) => pk.to_bech32(""),
                         }
                     )
                 }),
@@ -196,8 +196,8 @@ impl KeyRing {
                         InvalidKey,
                         "not in keyring: {}",
                         match public_key {
-                            TendermintKey::AccountKey(pk) => pk.to_bech32(""),
-                            TendermintKey::ConsensusKey(pk) => pk.to_bech32(""),
+                            CometbftKey::AccountKey(pk) => pk.to_bech32(""),
+                            CometbftKey::ConsensusKey(pk) => pk.to_bech32(""),
                         }
                     )
                 }),

--- a/src/keyring/ecdsa.rs
+++ b/src/keyring/ecdsa.rs
@@ -7,8 +7,8 @@ use crate::{
     keyring::SigningProvider,
     prelude::*,
 };
+use cometbft::CometbftKey;
 use std::sync::Arc;
-use tendermint::TendermintKey;
 
 /// ECDSA signer
 #[derive(Clone)]
@@ -18,7 +18,7 @@ pub struct Signer {
     provider: SigningProvider,
 
     /// Tendermint public key
-    public_key: TendermintKey,
+    public_key: CometbftKey,
 
     /// Signer trait object
     signer: Arc<Box<dyn signature::Signer<Signature> + Send + Sync>>,
@@ -28,7 +28,7 @@ impl Signer {
     /// Create a new signer
     pub fn new(
         provider: SigningProvider,
-        public_key: TendermintKey,
+        public_key: CometbftKey,
         signer: Box<dyn signature::Signer<Signature> + Send + Sync>,
     ) -> Self {
         Self {
@@ -39,7 +39,7 @@ impl Signer {
     }
 
     /// Get the Tendermint public key for this signer
-    pub fn public_key(&self) -> TendermintKey {
+    pub fn public_key(&self) -> CometbftKey {
         self.public_key
     }
 

--- a/src/keyring/ed25519.rs
+++ b/src/keyring/ed25519.rs
@@ -11,8 +11,8 @@ use crate::{
     keyring::SigningProvider,
     prelude::*,
 };
+use cometbft::CometbftKey;
 use std::sync::Arc;
-use tendermint::TendermintKey;
 
 /// Ed25519 signer
 #[derive(Clone)]
@@ -22,7 +22,7 @@ pub struct Signer {
     provider: SigningProvider,
 
     /// Tendermint public key
-    public_key: TendermintKey,
+    public_key: CometbftKey,
 
     /// Signer trait object
     signer: Arc<Box<dyn signature::Signer<Signature> + Send + Sync>>,
@@ -32,7 +32,7 @@ impl Signer {
     /// Create a new signer
     pub fn new(
         provider: SigningProvider,
-        public_key: TendermintKey,
+        public_key: CometbftKey,
         signer: Box<dyn signature::Signer<Signature> + Send + Sync>,
     ) -> Self {
         Self {
@@ -43,7 +43,7 @@ impl Signer {
     }
 
     /// Get the Tendermint public key for this signer
-    pub fn public_key(&self) -> TendermintKey {
+    pub fn public_key(&self) -> CometbftKey {
         self.public_key
     }
 

--- a/src/keyring/ed25519/signing_key.rs
+++ b/src/keyring/ed25519/signing_key.rs
@@ -1,65 +1,112 @@
 use super::{Signature, VerifyingKey};
 use crate::error::{Error, ErrorKind};
+use ed25519_dalek::hazmat::{raw_sign, ExpandedSecretKey};
 use signature::Signer;
 
 /// Signing key serialized as bytes.
 type SigningKeyBytes = [u8; SigningKey::BYTE_SIZE];
 
 /// Ed25519 signing key.
-#[derive(Clone, Debug)]
-pub struct SigningKey(ed25519_consensus::SigningKey);
+pub enum SigningKey {
+    /// Ed25519 signing key.
+    Ed25519(ed25519_consensus::SigningKey),
+    /// Ed25519 expanded signing key.
+    Ed25519Expanded(ExpandedSecretKey),
+}
 
 impl SigningKey {
     /// Size of an encoded Ed25519 signing key in bytes.
     pub const BYTE_SIZE: usize = 32;
 
+    /// Size of an Ed25519 expanded signing key in bytes.
+    pub const EXPANDED_BYTE_SIZE: usize = 64;
+
+    /// Size of an Ed25519 public key in bytes.
+    pub const PUBLIC_KEY_BYTE_SIZE: usize = 32;
+
     /// Borrow the serialized signing key as bytes.
     pub fn as_bytes(&self) -> &SigningKeyBytes {
-        self.0.as_bytes()
+        match &self {
+            SigningKey::Ed25519(signing_key) => signing_key.as_bytes(),
+            SigningKey::Ed25519Expanded(_) => panic!("unexpected expanded signing key"),
+        }
     }
 
     /// Get the verifying key for this signing key.
     pub fn verifying_key(&self) -> VerifyingKey {
-        VerifyingKey(self.0.verification_key())
+        match &self {
+            SigningKey::Ed25519(signing_key) => VerifyingKey(signing_key.verification_key()),
+            SigningKey::Ed25519Expanded(signing_key) => {
+                Into::<ed25519_dalek::VerifyingKey>::into(signing_key)
+                    .as_bytes()
+                    .as_slice()
+                    .try_into()
+                    .unwrap()
+            }
+        }
     }
 }
 
 impl From<SigningKeyBytes> for SigningKey {
     fn from(bytes: SigningKeyBytes) -> Self {
-        Self(bytes.into())
+        SigningKey::Ed25519(bytes.into())
     }
 }
 
 impl From<SigningKey> for ed25519_consensus::SigningKey {
     fn from(signing_key: SigningKey) -> ed25519_consensus::SigningKey {
-        signing_key.0
+        match signing_key {
+            SigningKey::Ed25519(signing_key) => signing_key,
+            SigningKey::Ed25519Expanded(_) => panic!("unexpected expanded signing key"),
+        }
     }
 }
 
 impl From<&SigningKey> for tendermint_p2p::secret_connection::PublicKey {
     fn from(signing_key: &SigningKey) -> tendermint_p2p::secret_connection::PublicKey {
-        Self::from(&signing_key.0)
+        match signing_key {
+            SigningKey::Ed25519(signing_key) => Self::from(signing_key),
+            SigningKey::Ed25519Expanded(signing_key) => {
+                let dalek_verifying_key: ed25519_dalek::VerifyingKey = signing_key.into();
+                let ed25519_consenus_verification_key: ed25519_consensus::VerificationKey =
+                    dalek_verifying_key
+                        .as_bytes()
+                        .as_slice()
+                        .try_into()
+                        .unwrap();
+                ed25519_consenus_verification_key.into()
+            }
+        }
     }
 }
 
 impl From<ed25519_consensus::SigningKey> for SigningKey {
     fn from(signing_key: ed25519_consensus::SigningKey) -> SigningKey {
-        SigningKey(signing_key)
+        SigningKey::Ed25519(signing_key)
     }
 }
 
-impl From<tendermint::private_key::Ed25519> for SigningKey {
-    fn from(signing_key: tendermint::private_key::Ed25519) -> SigningKey {
-        signing_key
-            .as_bytes()
-            .try_into()
-            .expect("invalid Ed25519 signing key")
+impl From<cometbft::private_key::Ed25519> for SigningKey {
+    fn from(signing_key: cometbft::private_key::Ed25519) -> SigningKey {
+        SigningKey::Ed25519(
+            signing_key
+                .as_bytes()
+                .try_into()
+                .expect("invalid Ed25519 signing key"),
+        )
     }
 }
 
 impl Signer<Signature> for SigningKey {
     fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
-        Ok(self.0.sign(msg).to_bytes().into())
+        match self {
+            SigningKey::Ed25519(signing_key) => Ok(signing_key.sign(msg).to_bytes().into()),
+            SigningKey::Ed25519Expanded(signing_key) => Ok(raw_sign::<sha2::Sha512>(
+                signing_key,
+                msg,
+                &signing_key.into(),
+            )),
+        }
     }
 }
 
@@ -67,9 +114,34 @@ impl TryFrom<&[u8]> for SigningKey {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        slice
-            .try_into()
-            .map(Self)
-            .map_err(|_| ErrorKind::InvalidKey.into())
+        if slice.len() == SigningKey::BYTE_SIZE {
+            // Assume seed key.
+            slice
+                .try_into()
+                .map(SigningKey::Ed25519)
+                .map_err(|_| ErrorKind::InvalidKey.into())
+        } else if slice.len() == SigningKey::EXPANDED_BYTE_SIZE {
+            // Assume key is big-endian encoded expanded secret key. (SHA512 hashed seed key.)
+            slice[0..SigningKey::EXPANDED_BYTE_SIZE]
+                .try_into()
+                .map(SigningKey::Ed25519Expanded)
+                .map_err(|_| ErrorKind::InvalidKey.into())
+        } else if slice.len() == (SigningKey::EXPANDED_BYTE_SIZE + SigningKey::PUBLIC_KEY_BYTE_SIZE)
+        {
+            // Assume key is little-endian encoded expanded secret key. (Exported from YubiHSM.)
+            let mut slice_copy: [u8; SigningKey::EXPANDED_BYTE_SIZE
+                + SigningKey::PUBLIC_KEY_BYTE_SIZE] =
+                [0; SigningKey::EXPANDED_BYTE_SIZE + SigningKey::PUBLIC_KEY_BYTE_SIZE];
+            slice_copy.copy_from_slice(slice);
+            slice_copy[0..32].reverse();
+            slice_copy[0..SigningKey::EXPANDED_BYTE_SIZE]
+                .try_into()
+                .map(SigningKey::Ed25519Expanded)
+                .map_err(|_| ErrorKind::InvalidKey.into())
+        } else {
+            Err(ErrorKind::InvalidKey
+                .context(format!("invalid Ed25519 key size {}", slice.len()))
+                .into())
+        }
     }
 }

--- a/src/keyring/ed25519/signing_key.rs
+++ b/src/keyring/ed25519/signing_key.rs
@@ -115,7 +115,6 @@ impl TryFrom<&[u8]> for SigningKey {
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
         if slice.len() == SigningKey::BYTE_SIZE {
-            // Assume seed key.
             slice
                 .try_into()
                 .map(SigningKey::Ed25519)

--- a/src/keyring/ed25519/signing_key.rs
+++ b/src/keyring/ed25519/signing_key.rs
@@ -1,112 +1,65 @@
 use super::{Signature, VerifyingKey};
 use crate::error::{Error, ErrorKind};
-use ed25519_dalek::hazmat::{raw_sign, ExpandedSecretKey};
 use signature::Signer;
 
 /// Signing key serialized as bytes.
 type SigningKeyBytes = [u8; SigningKey::BYTE_SIZE];
 
 /// Ed25519 signing key.
-pub enum SigningKey {
-    /// Ed25519 signing key.
-    Ed25519(ed25519_consensus::SigningKey),
-    /// Ed25519 expanded signing key.
-    Ed25519Expanded(ExpandedSecretKey),
-}
+#[derive(Clone, Debug)]
+pub struct SigningKey(ed25519_consensus::SigningKey);
 
 impl SigningKey {
     /// Size of an encoded Ed25519 signing key in bytes.
     pub const BYTE_SIZE: usize = 32;
 
-    /// Size of an Ed25519 expanded signing key in bytes.
-    pub const EXPANDED_BYTE_SIZE: usize = 64;
-
-    /// Size of an Ed25519 public key in bytes.
-    pub const PUBLIC_KEY_BYTE_SIZE: usize = 32;
-
     /// Borrow the serialized signing key as bytes.
     pub fn as_bytes(&self) -> &SigningKeyBytes {
-        match &self {
-            SigningKey::Ed25519(signing_key) => signing_key.as_bytes(),
-            SigningKey::Ed25519Expanded(_) => panic!("unexpected expanded signing key"),
-        }
+        self.0.as_bytes()
     }
 
     /// Get the verifying key for this signing key.
     pub fn verifying_key(&self) -> VerifyingKey {
-        match &self {
-            SigningKey::Ed25519(signing_key) => VerifyingKey(signing_key.verification_key()),
-            SigningKey::Ed25519Expanded(signing_key) => {
-                Into::<ed25519_dalek::VerifyingKey>::into(signing_key)
-                    .as_bytes()
-                    .as_slice()
-                    .try_into()
-                    .unwrap()
-            }
-        }
+        VerifyingKey(self.0.verification_key())
     }
 }
 
 impl From<SigningKeyBytes> for SigningKey {
     fn from(bytes: SigningKeyBytes) -> Self {
-        SigningKey::Ed25519(bytes.into())
+        Self(bytes.into())
     }
 }
 
 impl From<SigningKey> for ed25519_consensus::SigningKey {
     fn from(signing_key: SigningKey) -> ed25519_consensus::SigningKey {
-        match signing_key {
-            SigningKey::Ed25519(signing_key) => signing_key,
-            SigningKey::Ed25519Expanded(_) => panic!("unexpected expanded signing key"),
-        }
+        signing_key.0
     }
 }
 
 impl From<&SigningKey> for tendermint_p2p::secret_connection::PublicKey {
     fn from(signing_key: &SigningKey) -> tendermint_p2p::secret_connection::PublicKey {
-        match signing_key {
-            SigningKey::Ed25519(signing_key) => Self::from(signing_key),
-            SigningKey::Ed25519Expanded(signing_key) => {
-                let dalek_verifying_key: ed25519_dalek::VerifyingKey = signing_key.into();
-                let ed25519_consenus_verification_key: ed25519_consensus::VerificationKey =
-                    dalek_verifying_key
-                        .as_bytes()
-                        .as_slice()
-                        .try_into()
-                        .unwrap();
-                ed25519_consenus_verification_key.into()
-            }
-        }
+        Self::from(&signing_key.0)
     }
 }
 
 impl From<ed25519_consensus::SigningKey> for SigningKey {
     fn from(signing_key: ed25519_consensus::SigningKey) -> SigningKey {
-        SigningKey::Ed25519(signing_key)
+        SigningKey(signing_key)
     }
 }
 
 impl From<cometbft::private_key::Ed25519> for SigningKey {
     fn from(signing_key: cometbft::private_key::Ed25519) -> SigningKey {
-        SigningKey::Ed25519(
-            signing_key
-                .as_bytes()
-                .try_into()
-                .expect("invalid Ed25519 signing key"),
-        )
+        signing_key
+            .as_bytes()
+            .try_into()
+            .expect("invalid Ed25519 signing key")
     }
 }
 
 impl Signer<Signature> for SigningKey {
     fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
-        match self {
-            SigningKey::Ed25519(signing_key) => Ok(signing_key.sign(msg).to_bytes().into()),
-            SigningKey::Ed25519Expanded(signing_key) => Ok(raw_sign::<sha2::Sha512>(
-                signing_key,
-                msg,
-                &signing_key.into(),
-            )),
-        }
+        Ok(self.0.sign(msg).to_bytes().into())
     }
 }
 
@@ -114,29 +67,9 @@ impl TryFrom<&[u8]> for SigningKey {
     type Error = Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        if slice.len() == SigningKey::BYTE_SIZE {
-            slice
-                .try_into()
-                .map(SigningKey::Ed25519)
-                .map_err(|_| ErrorKind::InvalidKey.into())
-        } else if slice.len() == SigningKey::EXPANDED_BYTE_SIZE {
-            // Assume key is big-endian encoded expanded secret key. (SHA512 hashed seed key.)
-            slice[0..SigningKey::EXPANDED_BYTE_SIZE]
-                .try_into()
-                .map(SigningKey::Ed25519Expanded)
-                .map_err(|_| ErrorKind::InvalidKey.into())
-        } else if slice.len() == (SigningKey::EXPANDED_BYTE_SIZE + SigningKey::PUBLIC_KEY_BYTE_SIZE)
-        {
-            // Assume key is little-endian encoded expanded secret key. (Exported from YubiHSM.)
-            slice[0..32].reverse();
-            slice[0..SigningKey::EXPANDED_BYTE_SIZE]
-                .try_into()
-                .map(SigningKey::Ed25519Expanded)
-                .map_err(|_| ErrorKind::InvalidKey.into())
-        } else {
-            Err(ErrorKind::InvalidKey
-                .context(format!("invalid Ed25519 key size {}", slice.len()))
-                .into())
-        }
+        slice
+            .try_into()
+            .map(Self)
+            .map_err(|_| ErrorKind::InvalidKey.into())
     }
 }

--- a/src/keyring/ed25519/signing_key.rs
+++ b/src/keyring/ed25519/signing_key.rs
@@ -129,12 +129,8 @@ impl TryFrom<&[u8]> for SigningKey {
         } else if slice.len() == (SigningKey::EXPANDED_BYTE_SIZE + SigningKey::PUBLIC_KEY_BYTE_SIZE)
         {
             // Assume key is little-endian encoded expanded secret key. (Exported from YubiHSM.)
-            let mut slice_copy: [u8; SigningKey::EXPANDED_BYTE_SIZE
-                + SigningKey::PUBLIC_KEY_BYTE_SIZE] =
-                [0; SigningKey::EXPANDED_BYTE_SIZE + SigningKey::PUBLIC_KEY_BYTE_SIZE];
-            slice_copy.copy_from_slice(slice);
-            slice_copy[0..32].reverse();
-            slice_copy[0..SigningKey::EXPANDED_BYTE_SIZE]
+            slice[0..32].reverse();
+            slice[0..SigningKey::EXPANDED_BYTE_SIZE]
                 .try_into()
                 .map(SigningKey::Ed25519Expanded)
                 .map_err(|_| ErrorKind::InvalidKey.into())

--- a/src/keyring/ed25519/verifying_key.rs
+++ b/src/keyring/ed25519/verifying_key.rs
@@ -23,9 +23,9 @@ impl From<&SigningKey> for VerifyingKey {
     }
 }
 
-impl From<VerifyingKey> for tendermint::PublicKey {
-    fn from(verifying_key: VerifyingKey) -> tendermint::PublicKey {
-        tendermint::PublicKey::from_raw_ed25519(verifying_key.as_bytes())
+impl From<VerifyingKey> for cometbft::PublicKey {
+    fn from(verifying_key: VerifyingKey) -> cometbft::PublicKey {
+        cometbft::PublicKey::from_raw_ed25519(verifying_key.as_bytes())
             .expect("invalid Ed25519 key")
     }
 }

--- a/src/keyring/format.rs
+++ b/src/keyring/format.rs
@@ -1,9 +1,9 @@
 //! Chain-specific key configuration
 
-use cosmrs::crypto::PublicKey;
+use cometbft::CometbftKey;
+// use cosmrs::crypto::PublicKey;
 use serde::Deserialize;
 use subtle_encoding::bech32;
-use tendermint::TendermintKey;
 
 /// Options for how keys for this chain are represented
 #[derive(Clone, Debug, Deserialize)]
@@ -29,22 +29,22 @@ pub enum Format {
 }
 
 impl Format {
-    /// Serialize a `TendermintKey` according to chain-specific rules
-    pub fn serialize(&self, public_key: TendermintKey) -> String {
+    /// Serialize a `CometbftKey` according to chain-specific rules
+    pub fn serialize(&self, public_key: CometbftKey) -> String {
         match self {
             Format::Bech32 {
                 account_key_prefix,
                 consensus_key_prefix,
             } => match public_key {
-                TendermintKey::AccountKey(pk) => {
-                    bech32::encode(account_key_prefix, tendermint::account::Id::from(pk))
+                CometbftKey::AccountKey(pk) => {
+                    bech32::encode(account_key_prefix, cometbft::account::Id::from(pk))
                 }
-                TendermintKey::ConsensusKey(pk) => pk.to_bech32(consensus_key_prefix),
+                CometbftKey::ConsensusKey(pk) => pk.to_bech32(consensus_key_prefix),
             },
-            Format::CosmosJson => PublicKey::from(*public_key.public_key()).to_json(),
+            Format::CosmosJson => unimplemented!("cosmrs needs to be updated!"),
             Format::Hex => match public_key {
-                TendermintKey::AccountKey(pk) => pk.to_hex(),
-                TendermintKey::ConsensusKey(pk) => pk.to_hex(),
+                CometbftKey::AccountKey(pk) => pk.to_hex(),
+                CometbftKey::ConsensusKey(pk) => pk.to_hex(),
             },
         }
     }

--- a/src/keyring/providers/fortanixdsm.rs
+++ b/src/keyring/providers/fortanixdsm.rs
@@ -8,6 +8,8 @@ use crate::{
     keyring::{self, ed25519, SigningProvider},
     prelude::*,
 };
+use cometbft::public_key::{Ed25519, Secp256k1};
+use cometbft::{CometbftKey, PublicKey};
 use elliptic_curve::pkcs8::{
     spki::Error as SpkiError, DecodePublicKey, ObjectIdentifier, SubjectPublicKeyInfoRef,
 };
@@ -19,8 +21,6 @@ use sdkms::api_model::{
 use sdkms::{Error as SdkmsError, SdkmsClient};
 use signature::Signer;
 use std::sync::Arc;
-use tendermint::public_key::{Ed25519, Secp256k1};
-use tendermint::{PublicKey, TendermintKey};
 use url::Url;
 
 /// Create Fortanix DSM backed signer objects from the given configuration
@@ -80,7 +80,7 @@ impl SigningKey {
         client: Arc<SdkmsClient>,
         descriptor: KeyDescriptor,
         key_type: KeyType,
-    ) -> Result<(Self, TendermintKey), Error> {
+    ) -> Result<(Self, CometbftKey), Error> {
         let descriptor: SobjectDescriptor = descriptor.into();
         let key = client
             .get_sobject(None, &descriptor)
@@ -121,7 +121,7 @@ impl SigningKey {
                         )
                     })?
                     .into();
-                TendermintKey::AccountKey(PublicKey::from(pub_key))
+                CometbftKey::AccountKey(PublicKey::from(pub_key))
             }
             KeyType::Consensus => {
                 let pub_key = Ed25519PublicKey::from_public_key_der(&public_key).map_err(|e| {
@@ -131,7 +131,7 @@ impl SigningKey {
                         e
                     )
                 })?;
-                TendermintKey::ConsensusKey(PublicKey::from(pub_key.0))
+                CometbftKey::ConsensusKey(PublicKey::from(pub_key.0))
             }
         };
 

--- a/src/keyring/providers/ledgertm.rs
+++ b/src/keyring/providers/ledgertm.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     prelude::*,
 };
-use tendermint::{PublicKey, TendermintKey};
+use cometbft::{CometbftKey, PublicKey};
 
 /// Create Ledger Tendermint signer object from the given configuration
 pub fn init(
@@ -41,7 +41,7 @@ pub fn init(
 
     let signer = Signer::new(
         SigningProvider::LedgerTm,
-        TendermintKey::ConsensusKey(public_key),
+        CometbftKey::ConsensusKey(public_key),
         Box::new(provider),
     );
 

--- a/src/keyring/providers/softsign.rs
+++ b/src/keyring/providers/softsign.rs
@@ -13,9 +13,9 @@ use crate::{
     keyring::{self, ed25519, SigningProvider},
     prelude::*,
 };
+use cometbft::{CometbftKey, PrivateKey};
+use cometbft_config::PrivValidatorKey;
 use k256::ecdsa;
-use tendermint::{PrivateKey, TendermintKey};
-use tendermint_config::PrivValidatorKey;
 
 /// Create software-backed Ed25519 signer objects from the given configuration
 pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) -> Result<(), Error> {
@@ -29,12 +29,12 @@ pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) ->
         match config.key_type {
             KeyType::Account => {
                 let signer = load_secp256k1_key(config)?;
-                let public_key = tendermint::PublicKey::from_raw_secp256k1(
+                let public_key = cometbft::PublicKey::from_raw_secp256k1(
                     &signer.verifying_key().to_sec1_bytes(),
                 )
                 .unwrap();
 
-                let account_pubkey = TendermintKey::AccountKey(public_key);
+                let account_pubkey = CometbftKey::AccountKey(public_key);
 
                 let signer = keyring::ecdsa::Signer::new(
                     SigningProvider::SoftSign,
@@ -58,7 +58,7 @@ pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftsignConfig]) ->
 
                 let signing_key = load_ed25519_key(config)?;
                 let consensus_pubkey =
-                    TendermintKey::ConsensusKey(signing_key.verifying_key().into());
+                    CometbftKey::ConsensusKey(signing_key.verifying_key().into());
 
                 let signer = ed25519::Signer::new(
                     SigningProvider::SoftSign,

--- a/src/keyring/providers/yubihsm.rs
+++ b/src/keyring/providers/yubihsm.rs
@@ -10,7 +10,7 @@ use crate::{
     keyring::{self, SigningProvider},
     prelude::*,
 };
-use tendermint::TendermintKey;
+use cometbft::CometbftKey;
 
 /// Create hardware-backed YubiHSM signer objects from the given configuration
 pub fn init(
@@ -55,12 +55,12 @@ fn add_account_key(
         })?;
 
     let public_key =
-        tendermint::PublicKey::from_raw_secp256k1(signer.public_key().compress().as_bytes())
+        cometbft::PublicKey::from_raw_secp256k1(signer.public_key().compress().as_bytes())
             .expect("invalid secp256k1 key");
 
     let signer = keyring::ecdsa::Signer::new(
         SigningProvider::Yubihsm,
-        TendermintKey::AccountKey(public_key),
+        CometbftKey::AccountKey(public_key),
         Box::new(signer),
     );
 
@@ -85,12 +85,12 @@ fn add_consensus_key(
             )
         })?;
 
-    let public_key = tendermint::PublicKey::from_raw_ed25519(signer.public_key().as_bytes())
+    let public_key = cometbft::PublicKey::from_raw_ed25519(signer.public_key().as_bytes())
         .expect("invalid Ed25519 key");
 
     let signer = keyring::ed25519::Signer::new(
         SigningProvider::Yubihsm,
-        TendermintKey::ConsensusKey(public_key),
+        CometbftKey::ConsensusKey(public_key),
         Box::new(signer),
     );
 

--- a/src/keyring/signature.rs
+++ b/src/keyring/signature.rs
@@ -34,8 +34,8 @@ impl From<ed25519::Signature> for Signature {
     }
 }
 
-impl From<Signature> for tendermint::Signature {
-    fn from(sig: Signature) -> tendermint::Signature {
+impl From<Signature> for cometbft::Signature {
+    fn from(sig: Signature) -> cometbft::Signature {
         sig.to_vec().try_into().expect("signature should be valid")
     }
 }

--- a/src/yubihsm.rs
+++ b/src/yubihsm.rs
@@ -23,7 +23,7 @@ use zeroize::Zeroizing;
 #[cfg(not(feature = "yubihsm-mock"))]
 use {
     crate::config::provider::yubihsm::AdapterConfig,
-    tendermint_config::net,
+    cometbft_config::net,
     yubihsm::{device::SerialNumber, HttpConfig, UsbConfig},
 };
 


### PR DESCRIPTION
This PR adds support for CometBFT https://github.com/cometbft/cometbft/releases/tag/v1.0.0. It depends on an unreleased version of [cometbft-rs](https://github.com/cometbft/cometbft-rs/pull/120), the release for which needs to be coordinated with [ICL](https://interchain.io/).

**This feature was verified to work on Injective mainnet.**

It further renames `Tendermint KMS` to `CometBFT KMS` because [the former](https://github.com/tendermint/tendermint) is no longer maintained.

Also

- the support for `CosmosJson` is dropped because `cosmjs` needs to be updated to work with cometbft-rs keys.
- `skip_extension_signing` attribute is ignored, but should be respected.