### PR TITLE
tmkms-p2p: add delegated reader/writer methods to `CipherState`

### DIFF
--- a/tmkms-p2p/src/handshake.rs
+++ b/tmkms-p2p/src/handshake.rs
@@ -112,7 +112,7 @@ impl Handshake<AwaitingEphKey> {
         let loc_is_least = local_eph_pubkey_bytes == low_eph_pubkey_bytes;
 
         let kdf = Kdf::derive_secrets_and_challenge(shared_secret.as_bytes(), loc_is_least);
-        let cipher_state = CipherState::from(&kdf);
+        let cipher_state = CipherState::new(&kdf);
 
         let mut sc_mac: [u8; 32] = [0; 32];
         transcript.challenge_bytes(b"SECRET_CONNECTION_MAC", &mut sc_mac);

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -181,7 +181,6 @@ impl<IoHandler: Read> Read for SecretConnection<IoHandler> {
         checked_io!(
             self.terminate,
             self.cipher_state
-                .recv_state
                 .read_and_decrypt(&mut self.io_handler, data)
         )
     }
@@ -192,7 +191,6 @@ impl<IoHandler: Write> Write for SecretConnection<IoHandler> {
         checked_io!(
             self.terminate,
             self.cipher_state
-                .send_state
                 .encrypt_and_write(&mut self.io_handler, data)
         )
     }


### PR DESCRIPTION
Removes a bit of indirection