### PR TITLE
tmkms-p2p: `ReadMsg`/`WriteMsg` traits

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,10 @@ pub enum ErrorKind {
     #[error("config error")]
     ConfigError,
 
+    /// Error in validator connection
+    #[error("connection error")]
+    ConnectionError,
+
     /// Cryptographic operation failed
     #[error("cryptographic error")]
     CryptoError,
@@ -193,6 +197,12 @@ impl From<signature::Error> for Error {
 impl From<tendermint::Error> for Error {
     fn from(other: tendermint::error::Error) -> Self {
         ErrorKind::TendermintError.context(other).into()
+    }
+}
+
+impl From<tmkms_p2p::Error> for Error {
+    fn from(other: tmkms_p2p::Error) -> Self {
+        ErrorKind::ConnectionError.context(other).into()
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -13,6 +13,7 @@ use std::{os::unix::net::UnixStream, time::Instant};
 use tendermint::{TendermintKey, consensus, node};
 use tendermint_config::net;
 use tendermint_proto as proto;
+use tmkms_p2p::WriteMsg;
 
 /// Encrypted session with a validator node
 pub struct Session {
@@ -122,9 +123,7 @@ impl Session {
             &self.config.chain_id, &self.config.addr, &response
         );
 
-        let response_bytes = response.encode()?;
-        self.connection.write_all(&response_bytes)?;
-
+        self.connection.write_msg(&response.to_proto())?;
         Ok(true)
     }
 

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -15,11 +15,13 @@ mod error;
 mod framing;
 mod handshake;
 mod kdf;
+mod msg_traits;
 mod public_key;
 mod secret_connection;
 
 pub use crate::{
     error::{Error, Result},
+    msg_traits::{ReadMsg, WriteMsg},
     public_key::{PeerId, PublicKey},
     secret_connection::SecretConnection,
 };

--- a/tmkms-p2p/src/msg_traits.rs
+++ b/tmkms-p2p/src/msg_traits.rs
@@ -1,0 +1,55 @@
+//! Helper traits for reading and writing Protobuf messages.
+
+use crate::{DATA_MAX_SIZE, Result};
+use prost::Message;
+use std::io::{Read, Write};
+
+/// Read the given Protobuf message from the underlying I/O object.
+pub trait ReadMsg {
+    /// Read from the underlying I/O object, decoding (and if necessary decrypting) the data
+    /// to the given Protobuf message.
+    fn read_msg<M: Message + Default>(&mut self) -> Result<M>;
+}
+
+/// Write the given Protobuf message to the underlying I/O object.
+pub trait WriteMsg {
+    /// Encode the given Protobuf as bytes and write them to the underlying I/O object
+    /// (and encrypting if necessary).
+    fn write_msg<M: Message>(&mut self, msg: &M) -> Result<()>;
+}
+
+impl<IoHandler: Read> ReadMsg for IoHandler {
+    fn read_msg<M: Message + Default>(&mut self) -> Result<M> {
+        let mut msg_bytes = Vec::with_capacity(DATA_MAX_SIZE);
+
+        // Read the input incrementally, speculatively decoding it as the given Protobuf message
+        // TODO(tarcieri): consume the length prefix and use it to inform message buffering
+        loop {
+            // Read a chunk and add it to the
+            let mut chunk = [0; DATA_MAX_SIZE];
+            let nbytes = self.read(&mut chunk)?;
+            msg_bytes.extend_from_slice(&chunk[..nbytes]);
+
+            // if we can decode it, great, break the loop
+            match M::decode_length_delimited(msg_bytes.as_ref()) {
+                Ok(m) => return Ok(m),
+                Err(e) => {
+                    // if chunk_len < DATA_MAX_SIZE (1024) we assume it was the end of the message
+                    // and it is malformed
+                    if nbytes < DATA_MAX_SIZE {
+                        return Err(e.into());
+                    }
+                    // otherwise, we go to start of the loop assuming next chunk(s)
+                    // will fill the message
+                }
+            }
+        }
+    }
+}
+
+impl<IoHandler: Write> WriteMsg for IoHandler {
+    fn write_msg<M: Message>(&mut self, msg: &M) -> Result<()> {
+        let bytes = msg.encode_length_delimited_to_vec();
+        Ok(self.write_all(&bytes)?)
+    }
+}


### PR DESCRIPTION
Adds a set of helper traits for reading/writing Protobuf messages to underling I/O objects, including `SecretConnection`.