### PR TITLE
tmkms-p2p: initial handshake encoding improvements

### DIFF
--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -20,9 +20,6 @@ pub enum Error {
     /// I/O error
     Io(std::io::Error),
 
-    /// Malformed handshake message. Possible protocol version mismatch.
-    MalformedHandshake,
-
     /// Message exceeds the maximum allowed size.
     MessageOversized {
         /// Size of the message.
@@ -46,10 +43,7 @@ impl Display for Error {
             Self::Crypto(_) => f.write_str("cryptographic error"),
             Self::Decode(_) => f.write_str("malformed protocol message (version mismatch?)"),
             Self::Io(_) => f.write_str("I/O error"),
-            Self::MalformedHandshake => {
-                f.write_str("malformed handshake message (protocol version mismatch?)")
-            }
-            Self::MessageOversized { size } => write!(f, "message is too large: {size} bytes"),
+            Self::MessageOversized { size } => write!(f, "message is too large ({size} bytes)"),
             Self::MissingKey => f.write_str("public key missing"),
             Self::MissingSecret => f.write_str("missing secret (forgot to call Handshake::new?)"),
             Self::UnsupportedKey => f.write_str("key type (e.g. secp256k1) is not supported"),

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -262,8 +262,10 @@ fn share_eph_pubkey<Io: Read + Write + Send + Sync>(
     let mut response_len = 0_u8;
     handler.read_exact(slice::from_mut(&mut response_len))?;
 
-    let mut buf = vec![0; response_len as usize];
-    handler.read_exact(&mut buf)?;
+    let mut buf = vec![0; usize::from(response_len) + 1];
+    buf[0] = response_len;
+    handler.read_exact(&mut buf[1..])?;
+
     framing::decode_initial_handshake(&buf)
 }
 


### PR DESCRIPTION
- Use stack allocated buffers
- Make APIs consistent in terms of acting on full messages
- Extract constant for `google.protobuf.BytesValue` prefix
- Get rid of `Error::MalformedHandshake`, using `Error::Decode` instead

It would be good to refactor these free functions into a type for handling the initial handshake messages, but that is left for a followup