### PR TITLE
tmkms-p2p: error cleanup

### DIFF
--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -4,10 +4,7 @@ use std::{net::TcpStream, path::PathBuf, time::Duration};
 
 use subtle::ConstantTimeEq;
 use tendermint::node;
-use tmkms_p2p::{
-    self as p2p,
-    secret_connection::{PublicKey, SecretConnection},
-};
+use tmkms_p2p::secret_connection::{PublicKey, SecretConnection};
 
 use crate::{
     error::{Error, ErrorKind::*},
@@ -45,12 +42,7 @@ pub fn open_secret_connection(
 
     let connection = match SecretConnection::new(socket, identity_key.into()) {
         Ok(conn) => conn,
-        Err(error) => match error {
-            p2p::Error::Crypto => fail!(CryptoError, format!("{error}")),
-            p2p::Error::Protocol => fail!(ProtocolError, format!("{error}")),
-            p2p::Error::InvalidKey => fail!(InvalidKey, format!("{error}")),
-            _ => fail!(ProtocolError, format!("{error}")),
-        },
+        Err(error) => fail!(ProtocolError, format!("{error}")),
     };
     let actual_peer_id = connection.remote_pubkey().peer_id();
 

--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -8,50 +8,35 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Error type
 #[derive(Debug)]
 pub enum Error {
-    /// Cryptographic error
-    Crypto,
-
-    /// Invalid key
-    InvalidKey,
-
-    /// Low-order points found. Possible man-in-the-middle attack!
-    LowOrderKey,
-
-    /// Protocol error
-    Protocol,
-
-    /// Malformed handshake message. Possible protocol version mismatch.
-    MalformedHandshake,
-
-    /// I/O error
-    Io(std::io::Error),
+    /// Output buffer is too small
+    BufferOverflow,
 
     /// Protobuf decode message
     Decode(prost::DecodeError),
 
-    /// Missing secret. Possibly forgot to call `Handshake::new`?
-    MissingSecret,
+    /// Public key is a low-order-point. Possible man-in-the-middle attack!
+    InsecureKey,
+
+    /// I/O error
+    Io(std::io::Error),
+
+    /// Malformed handshake message. Possible protocol version mismatch.
+    MalformedHandshake,
 
     /// Public key missing
     MissingKey,
 
+    /// Missing secret. Possibly forgot to call `Handshake::new`?
+    MissingSecret,
+
+    /// Packet encryption error. Possible forgery.
+    PacketEncryption,
+
     /// Signature error
-    Signature,
+    SignatureInvalid,
 
     /// Key type supported (e.g. secp256k1)
     UnsupportedKey,
-
-    /// AEAD encryption error
-    Aead,
-
-    /// Ciphertext must be at least as long as a MAC tag
-    ShortCiphertext {
-        /// Actual tag size encountered
-        tag_size: usize,
-    },
-
-    /// Output buffer is too small
-    SmallOutputBuffer,
 
     /// Failed to clone underlying transport
     TransportClone,
@@ -60,27 +45,18 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Crypto => f.write_str("cryptographic error"),
-            Self::InvalidKey => f.write_str("invalid key"),
-            Self::LowOrderKey => f.write_str("low-order points found (potential MitM attack!)"),
-            Self::Protocol => f.write_str("protocol error"),
+            Self::BufferOverflow => f.write_str("output buffer is too small"),
+            Self::Decode(_) => f.write_str("malformed protocol message (version mismatch?)"),
+            Self::InsecureKey => f.write_str("insecure public key (potential MitM attack!)"),
+            Self::Io(_) => f.write_str("I/O error"),
             Self::MalformedHandshake => {
                 f.write_str("malformed handshake message (protocol version mismatch?)")
             }
-            Self::Io(_) => f.write_str("I/O error"),
-            Self::Decode(_) => f.write_str("malformed protocol message (version mismatch?)"),
-            Self::MissingSecret => f.write_str("missing secret (forgot to call Handshake::new?)"),
             Self::MissingKey => f.write_str("public key missing"),
-            Self::Signature => f.write_str("signature error"),
+            Self::MissingSecret => f.write_str("missing secret (forgot to call Handshake::new?)"),
+            Self::PacketEncryption => f.write_str("packet encryption error (forget packet?)"),
+            Self::SignatureInvalid => f.write_str("signature error"),
             Self::UnsupportedKey => f.write_str("key type (e.g. secp256k1) is not supported"),
-            Self::Aead => f.write_str("AEAD encryption error"),
-            Self::ShortCiphertext { tag_size } => {
-                write!(
-                    f,
-                    "ciphertext must be at least as long as a MAC tag: {tag_size}"
-                )
-            }
-            Self::SmallOutputBuffer => f.write_str("output buffer is too small"),
             Self::TransportClone => f.write_str("failed to clone underlying transport"),
         }
     }
@@ -96,6 +72,7 @@ impl std::error::Error for Error {
     }
 }
 
+// TODO(tarcieri): avoid leaking `prost::DecodeError` in public API?
 impl From<prost::DecodeError> for Error {
     fn from(e: prost::DecodeError) -> Self {
         Self::Decode(e)

--- a/tmkms-p2p/src/secret_connection/protocol.rs
+++ b/tmkms-p2p/src/secret_connection/protocol.rs
@@ -37,7 +37,7 @@ pub fn decode_initial_handshake(bytes: &[u8]) -> Result<EphemeralPublic, Error> 
 
     // Reject the key if it is of low order
     if is_low_order_point(&eph_pubkey) {
-        return Err(Error::LowOrderKey);
+        return Err(Error::InsecureKey);
     }
 
     Ok(eph_pubkey)


### PR DESCRIPTION
Removes unused error variants and reorders them to be alphabetical