### PR TITLE
tmkms-p2p: drop `tendermint-proto` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2677,11 +2677,9 @@ dependencies = [
  "merlin",
  "proptest",
  "prost",
- "prost-derive",
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "subtle",
- "tendermint-proto",
  "zeroize",
 ]
 

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -23,15 +23,13 @@ curve25519-dalek = { version = "4", default-features = false, features = ["rand_
 ed25519-dalek = { version = "2", default-features = false, features = ["alloc", "zeroize"] }
 hkdf = { version = "0.12.3", default-features = false }
 merlin = { version = "3", default-features = false }
-prost = { version = "0.13", default-features = false, features = ["std"] }
+prost = { version = "0.13", default-features = false, features = ["derive", "std"] }
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
-tendermint-proto = { version = "0.40.4", default-features = false }
 zeroize = { version = "1", default-features = false }
 proptest = "1.6.0"
 
 [dev-dependencies]
 hex-literal = "1"
 proptest = "1"
-prost-derive = "0.13"

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -15,6 +15,7 @@ mod error;
 mod handshake;
 mod kdf;
 mod msg_traits;
+mod proto;
 mod public_key;
 mod secret_connection;
 mod test_vectors;
@@ -34,7 +35,6 @@ pub type PeerId = [u8; 20];
 
 pub(crate) use curve25519_dalek::montgomery::MontgomeryPoint as EphemeralPublic;
 pub(crate) use ed25519_dalek as ed25519;
-pub(crate) use tendermint_proto::v0_38 as proto;
 
 /// Maximum size of a message
 pub(crate) const FRAME_MAX_SIZE: usize = 1024;

--- a/tmkms-p2p/src/proto.rs
+++ b/tmkms-p2p/src/proto.rs
@@ -1,0 +1,39 @@
+//! Vendored protos from tendermint-rs.
+// TODO(tarcieri): replace with `cometbft-proto` when released.
+
+pub(crate) mod crypto {
+    use prost::Message;
+
+    /// PublicKey defines the keys available for use with Validators
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, Message)]
+    pub struct PublicKey {
+        #[prost(oneof = "public_key::Sum", tags = "1, 2")]
+        pub sum: Option<public_key::Sum>,
+    }
+    /// Nested message and enum types in `PublicKey`.
+    pub mod public_key {
+        use prost::Oneof;
+
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Clone, PartialEq, Oneof)]
+        pub enum Sum {
+            #[prost(bytes, tag = "1")]
+            Ed25519(Vec<u8>),
+            #[prost(bytes, tag = "2")]
+            Secp256k1(Vec<u8>),
+        }
+    }
+}
+
+pub(crate) mod p2p {
+    use prost::Message;
+
+    #[derive(Clone, PartialEq, Message)]
+    pub struct AuthSigMessage {
+        #[prost(message, optional, tag = "1")]
+        pub pub_key: Option<super::crypto::PublicKey>,
+        #[prost(bytes = "vec", tag = "2")]
+        pub sig: Vec<u8>,
+    }
+}

--- a/tmkms-p2p/tests/secret_connection.rs
+++ b/tmkms-p2p/tests/secret_connection.rs
@@ -3,7 +3,7 @@
 #![cfg(unix)]
 
 use proptest::{collection, prelude::*};
-use prost_derive::Message;
+use prost::Message;
 use std::{
     io::{Read, Write},
     os::unix::net::UnixStream,


### PR DESCRIPTION
Vendors the roughly 40 lines of protos we actually use into a `proto.rs` and removes `tendermint-proto` as a dependency, which is our last dependency on a legacy `tendermint-rs` crate.

Leaves a TODO to eventually replace it with `cometbft-proto`.