### PR TITLE
tmkms-p2p v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-p2p"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aead",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tendermint = { version = "0.40", features = ["secp256k1"] }
 tendermint-config = "0.40"
 tendermint-proto = "0.40"
 thiserror = "1"
-tmkms-p2p = "0.2"
+tmkms-p2p = "0.3"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"

--- a/tmkms-p2p/CHANGELOG.md
+++ b/tmkms-p2p/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 (2025-08-20)
+### Added
+- Re-export `IdentitySecret` (#1032)
+- `Error::Internal` (#1037)
+
+### Changed
+- Rename `Error::MessageOversized` to `MessageTooBig` (#1037)
+- Replace `Error::UnsupportedKey` with a `CryptoError` (#1037)
+
+### Removed
+- `Error::MissingKey` (#1037)
+- `Error::MissingSecret` (#1037)
+- `Error::TransportClone` (#1034)
+- `Error::UnsupportedKey` (#1037)
+
 ## 0.2.0 (2025-08-20)
 ### Added
 - `ReadMsg`/`WriteMsg` traits (#1018)

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tmkms-p2p"
 description = "Implementation of CometBFT's encrypted P2P protocol"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms"


### PR DESCRIPTION
### Added
- Re-export `IdentitySecret` (#1032)
- `Error::Internal` (#1037)

### Changed
- Rename `Error::MessageOversized` to `MessageTooBig` (#1037)
- Replace `Error::UnsupportedKey` with a `CryptoError` (#1037)

### Removed
- `Error::MissingKey` (#1037)
- `Error::MissingSecret` (#1037)
- `Error::TransportClone` (#1034)
- `Error::UnsupportedKey` (#1037)