### PR TITLE
tmkms-p2p: opaque `CryptoError`

### DIFF
--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -11,11 +11,11 @@ pub enum Error {
     /// Output buffer is too small
     BufferOverflow,
 
+    /// Cryptographic errors
+    Crypto(CryptoError),
+
     /// Protobuf decode message
     Decode(prost::DecodeError),
-
-    /// Public key is a low-order-point. Possible man-in-the-middle attack!
-    InsecureKey,
 
     /// I/O error
     Io(std::io::Error),
@@ -29,12 +29,6 @@ pub enum Error {
     /// Missing secret. Possibly forgot to call `Handshake::new`?
     MissingSecret,
 
-    /// Packet encryption error. Possible forgery.
-    PacketEncryption,
-
-    /// Signature error
-    SignatureInvalid,
-
     /// Key type supported (e.g. secp256k1)
     UnsupportedKey,
 
@@ -46,16 +40,14 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::BufferOverflow => f.write_str("output buffer is too small"),
+            Self::Crypto(_) => f.write_str("cryptographic error"),
             Self::Decode(_) => f.write_str("malformed protocol message (version mismatch?)"),
-            Self::InsecureKey => f.write_str("insecure public key (potential MitM attack!)"),
             Self::Io(_) => f.write_str("I/O error"),
             Self::MalformedHandshake => {
                 f.write_str("malformed handshake message (protocol version mismatch?)")
             }
             Self::MissingKey => f.write_str("public key missing"),
             Self::MissingSecret => f.write_str("missing secret (forgot to call Handshake::new?)"),
-            Self::PacketEncryption => f.write_str("packet encryption error (forget packet?)"),
-            Self::SignatureInvalid => f.write_str("signature error"),
             Self::UnsupportedKey => f.write_str("key type (e.g. secp256k1) is not supported"),
             Self::TransportClone => f.write_str("failed to clone underlying transport"),
         }
@@ -65,6 +57,7 @@ impl Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::Crypto(e) => Some(e),
             Self::Decode(e) => Some(e),
             Self::Io(e) => Some(e),
             _ => None,
@@ -83,4 +76,48 @@ impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         Self::Io(e)
     }
+}
+
+/// Opaque type for cryptographic errors which still internally tracks what went wrong for debugging
+/// purposes.
+///
+/// Intentionally kept opaque to reduce potential for sidechannels.
+#[derive(Debug)]
+pub struct CryptoError(pub(crate) InternalCryptoError);
+
+impl CryptoError {
+    pub(crate) const INSECURE_KEY: Self = Self(InternalCryptoError::InsecureKey);
+    pub(crate) const ENCRYPTION: Self = Self(InternalCryptoError::PacketEncryption);
+    pub(crate) const SIGNATURE: Self = Self(InternalCryptoError::SignatureInvalid);
+}
+
+impl Display for CryptoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            InternalCryptoError::InsecureKey => f.write_str("insecure public key (potential MitM attack!)"),
+            InternalCryptoError::PacketEncryption => f.write_str("packet encryption error (forget packet?)"),
+            InternalCryptoError::SignatureInvalid => f.write_str("signature error"),
+        }
+    }
+}
+
+impl From<CryptoError> for Error {
+    fn from(err: CryptoError) -> Self {
+        Error::Crypto(err)
+    }
+}
+
+impl std::error::Error for CryptoError {}
+
+/// Hidden inner type for tracking what type of cryptographic error occurred.
+#[derive(Debug)]
+pub(crate) enum InternalCryptoError {
+    /// Public key is a low-order-point. Possible man-in-the-middle attack!
+    InsecureKey,
+
+    /// Packet encryption error. Possible forgery.
+    PacketEncryption,
+
+    /// Signature error
+    SignatureInvalid,
 }

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -20,7 +20,7 @@ mod public_key;
 mod secret_connection;
 
 pub use crate::{
-    error::{Error, Result},
+    error::{Error, CryptoError, Result},
     msg_traits::{ReadMsg, WriteMsg},
     public_key::{PeerId, PublicKey},
     secret_connection::SecretConnection,

--- a/tmkms-p2p/src/public_key.rs
+++ b/tmkms-p2p/src/public_key.rs
@@ -1,6 +1,6 @@
 //! Secret Connection peer identity public keys.
 
-use crate::{Error, Result, ed25519};
+use crate::{CryptoError, Result, ed25519};
 use sha2::{Sha256, digest::Digest};
 use std::fmt::{self, Debug, Display};
 
@@ -23,7 +23,7 @@ impl PublicKey {
     pub fn from_raw_ed25519(bytes: &[u8]) -> Result<Self> {
         ed25519::VerifyingKey::try_from(bytes)
             .map(Self::Ed25519)
-            .map_err(|_| Error::SignatureInvalid)
+            .map_err(|_| CryptoError::SIGNATURE.into())
     }
 
     /// Get Ed25519 public key.


### PR DESCRIPTION
Prevent possible cryptographic sidechannels by using a common opaque `CryptoError` type for all cryptographic errors.

Internally it keeps track of the specific kind of error for debugging purposes.