### PR TITLE
Warn about `protocol_version` field in tmkms.toml

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,10 +1,8 @@
 //! Connections to a validator (TCP or Unix socket)
 
-use std::io;
-
-use tmkms_p2p::SecretConnection;
-
 use self::unix::UnixConnection;
+use std::io;
+use tmkms_p2p::SecretConnection;
 
 pub mod tcp;
 pub mod unix;

--- a/src/session.rs
+++ b/src/session.rs
@@ -26,6 +26,13 @@ pub struct Session {
 impl Session {
     /// Open a session using the given validator configuration
     pub fn open(config: ValidatorConfig) -> Result<Self, Error> {
+        if config.protocol_version.is_some() {
+            warn!(
+                "[{}]: deprecated `protocol_version` field in config! Will be a hard error in next release",
+                &config.chain_id,
+            );
+        }
+
         let connection: Box<dyn Connection> = match &config.addr {
             net::Address::Tcp {
                 peer_id,


### PR DESCRIPTION
Support for legacy (amino) protocol versions was removed in #985.

This field is no longer needed but preserved for backwards compatibility, so long as it's set to "v0.34".

However, this adds a warning to remove the configuration now that the setting is no longer needed or useful.