### PR TITLE
tmkms-p2p: namespace fixups

### DIFF
--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -27,7 +27,8 @@ pub use crate::{
     secret_connection::SecretConnection,
 };
 
-pub(crate) use tendermint_proto::v0_38 as proto;
+pub(crate) use ed25519_dalek as ed25519;
+pub(crate) use tendermint_proto::v0_38 as protobuf;
 
 /// Maximum size of a message
 pub const DATA_MAX_SIZE: usize = 1024;

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -3,7 +3,7 @@
 use crate::{
     Error, PublicKey, Result,
     handshake::Handshake,
-    proto, protocol,
+    protobuf, protocol,
     state::{ReceiveState, SendState},
 };
 use curve25519_dalek::montgomery::MontgomeryPoint as EphemeralPublic;
@@ -130,7 +130,7 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
         &mut self,
         pubkey: &ed25519_dalek::VerifyingKey,
         local_signature: &ed25519_dalek::Signature,
-    ) -> Result<proto::p2p::AuthSigMessage> {
+    ) -> Result<protobuf::p2p::AuthSigMessage> {
         /// Length of the auth message response
         // 32 + 64 + (proto overhead = 1 prefix + 2 fields + 2 lengths + total length)
         const AUTH_SIG_MSG_RESPONSE_LEN: usize = 103;


### PR DESCRIPTION
- Re-export protos as `protobuf` to prevent confusion with `protocol`
- Use `ed25519` as namespace for Ed25519 types