### PR TITLE
tmkms-p2p: improved message buffering logic

### DIFF
--- a/tmkms-p2p/src/encryption.rs
+++ b/tmkms-p2p/src/encryption.rs
@@ -1,7 +1,7 @@
 //! Symmetric encryption.
 
 use crate::{
-    CryptoError, DATA_LEN_SIZE, DATA_MAX_SIZE, Error, Result, TAG_SIZE, TAGGED_FRAME_SIZE,
+    CryptoError, Error, FRAME_MAX_SIZE, LENGTH_PREFIX_SIZE, Result, TAG_SIZE, TAGGED_FRAME_SIZE,
     TOTAL_FRAME_SIZE, kdf::Kdf,
 };
 use aead::AeadInPlace;
@@ -53,13 +53,13 @@ impl SendState {
 
         assert!(!chunk.is_empty(), "chunk is empty");
         assert!(
-            chunk.len() <= TOTAL_FRAME_SIZE - DATA_LEN_SIZE,
+            chunk.len() <= TOTAL_FRAME_SIZE - LENGTH_PREFIX_SIZE,
             "chunk is too big: {}! max: {}",
             chunk.len(),
-            DATA_MAX_SIZE,
+            FRAME_MAX_SIZE,
         );
-        sealed_frame[..DATA_LEN_SIZE].copy_from_slice(&(chunk.len() as u32).to_le_bytes());
-        sealed_frame[DATA_LEN_SIZE..DATA_LEN_SIZE + chunk.len()].copy_from_slice(chunk);
+        sealed_frame[..LENGTH_PREFIX_SIZE].copy_from_slice(&(chunk.len() as u32).to_le_bytes());
+        sealed_frame[LENGTH_PREFIX_SIZE..LENGTH_PREFIX_SIZE + chunk.len()].copy_from_slice(chunk);
 
         let tag = self
             .cipher

--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -23,6 +23,12 @@ pub enum Error {
     /// Malformed handshake message. Possible protocol version mismatch.
     MalformedHandshake,
 
+    /// Message exceeds the maximum allowed size.
+    MessageOversized {
+        /// Size of the message.
+        size: usize,
+    },
+
     /// Public key missing
     MissingKey,
 
@@ -46,6 +52,7 @@ impl Display for Error {
             Self::MalformedHandshake => {
                 f.write_str("malformed handshake message (protocol version mismatch?)")
             }
+            Self::MessageOversized { size } => write!(f, "message is too large: {size} bytes"),
             Self::MissingKey => f.write_str("public key missing"),
             Self::MissingSecret => f.write_str("missing secret (forgot to call Handshake::new?)"),
             Self::UnsupportedKey => f.write_str("key type (e.g. secp256k1) is not supported"),

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -32,11 +32,11 @@ pub(crate) use curve25519_dalek::montgomery::MontgomeryPoint as EphemeralPublic;
 pub(crate) use tendermint_proto::v0_38 as proto;
 
 /// Maximum size of a message
-pub(crate) const DATA_MAX_SIZE: usize = 1024;
+pub(crate) const FRAME_MAX_SIZE: usize = 1024;
 
 /// 4 + 1024 == 1028 total frame size
-pub(crate) const DATA_LEN_SIZE: usize = 4;
-pub(crate) const TOTAL_FRAME_SIZE: usize = DATA_MAX_SIZE + DATA_LEN_SIZE;
+pub(crate) const LENGTH_PREFIX_SIZE: usize = 4;
+pub(crate) const TOTAL_FRAME_SIZE: usize = FRAME_MAX_SIZE + LENGTH_PREFIX_SIZE;
 
 /// Size of the `ChaCha20Poly1305` MAC tag
 pub(crate) const TAG_SIZE: usize = 16;


### PR DESCRIPTION
- Add a sanity limit of 1MiB
- Avoid buffering the message on the heap if it fits in a frame
- Remove speculative message decoding and allocate a single buffer based on the total expected message length