### PR TITLE
tmkms-p2p: remove `tendermint` crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,6 @@ dependencies = [
  "sha2 0.10.9",
  "signature",
  "subtle",
- "tendermint",
  "tendermint-proto",
  "zeroize",
 ]

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -48,14 +48,19 @@ pub fn open_secret_connection(
 
     // TODO(tarcieri): move this into `SecretConnection::new`
     if let Some(expected_peer_id) = peer_id {
-        if expected_peer_id.ct_eq(&actual_peer_id).unwrap_u8() == 0 {
+        if expected_peer_id
+            .as_bytes()
+            .ct_eq(&actual_peer_id)
+            .unwrap_u8()
+            == 0
+        {
             fail!(
                 VerificationError,
                 "{}:{}: validator peer ID mismatch! (expected {}, got {})",
                 host,
                 port,
                 expected_peer_id,
-                actual_peer_id
+                node::Id::new(actual_peer_id)
             );
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,7 +10,7 @@ use crate::{
     rpc::{Request, Response},
 };
 use std::{os::unix::net::UnixStream, time::Instant};
-use tendermint::{TendermintKey, consensus};
+use tendermint::{TendermintKey, consensus, node};
 use tendermint_config::net;
 use tendermint_proto as proto;
 
@@ -63,7 +63,7 @@ impl Session {
                         "[{}@{}]: unverified validator peer ID! ({})",
                         &config.chain_id,
                         &config.addr,
-                        conn.remote_pubkey().peer_id()
+                        node::Id::new(conn.remote_pubkey().peer_id())
                     );
                 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,6 +14,7 @@ use std::{
     process::{Child, Command},
 };
 use tempfile::NamedTempFile;
+use tendermint::node;
 use tendermint_proto as proto;
 use tmkms::{
     config::provider::KeyType,
@@ -152,7 +153,7 @@ impl KmsProcess {
             path = "{}"
             key_type = "{}"
         "#,
-            &peer_id.to_string(), port, signing_key_path(key_type), key_type
+            node::Id::new(peer_id).to_string(), port, signing_key_path(key_type), key_type
         )
             .unwrap();
 

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -28,7 +28,6 @@ rand_core = { version = "0.6", default-features = false, features = ["std"] }
 sha2 = { version = "0.10", default-features = false }
 signature = { version = "2", default-features = false }
 subtle = { version = "2", default-features = false }
-tendermint = { version = "0.40.4", default-features = false }
 tendermint-proto = { version = "0.40.4", default-features = false }
 zeroize = { version = "1", default-features = false }
 

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -20,7 +20,7 @@ mod secret_connection;
 
 pub use crate::{
     error::{Error, Result},
-    public_key::PublicKey,
+    public_key::{PeerId, PublicKey},
     secret_connection::SecretConnection,
 };
 

--- a/tmkms-p2p/src/public_key.rs
+++ b/tmkms-p2p/src/public_key.rs
@@ -1,16 +1,17 @@
-//! Secret Connection peer public keys
+//! Secret Connection peer identity public keys.
 
-use std::fmt::{self, Display};
-
-use crate::{Error, Result};
+use crate::{Error, Result, ed25519};
 use sha2::{Sha256, digest::Digest};
-use tendermint::node;
+use std::fmt::{self, Debug, Display};
 
-/// Secret Connection peer public keys (signing, presently Ed25519-only)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+/// Secret Connection Peer IDs.
+pub type PeerId = [u8; 20];
+
+/// Secret Connection peer identity public keys (signing, presently Ed25519-only)
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub enum PublicKey {
     /// Ed25519 Secret Connection Keys
-    Ed25519(ed25519_dalek::VerifyingKey),
+    Ed25519(ed25519::VerifyingKey),
 }
 
 impl PublicKey {
@@ -20,28 +21,28 @@ impl PublicKey {
     ///
     /// * if the bytes given are invalid
     pub fn from_raw_ed25519(bytes: &[u8]) -> Result<Self> {
-        ed25519_dalek::VerifyingKey::try_from(bytes)
+        ed25519::VerifyingKey::try_from(bytes)
             .map(Self::Ed25519)
             .map_err(|_| Error::SignatureInvalid)
     }
 
-    /// Get Ed25519 public key
+    /// Get Ed25519 public key.
     #[must_use]
-    pub fn ed25519(self) -> Option<ed25519_dalek::VerifyingKey> {
+    pub fn ed25519(self) -> Option<ed25519::VerifyingKey> {
         match self {
             Self::Ed25519(pk) => Some(pk),
         }
     }
 
-    /// Get the remote Peer ID
+    /// Get the remote [`PeerId`].
+    ///
+    /// This is a 20-byte fingerprint of the public key.
     #[must_use]
-    pub fn peer_id(self) -> node::Id {
+    pub fn peer_id(self) -> PeerId {
         match self {
             Self::Ed25519(pk) => {
                 let digest = Sha256::digest(pk.as_bytes());
-                let mut bytes = [0_u8; 20];
-                bytes.copy_from_slice(&digest[..20]);
-                node::Id::new(bytes)
+                digest[..20].try_into().expect("should be 20 bytes")
             }
         }
     }
@@ -49,18 +50,29 @@ impl PublicKey {
 
 impl Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.peer_id())
+        for byte in self.peer_id() {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
     }
 }
 
-impl From<&ed25519_dalek::SigningKey> for PublicKey {
-    fn from(sk: &ed25519_dalek::SigningKey) -> Self {
+impl Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PublicKey::Ed25519(_) => write!(f, "PublicKey::Ed25519({self})"),
+        }
+    }
+}
+
+impl From<&ed25519::SigningKey> for PublicKey {
+    fn from(sk: &ed25519::SigningKey) -> Self {
         Self::Ed25519(sk.verifying_key())
     }
 }
 
-impl From<ed25519_dalek::VerifyingKey> for PublicKey {
-    fn from(pk: ed25519_dalek::VerifyingKey) -> Self {
+impl From<ed25519::VerifyingKey> for PublicKey {
+    fn from(pk: ed25519::VerifyingKey) -> Self {
         Self::Ed25519(pk)
     }
 }

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -53,10 +53,11 @@ macro_rules! checked_io {
 /// one can either read from the connection or write to it at a given time, but
 /// not both simultaneously).
 ///
-/// If, however, the underlying I/O handler class implements [`TryClone`], then you can use
+/// If, however, the underlying I/O handler is a [`TcpStream`], then you can use
 /// [`SecretConnection::split`] to split the `SecretConnection` into sending and receiving halves.
 ///
-/// Each of these halves can then be used in a separate thread to facilitate full-duplex communication.
+/// Each of these halves can then be used in a separate thread to facilitate full-duplex
+/// communication.
 ///
 /// ## Contracts
 ///


### PR DESCRIPTION
It was only used for `tendermint::node::Id`, which we can just as easily represent as `[u8; 20]`.

This should ease a migration to `cometbft-rs`.