### PR TITLE
tmkms-p2p: use clamped scalar mul for X25519

### DIFF
--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -20,7 +20,7 @@ authors = [
 aead = { version = "0.5", default-features = false }
 chacha20poly1305 = { version = "0.10", default-features = false }
 curve25519-dalek = { version = "4", default-features = false, features = ["rand_core"] }
-ed25519-dalek = { version = "2", default-features = false }
+ed25519-dalek = { version = "2", default-features = false, features = ["zeroize"] }
 hkdf = { version = "0.12.3", default-features = false }
 merlin = { version = "3", default-features = false }
 prost = { version = "0.13", default-features = false, features = ["std"] }


### PR DESCRIPTION
Uses `curve25519-dalek`'s clamped APIs for implementing X25519.

This follows the behavior of `x25519-dalek`