### PR TITLE
tmkms-p2p: use protos in integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,6 +2677,7 @@ dependencies = [
  "merlin",
  "proptest",
  "prost",
+ "prost-derive",
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "signature",

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -35,3 +35,4 @@ proptest = "1.6.0"
 [dev-dependencies]
 hex-literal = "1"
 proptest = "1"
+prost-derive = "0.13"

--- a/tmkms-p2p/src/msg_traits.rs
+++ b/tmkms-p2p/src/msg_traits.rs
@@ -54,3 +54,5 @@ impl<Io: Write> WriteMsg for Io {
         Ok(self.write_all(&bytes)?)
     }
 }
+
+// NOTE: only existing test coverage of these is in `tests/secret_connection.rs`


### PR DESCRIPTION
Uses `prost-derive` to define some basic proto types.

This makes it possible to do at least some basic testing of the `ReadMsg` and `WriteMsg` traits.