### PR TITLE
tmkms-p2p: remove `flex-error` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,17 +822,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
 dependencies = [
- "eyre",
  "paste",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "spin",
 ]
 
 [[package]]
@@ -1458,16 +1448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,12 +2001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "sdkms"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,15 +2261,6 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]
@@ -2623,9 +2588,6 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek-ng",
  "ed25519-consensus",
- "eyre",
- "flex-error",
- "flume",
  "hkdf",
  "merlin",
  "prost",

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -4,8 +4,10 @@ use std::{net::TcpStream, path::PathBuf, time::Duration};
 
 use subtle::ConstantTimeEq;
 use tendermint::node;
-use tmkms_p2p::error::ErrorDetail as TmError;
-use tmkms_p2p::secret_connection::{PublicKey, SecretConnection};
+use tmkms_p2p::{
+    self as p2p,
+    secret_connection::{PublicKey, SecretConnection},
+};
 
 use crate::{
     error::{Error, ErrorKind::*},
@@ -43,10 +45,10 @@ pub fn open_secret_connection(
 
     let connection = match SecretConnection::new(socket, identity_key.into()) {
         Ok(conn) => conn,
-        Err(error) => match error.detail() {
-            TmError::Crypto(_) => fail!(CryptoError, format!("{error}")),
-            TmError::Protocol(_) => fail!(ProtocolError, format!("{error}")),
-            TmError::InvalidKey(_) => fail!(InvalidKey, format!("{error}")),
+        Err(error) => match error {
+            p2p::Error::Crypto => fail!(CryptoError, format!("{error}")),
+            p2p::Error::Protocol => fail!(ProtocolError, format!("{error}")),
+            p2p::Error::InvalidKey => fail!(InvalidKey, format!("{error}")),
             _ => fail!(ProtocolError, format!("{error}")),
         },
     };

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -20,25 +20,19 @@ description = """
     The Tendermint P2P stack in Rust.
     """
 
-[features]
-default = ["flex-error/std", "flex-error/eyre_tracer"]
-
 [dependencies]
 chacha20poly1305 = { version = "0.10", default-features = false, features = ["reduced-round"] }
 curve25519-dalek-ng = { version = "4", default-features = false }
 ed25519-consensus = { version = "2", default-features = false }
-eyre = { version = "0.6", default-features = false }
-flume = { version = "0.11.0", default-features = false }
 hkdf = { version = "0.12.3", default-features = false }
 merlin = { version = "3", default-features = false }
-prost = { version = "0.13", default-features = false }
+prost = { version = "0.13", default-features = false, features = ["std"] }
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
 signature = { version = "2", default-features = false }
 aead = { version = "0.5", default-features = false }
-flex-error = { version = "0.4.4", default-features = false }
 tendermint = { version = "0.40.4", default-features = false }
 tendermint-proto = { version = "0.40.4", default-features = false }
 tendermint-std-ext = { version = "0.40.4", default-features = false }

--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -1,69 +1,109 @@
 //! Error types
 
-// Related to the `Error` definition below.
-// TODO(soares): Update flex-error accordingly to address this.
-#![allow(clippy::use_self)]
+use std::fmt::{self, Display};
 
-use flex_error::{DisplayOnly, define_error};
-use prost::DecodeError;
+/// Result type for the `tmkms-p2p` crate.
+pub type Result<T> = std::result::Result<T, Error>;
 
-define_error! {
-    Error {
-        Crypto
-            | _ | { "cryptographic error" },
+/// Error type
+#[derive(Debug)]
+pub enum Error {
+    /// Cryptographic error
+    Crypto,
 
-        InvalidKey
-            | _ | { "invalid key" },
+    /// Invalid key
+    InvalidKey,
 
-        LowOrderKey
-            | _ | { "low-order points found (potential MitM attack!)" },
+    /// Low-order points found. Possible man-in-the-middle attack!
+    LowOrderKey,
 
-        Protocol
-            | _ | { "protocol error" },
+    /// Protocol error
+    Protocol,
 
-        MalformedHandshake
-            | _ | { "malformed handshake message (protocol version mismatch?)" },
+    /// Malformed handshake message. Possible protocol version mismatch.
+    MalformedHandshake,
 
-        Io
-            [ DisplayOnly<std::io::Error> ]
-            | _ | { "io error" },
+    /// I/O error
+    Io(std::io::Error),
 
-        Decode
-            [ DisplayOnly<DecodeError> ]
-            | _ | { "malformed handshake message (protocol version mismatch?)" },
+    /// Protobuf decode message
+    Decode(prost::DecodeError),
 
-        MissingSecret
-            | _ | { "missing secret: forgot to call Handshake::new?" },
+    /// Missing secret. Possibly forgot to call `Handshake::new`?
+    MissingSecret,
 
-        MissingKey
-            | _ | { "public key missing" },
+    /// Public key missing
+    MissingKey,
 
-        Signature
-            | _ | { "signature error" },
+    /// Signature error
+    Signature,
 
-        UnsupportedKey
-            | _ | { "secp256k1 is not supported" },
+    /// Key type supported (e.g. secp256k1)
+    UnsupportedKey,
 
-        Aead
-            [ DisplayOnly<aead::Error> ]
-            | _ | { "aead error" },
+    /// AEAD encryption error
+    Aead,
 
-        ShortCiphertext
-            { tag_size: usize }
-            | _ | { "ciphertext must be at least as long as a MAC tag" },
+    /// Ciphertext must be at least as long as a MAC tag
+    ShortCiphertext {
+        /// Actual tag size encountered
+        tag_size: usize,
+    },
 
-        SmallOutputBuffer
-            | _ | { "output buffer is too small" },
+    /// Output buffer is too small
+    SmallOutputBuffer,
 
-        TransportClone
-            { detail: String }
-            | _ | { "failed to clone underlying transport" }
+    /// Failed to clone underlying transport
+    TransportClone,
+}
 
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Crypto => f.write_str("cryptographic error"),
+            Self::InvalidKey => f.write_str("invalid key"),
+            Self::LowOrderKey => f.write_str("low-order points found (potential MitM attack!)"),
+            Self::Protocol => f.write_str("protocol error"),
+            Self::MalformedHandshake => {
+                f.write_str("malformed handshake message (protocol version mismatch?)")
+            }
+            Self::Io(_) => f.write_str("I/O error"),
+            Self::Decode(_) => f.write_str("malformed protocol message (version mismatch?)"),
+            Self::MissingSecret => f.write_str("missing secret (forgot to call Handshake::new?)"),
+            Self::MissingKey => f.write_str("public key missing"),
+            Self::Signature => f.write_str("signature error"),
+            Self::UnsupportedKey => f.write_str("key type (e.g. secp256k1) is not supported"),
+            Self::Aead => f.write_str("AEAD encryption error"),
+            Self::ShortCiphertext { tag_size } => {
+                write!(
+                    f,
+                    "ciphertext must be at least as long as a MAC tag: {tag_size}"
+                )
+            }
+            Self::SmallOutputBuffer => f.write_str("output buffer is too small"),
+            Self::TransportClone => f.write_str("failed to clone underlying transport"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decode(e) => Some(e),
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<prost::DecodeError> for Error {
+    fn from(e: prost::DecodeError) -> Self {
+        Self::Decode(e)
     }
 }
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
-        Self::io(e)
+        Self::Io(e)
     }
 }

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -21,6 +21,9 @@
     html_logo_url = "https://raw.githubusercontent.com/informalsystems/tendermint-rs/master/img/logo-tendermint-rs_3961x4001.png"
 )]
 
-pub mod error;
 pub mod secret_connection;
 pub mod transport;
+
+mod error;
+
+pub use error::{Error, Result};

--- a/tmkms-p2p/src/secret_connection/protocol.rs
+++ b/tmkms-p2p/src/secret_connection/protocol.rs
@@ -29,7 +29,7 @@ pub fn decode_initial_handshake(bytes: &[u8]) -> Result<EphemeralPublic, Error> 
     // https://github.com/tendermint/tendermint/blob/9e98c74/p2p/conn/secret_connection.go#L315-L323
     // TODO(tarcieri): proper protobuf framing
     if bytes.len() != 34 || bytes[..2] != [0x0a, 0x20] {
-        return Err(Error::malformed_handshake());
+        return Err(Error::MalformedHandshake);
     }
 
     let eph_pubkey_bytes: [u8; 32] = bytes[2..].try_into().expect("framing failed");
@@ -37,7 +37,7 @@ pub fn decode_initial_handshake(bytes: &[u8]) -> Result<EphemeralPublic, Error> 
 
     // Reject the key if it is of low order
     if is_low_order_point(&eph_pubkey) {
-        return Err(Error::low_order_key());
+        return Err(Error::LowOrderKey);
     }
 
     Ok(eph_pubkey)
@@ -81,7 +81,7 @@ pub const AUTH_SIG_MSG_RESPONSE_LEN: usize = 103;
 /// * if the decoding of the bytes fails
 pub fn decode_auth_signature(bytes: &[u8]) -> Result<proto::p2p::AuthSigMessage, Error> {
     // Parse Protobuf-encoded `AuthSigMessage`
-    proto::p2p::AuthSigMessage::decode_length_delimited(bytes).map_err(Error::decode)
+    Ok(proto::p2p::AuthSigMessage::decode_length_delimited(bytes)?)
 }
 
 /// Reject low order points listed on <https://cr.yp.to/ecdh.html>

--- a/tmkms-p2p/src/transport.rs
+++ b/tmkms-p2p/src/transport.rs
@@ -1,9 +1,8 @@
 //! Abstractions that describe types which support the physical transport - i.e. connection
 //! management - used in the p2p stack.
 
+use crate::Result;
 use std::net::{SocketAddr, ToSocketAddrs};
-
-use eyre::Result;
 use tendermint::{node, public_key::PublicKey};
 
 /// Information which resources to bind to and how to identify on the network.
@@ -95,7 +94,7 @@ pub trait Connection: Send {
     fn open_bidirectional(
         &self,
         stream_id: StreamId,
-    ) -> Result<(Self::StreamRead, Self::StreamSend), Self::Error>;
+    ) -> core::result::Result<(Self::StreamRead, Self::StreamSend), Self::Error>;
     /// Public key of the remote peer.
     fn public_key(&self) -> PublicKey;
     /// Local address(es) to the endpoint listens on.


### PR DESCRIPTION
Switches from `flex-error` to a simple `Error` enum