### PR TITLE
tmkms-p2p: remove `Error::TransportClone`

### DIFF
--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -37,9 +37,6 @@ pub enum Error {
 
     /// Key type supported (e.g. secp256k1)
     UnsupportedKey,
-
-    /// Failed to clone underlying transport
-    TransportClone,
 }
 
 impl Display for Error {
@@ -56,7 +53,6 @@ impl Display for Error {
             Self::MissingKey => f.write_str("public key missing"),
             Self::MissingSecret => f.write_str("missing secret (forgot to call Handshake::new?)"),
             Self::UnsupportedKey => f.write_str("key type (e.g. secp256k1) is not supported"),
-            Self::TransportClone => f.write_str("failed to clone underlying transport"),
         }
     }
 }

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -1,7 +1,7 @@
 //! Encrypted connection between peers in a CometBFT network.
 
 use crate::{
-    EphemeralPublic, Error, FRAME_MAX_SIZE, LENGTH_PREFIX_SIZE, PublicKey, Result, TAG_SIZE,
+    EphemeralPublic, FRAME_MAX_SIZE, LENGTH_PREFIX_SIZE, PublicKey, Result, TAG_SIZE,
     TOTAL_FRAME_SIZE, ed25519,
     encryption::{CipherState, RecvState, SendState},
     framing,
@@ -149,10 +149,7 @@ impl SecretConnection<TcpStream> {
         let remote_pubkey = self.remote_pubkey.expect("remote_pubkey to be initialized");
         Ok((
             Sender {
-                io_handler: self
-                    .io_handler
-                    .try_clone()
-                    .map_err(|_| Error::TransportClone)?,
+                io_handler: self.io_handler.try_clone()?,
                 remote_pubkey,
                 state: self.cipher_state.send_state,
                 terminate: self.terminate.clone(),


### PR DESCRIPTION
We can already handle these errors as `Error::Io`