### PR TITLE
v0.15.0-pre.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2536,7 +2536,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tmkms"
-version = "0.15.0-pre"
+version = "0.15.0-pre.0"
 dependencies = [
  "abscissa_core",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Tendermint Key Management System: provides isolated, optionally HSM-backed
 signing key management for Tendermint applications including validators,
 oracles, IBC relayers, and other transaction signing applications
 """
-version = "0.15.0-pre"
+version = "0.15.0-pre.0"
 authors = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms/"


### PR DESCRIPTION
Initial prerelease of the v0.15 series.

This includes a migration to `tmkms-p2p`, `ed25519-dalek`, as well as upgrades to `tendermint-rs`, `prost`, and `abscissa` (real CHANGELOG coming with the final release)