### PR TITLE
tmkms-p2p: remove `Error::BufferOverflow`

### DIFF
--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -8,9 +8,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Error type
 #[derive(Debug)]
 pub enum Error {
-    /// Output buffer is too small
-    BufferOverflow,
-
     /// Cryptographic errors
     Crypto(CryptoError),
 
@@ -34,7 +31,6 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::BufferOverflow => f.write_str("output buffer is too small"),
             Self::Crypto(_) => f.write_str("cryptographic error"),
             Self::Decode(_) => f.write_str("malformed protocol message (version mismatch?)"),
             Self::Internal => f.write_str("internal error"),


### PR DESCRIPTION
This is an internal error previously raised in the `encryption` module.

We can use `CryptoError` instead (it shouldn't happen unless there is a bug in `tmkms-p2p`), and that allows us to return `CryptoError` everywhere from within that module, which should help prevent potential sidechannels.