### PR TITLE
tmkms-p2p: use `ReadMsg` to read initial handshake

### DIFF
--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     Io(std::io::Error),
 
     /// Message exceeds the maximum allowed size.
-    MessageTooBig {
+    MessageSize {
         /// Size of the message.
         size: usize,
     },
@@ -39,7 +39,7 @@ impl Display for Error {
             Self::Decode(_) => f.write_str("malformed protocol message (version mismatch?)"),
             Self::Internal => f.write_str("internal error"),
             Self::Io(_) => f.write_str("I/O error"),
-            Self::MessageTooBig { size } => write!(f, "message is too big ({size} bytes)"),
+            Self::MessageSize { size } => write!(f, "unexpected message size ({size} bytes)"),
         }
     }
 }

--- a/tmkms-p2p/src/handshake.rs
+++ b/tmkms-p2p/src/handshake.rs
@@ -38,14 +38,6 @@ pub(crate) struct InitialMessage {
 }
 
 impl InitialMessage {
-    /// Length of the initial message when encoded with a length delimiter.
-    ///
-    /// - 1-byte outer length delimiter
-    /// - 1-byte proto tag (field ID + wiretype)
-    /// - 1-byte inner length delimiter
-    /// - 32-byte X25519 public key
-    pub(crate) const ENCODED_LEN: usize = 35;
-
     /// Field ID of the public key.
     const FIELD_TAG: u8 = 1;
 


### PR DESCRIPTION
Now that #1048 has landed and unblocked us from hitting buffering bugs in `SecretConnection`, it's possible to use `ReadMsg` to consume the initial handshake message from the TCP socket.