### PR TITLE
tmkms-p2p: extract a `CipherState` struct

### DIFF
--- a/tmkms-p2p/src/kdf.rs
+++ b/tmkms-p2p/src/kdf.rs
@@ -1,3 +1,5 @@
+//! Key Derivation Function
+
 use hkdf::Hkdf;
 use sha2::Sha256;
 use zeroize::Zeroize;


### PR DESCRIPTION
This is partially inspired by the similar named concept from the Noise Protocol:

https://noiseprotocol.org/noise.html#the-cipherstate-object