### PR TITLE
tmkms-p2p v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-p2p"
-version = "0.2.0-pre"
+version = "0.2.0"
 dependencies = [
  "aead",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tendermint = { version = "0.40", features = ["secp256k1"] }
 tendermint-config = "0.40"
 tendermint-proto = "0.40"
 thiserror = "1"
-tmkms-p2p = "=0.2.0-pre"
+tmkms-p2p = "0.2"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"

--- a/tmkms-p2p/CHANGELOG.md
+++ b/tmkms-p2p/CHANGELOG.md
@@ -4,5 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2025-08-20)
+### Added
+- `ReadMsg`/`WriteMsg` traits (#1018)
+
+### Changed
+- Replace crypto `Error` variants with opaque `CryptoError` (#1021)
+
+### Removed
+- `transport` module (#1011)
+- `tendermint` crate dependency (#1015)
+- `DATA_MAX_SIZE` constant (#1022)
+
 ## 0.1.0 (2025-08-19)
 - Initial release

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tmkms-p2p"
 description = "Implementation of CometBFT's encrypted P2P protocol"
-version = "0.2.0-pre"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms"


### PR DESCRIPTION
### Added
- `ReadMsg`/`WriteMsg` traits (#1018)

### Changed
- Replace crypto `Error` variants with opaque `CryptoError` (#1021)

### Removed
- `transport` module (#1011)
- `tendermint` crate dependency (#1015)
- `DATA_MAX_SIZE` constant (#1022)