### PR TITLE
tmkms-p2p: remove `DATA_MAX_SIZE` constant from public API

### DIFF
--- a/tmkms-p2p/src/encryption.rs
+++ b/tmkms-p2p/src/encryption.rs
@@ -1,8 +1,8 @@
 //! Symmetric encryption.
 
 use crate::{
-    DATA_LEN_SIZE, DATA_MAX_SIZE, Error, Result, TAG_SIZE, TAGGED_FRAME_SIZE, TOTAL_FRAME_SIZE,
-    kdf::Kdf, CryptoError
+    CryptoError, DATA_LEN_SIZE, DATA_MAX_SIZE, Error, Result, TAG_SIZE, TAGGED_FRAME_SIZE,
+    TOTAL_FRAME_SIZE, kdf::Kdf,
 };
 use aead::AeadInPlace;
 use chacha20poly1305::{ChaCha20Poly1305, KeyInit};

--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -94,8 +94,12 @@ impl CryptoError {
 impl Display for CryptoError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            InternalCryptoError::InsecureKey => f.write_str("insecure public key (potential MitM attack!)"),
-            InternalCryptoError::PacketEncryption => f.write_str("packet encryption error (forget packet?)"),
+            InternalCryptoError::InsecureKey => {
+                f.write_str("insecure public key (potential MitM attack!)")
+            }
+            InternalCryptoError::PacketEncryption => {
+                f.write_str("packet encryption error (forget packet?)")
+            }
             InternalCryptoError::SignatureInvalid => f.write_str("signature error"),
         }
     }

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -20,7 +20,7 @@ mod public_key;
 mod secret_connection;
 
 pub use crate::{
-    error::{Error, CryptoError, Result},
+    error::{CryptoError, Error, Result},
     msg_traits::{ReadMsg, WriteMsg},
     public_key::{PeerId, PublicKey},
     secret_connection::SecretConnection,
@@ -31,7 +31,7 @@ pub(crate) use ed25519_dalek as ed25519;
 pub(crate) use tendermint_proto::v0_38 as proto;
 
 /// Maximum size of a message
-pub const DATA_MAX_SIZE: usize = 1024;
+pub(crate) const DATA_MAX_SIZE: usize = 1024;
 
 /// 4 + 1024 == 1028 total frame size
 pub(crate) const DATA_LEN_SIZE: usize = 4;


### PR DESCRIPTION
This is actually the maximum data allowed in an individual frame, which should be an implementation detail end users (no longer) have to care about.