### PR TITLE
tmkms-p2p: move `ReadMsg`/`WriteMsg` generic to trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-p2p"
-version = "0.3.0"
+version = "0.4.0-pre"
 dependencies = [
  "aead",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tendermint = { version = "0.40", features = ["secp256k1"] }
 tendermint-config = "0.40"
 tendermint-proto = "0.40"
 thiserror = "1"
-tmkms-p2p = "0.3"
+tmkms-p2p = "=0.4.0-pre"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,6 @@
 //! Connections to a validator (TCP or Unix socket)
 
 use self::unix::UnixConnection;
-use crate::error::Error;
 use std::io;
 use tendermint_proto as proto;
 use tmkms_p2p::{ReadMsg, SecretConnection, WriteMsg};
@@ -10,36 +9,11 @@ pub mod tcp;
 pub mod unix;
 
 /// Connections to a validator
-pub trait Connection: Sync + Send {
-    /// Read a request from the validator.
-    fn read_request(&mut self) -> Result<proto::privval::Message, Error>;
-
-    /// Write a response to the validator.
-    fn write_response(&mut self, msg: &proto::privval::Message) -> Result<(), Error>;
-}
-
-impl<T> Connection for SecretConnection<T>
-where
-    T: io::Read + io::Write + Sync + Send,
+pub trait Connection:
+    ReadMsg<proto::privval::Message> + WriteMsg<proto::privval::Message> + Sync + Send
 {
-    fn read_request(&mut self) -> Result<proto::privval::Message, Error> {
-        Ok(self.read_msg()?)
-    }
-
-    fn write_response(&mut self, msg: &proto::privval::Message) -> Result<(), Error> {
-        Ok(self.write_msg(msg)?)
-    }
 }
 
-impl<T> Connection for UnixConnection<T>
-where
-    T: io::Read + io::Write + Sync + Send,
-{
-    fn read_request(&mut self) -> Result<proto::privval::Message, Error> {
-        Ok(self.read_msg()?)
-    }
+impl<T> Connection for SecretConnection<T> where T: io::Read + io::Write + Sync + Send {}
 
-    fn write_response(&mut self, msg: &proto::privval::Message) -> Result<(), Error> {
-        Ok(self.write_msg(msg)?)
-    }
-}
+impl<T> Connection for UnixConnection<T> where T: io::Read + io::Write + Sync + Send {}

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -29,7 +29,7 @@ impl Request {
         conn: &mut C,
         expected_chain_id: &chain::Id,
     ) -> Result<Self, Error> {
-        let msg = conn.read_request()?;
+        let msg = conn.read_msg()?;
 
         let (req, chain_id) = match msg.sum {
             Some(proto::privval::message::Sum::SignVoteRequest(

--- a/src/session.rs
+++ b/src/session.rs
@@ -122,7 +122,7 @@ impl Session {
             &self.config.chain_id, &self.config.addr, &response
         );
 
-        self.connection.write_response(&response.to_proto())?;
+        self.connection.write_msg(&response.to_proto())?;
         Ok(true)
     }
 

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tmkms-p2p"
 description = "Implementation of CometBFT's encrypted P2P protocol"
-version = "0.3.0"
+version = "0.4.0-pre"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms"


### PR DESCRIPTION
Previously `read_msg` and `write_msg` had a generic parameter on the methods, but this is incompatible with dyn compatibility / object safety.

By moving the generic parameter to the trait, tmkms can now bound on `ReadMsg<proto::privval::Message>` which makes the generic type concrete and therefore dyn compatible.