### PR TITLE
tmkms-p2p: vendor `TryClone` from `tendermint-std-ext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,12 +2423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint-std-ext"
-version = "0.40.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298e90b07eab583fdf4829f4b1b85f0405ea3bfdd3154287064ac8507d3969f1"
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,7 +2590,6 @@ dependencies = [
  "subtle",
  "tendermint",
  "tendermint-proto",
- "tendermint-std-ext",
  "zeroize",
 ]
 

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -30,5 +30,4 @@ signature = { version = "2", default-features = false }
 subtle = { version = "2", default-features = false }
 tendermint = { version = "0.40.4", default-features = false }
 tendermint-proto = { version = "0.40.4", default-features = false }
-tendermint-std-ext = { version = "0.40.4", default-features = false }
 zeroize = { version = "1", default-features = false }

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -5,6 +5,7 @@ use crate::{
     handshake::Handshake,
     proto, protocol,
     state::{ReceiveState, SendState},
+    transport::TryClone,
 };
 use curve25519_dalek::montgomery::MontgomeryPoint as EphemeralPublic;
 use std::{
@@ -15,7 +16,6 @@ use std::{
         atomic::{AtomicBool, Ordering},
     },
 };
-use tendermint_std_ext::TryClone;
 
 #[cfg(doc)]
 use crate::DATA_MAX_SIZE;
@@ -50,16 +50,15 @@ macro_rules! checked_io {
 /// read or write failure occurs, it is necessary to disconnect from the remote
 /// peer and attempt to reconnect.
 ///
-/// ## Half- and full-duplex connections
+/// ## Half and full-duplex connections
 /// By default, a `SecretConnection` facilitates half-duplex operations (i.e.
 /// one can either read from the connection or write to it at a given time, but
 /// not both simultaneously).
 ///
-/// If, however, the underlying I/O handler class implements
-/// [`tendermint_std_ext::TryClone`], then you can use
-/// [`SecretConnection::split`] to split the `SecretConnection` into its
-/// sending and receiving halves. Each of these halves can then be used in a
-/// separate thread to facilitate full-duplex communication.
+/// If, however, the underlying I/O handler class implements [`TryClone`], then you can use
+/// [`SecretConnection::split`] to split the `SecretConnection` into sending and receiving halves.
+///
+/// Each of these halves can then be used in a separate thread to facilitate full-duplex communication.
 ///
 /// ## Contracts
 ///

--- a/tmkms-p2p/src/transport.rs
+++ b/tmkms-p2p/src/transport.rs
@@ -2,6 +2,7 @@
 //! management - used in the p2p stack.
 
 use crate::Result;
+use std::net::TcpStream;
 use std::net::{SocketAddr, ToSocketAddrs};
 use tendermint::{node, public_key::PublicKey};
 
@@ -139,4 +140,28 @@ where
     ///
     /// * If resource allocation fails for lack of privileges or being not available.
     fn bind(self, bind_info: BindInfo<A>) -> Result<(Self::Endpoint, Self::Incoming)>;
+}
+
+/// Types that can be cloned where success is not guaranteed can implement this
+/// trait.
+pub trait TryClone: Sized {
+    /// The type of error that can be returned when an attempted clone
+    /// operation fails.
+    type Error: std::error::Error;
+
+    /// Attempt to clone this instance.
+    ///
+    /// # Errors
+    /// Can fail if the underlying instance cannot be cloned (e.g. the OS could
+    /// be out of file descriptors, or some low-level OS-specific error could
+    /// be produced).
+    fn try_clone(&self) -> std::result::Result<Self, Self::Error>;
+}
+
+impl TryClone for TcpStream {
+    type Error = std::io::Error;
+
+    fn try_clone(&self) -> std::result::Result<Self, Self::Error> {
+        TcpStream::try_clone(self)
+    }
 }


### PR DESCRIPTION
...and drop the crate dependency.

It's currently only impl'd for `TcpStream` anyway, so we can probably just change `split` to work with `TcpStream` as a concrete type.