### PR TITLE
tmkms-p2p: remove `TryClone`

### DIFF
--- a/tmkms-p2p/src/transport.rs
+++ b/tmkms-p2p/src/transport.rs
@@ -2,7 +2,6 @@
 //! management - used in the p2p stack.
 
 use crate::Result;
-use std::net::TcpStream;
 use std::net::{SocketAddr, ToSocketAddrs};
 use tendermint::{node, public_key::PublicKey};
 
@@ -140,28 +139,4 @@ where
     ///
     /// * If resource allocation fails for lack of privileges or being not available.
     fn bind(self, bind_info: BindInfo<A>) -> Result<(Self::Endpoint, Self::Incoming)>;
-}
-
-/// Types that can be cloned where success is not guaranteed can implement this
-/// trait.
-pub trait TryClone: Sized {
-    /// The type of error that can be returned when an attempted clone
-    /// operation fails.
-    type Error: std::error::Error;
-
-    /// Attempt to clone this instance.
-    ///
-    /// # Errors
-    /// Can fail if the underlying instance cannot be cloned (e.g. the OS could
-    /// be out of file descriptors, or some low-level OS-specific error could
-    /// be produced).
-    fn try_clone(&self) -> std::result::Result<Self, Self::Error>;
-}
-
-impl TryClone for TcpStream {
-    type Error = std::io::Error;
-
-    fn try_clone(&self) -> std::result::Result<Self, Self::Error> {
-        TcpStream::try_clone(self)
-    }
 }


### PR DESCRIPTION
Makes `SecretConnection::split` a method on `SectretConnection<TcpStream>`.

The `TryClone` trait was only impl'd for `TcpStream` anyway, so this is functionally equivalent.