### PR TITLE
tmkms-p2p: add `ReadFrame` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,6 +2584,7 @@ name = "tmkms-p2p"
 version = "0.2.0-pre"
 dependencies = [
  "aead",
+ "bytes",
  "chacha20poly1305",
  "curve25519-dalek",
  "ed25519-dalek",

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,10 @@ pub enum ErrorKind {
     #[error("config error")]
     ConfigError,
 
+    /// Connection errors (i.e. SecretConnection "P2P") errors.
+    #[error("connection error")]
+    ConnectionError,
+
     /// Cryptographic operation failed
     #[error("cryptographic error")]
     CryptoError,
@@ -193,6 +197,12 @@ impl From<signature::Error> for Error {
 impl From<tendermint::Error> for Error {
     fn from(other: tendermint::error::Error) -> Self {
         ErrorKind::TendermintError.context(other).into()
+    }
+}
+
+impl From<tmkms_p2p::Error> for Error {
+    fn from(other: tmkms_p2p::Error) -> Self {
+        ErrorKind::ConnectionError.context(other).into()
     }
 }
 

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -18,6 +18,7 @@ authors = [
 
 [dependencies]
 aead = { version = "0.5", default-features = false }
+bytes = "1"
 chacha20poly1305 = { version = "0.10", default-features = false }
 curve25519-dalek = { version = "4", default-features = false, features = ["rand_core"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["zeroize"] }

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -21,7 +21,7 @@ mod secret_connection;
 pub use crate::{
     error::{Error, Result},
     public_key::PublicKey,
-    secret_connection::SecretConnection,
+    secret_connection::{ReadFrame, SecretConnection},
 };
 
 pub(crate) use ed25519_dalek as ed25519;


### PR DESCRIPTION
Adds a trait for moving buffer allocation for frames to `tmkms-p2p`, rather than having tmkms allocate the buffer.

This is a bit awkward and it would be nice if it could just be an inherent method on `SecretConnection` instead, but this fits within the somewhat awkward abstractions that are currently in place to support Unix sockets in addition to SecretConnection.

(Ideally we'd just take separate I/O paths for SecretConnection vs Unix sockets, or just drop support for Unix sockets entirely)

Uses `Bytes` as the return type, introducing `bytes` as a dependency. This is more interesting for forthcoming async support, but we can use it in both places.