### PR TITLE
tmkms-p2p: add fully deterministic handshake test vectors

### DIFF
--- a/tmkms-p2p/src/protocol.rs
+++ b/tmkms-p2p/src/protocol.rs
@@ -5,6 +5,10 @@ use curve25519_dalek::montgomery::MontgomeryPoint as EphemeralPublic;
 use prost::Message as _;
 use tendermint_proto::v0_38 as proto;
 
+/// Length of the auth message response
+// 32 + 64 + (proto overhead = 1 prefix + 2 fields + 2 lengths + total length)
+pub(crate) const AUTH_SIG_MSG_RESPONSE_LEN: usize = 103;
+
 /// Encode the initial handshake message (i.e. first one sent by both peers)
 #[must_use]
 pub(crate) fn encode_initial_handshake(eph_pubkey: &EphemeralPublic) -> Vec<u8> {

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -131,14 +131,10 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
         pubkey: &ed25519_dalek::VerifyingKey,
         local_signature: &ed25519_dalek::Signature,
     ) -> Result<protobuf::p2p::AuthSigMessage> {
-        /// Length of the auth message response
-        // 32 + 64 + (proto overhead = 1 prefix + 2 fields + 2 lengths + total length)
-        const AUTH_SIG_MSG_RESPONSE_LEN: usize = 103;
-
         let buf = protocol::encode_auth_signature(pubkey, local_signature);
         self.write_all(&buf)?;
 
-        let mut buf = [0u8; AUTH_SIG_MSG_RESPONSE_LEN];
+        let mut buf = [0u8; protocol::AUTH_SIG_MSG_RESPONSE_LEN];
         self.read_exact(&mut buf)?;
         protocol::decode_auth_signature(&buf)
     }


### PR DESCRIPTION
Adds test vectors for "ephemeral" secrets and the serialized `protobuf::p2p::AuthSigMessage`.

The test vectors were tested using the existing state of the current implementation, which itself has been live tested against multiple validator nodes successfully. So, it's more or less a regression test that future changes don't break the handshake.