### PR TITLE
tmkms-p2p: re-export `IdentitySecret`

### DIFF
--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -26,9 +26,12 @@ pub use crate::{
     public_key::{PeerId, PublicKey},
     secret_connection::SecretConnection,
 };
-pub use ed25519_dalek as ed25519;
+
+/// Secret Connection node identity secret keys.
+pub type IdentitySecret = ed25519::SigningKey;
 
 pub(crate) use curve25519_dalek::montgomery::MontgomeryPoint as EphemeralPublic;
+pub(crate) use ed25519_dalek as ed25519;
 pub(crate) use tendermint_proto::v0_38 as proto;
 
 /// Maximum size of a message

--- a/tmkms-p2p/src/public_key.rs
+++ b/tmkms-p2p/src/public_key.rs
@@ -1,6 +1,6 @@
 //! Secret Connection peer identity public keys.
 
-use crate::{CryptoError, Result, ed25519};
+use crate::{CryptoError, IdentitySecret, Result, ed25519};
 use sha2::{Sha256, digest::Digest};
 use std::fmt::{self, Debug, Display};
 
@@ -65,8 +65,8 @@ impl Debug for PublicKey {
     }
 }
 
-impl From<&ed25519::SigningKey> for PublicKey {
-    fn from(sk: &ed25519::SigningKey) -> Self {
+impl From<&IdentitySecret> for PublicKey {
+    fn from(sk: &IdentitySecret) -> Self {
         Self::Ed25519(sk.verifying_key())
     }
 }
@@ -74,5 +74,11 @@ impl From<&ed25519::SigningKey> for PublicKey {
 impl From<ed25519::VerifyingKey> for PublicKey {
     fn from(pk: ed25519::VerifyingKey) -> Self {
         Self::Ed25519(pk)
+    }
+}
+
+impl From<&ed25519::VerifyingKey> for PublicKey {
+    fn from(pk: &ed25519::VerifyingKey) -> Self {
+        Self::from(*pk)
     }
 }


### PR DESCRIPTION
Type alias for `ed25519::SigningKey`