### PR TITLE
tmkms-p2p: remove `Error::Internal`

### DIFF
--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -14,10 +14,6 @@ pub enum Error {
     /// Protobuf decode message
     Decode(prost::DecodeError),
 
-    /// Internal error
-    // TODO(tarcieri): get rid of these cases in the code
-    Internal,
-
     /// I/O error
     Io(std::io::Error),
 
@@ -33,7 +29,6 @@ impl Display for Error {
         match self {
             Self::Crypto(_) => f.write_str("cryptographic error"),
             Self::Decode(_) => f.write_str("malformed protocol message (version mismatch?)"),
-            Self::Internal => f.write_str("internal error"),
             Self::Io(_) => f.write_str("I/O error"),
             Self::MessageSize { size } => write!(f, "unexpected message size ({size} bytes)"),
         }

--- a/tmkms-p2p/src/handshake.rs
+++ b/tmkms-p2p/src/handshake.rs
@@ -10,7 +10,7 @@
 //! [specification]: https://github.com/cometbft/cometbft/blob/015f455/spec/p2p/legacy-docs/peer.md#authenticated-encryption-handshake
 
 use crate::{
-    CryptoError, EphemeralPublic, Error, PublicKey, Result,
+    CryptoError, EphemeralPublic, PublicKey, Result,
     ed25519::{self, Signer},
     encryption::CipherState,
     kdf::Kdf,
@@ -165,7 +165,10 @@ impl InitialState {
             return Err(CryptoError::INSECURE_KEY.into());
         }
 
-        let local_eph_privkey = self.local_eph_privkey.take().ok_or(Error::Internal)?;
+        let local_eph_privkey = self
+            .local_eph_privkey
+            .take()
+            .ok_or(CryptoError::ENCRYPTION)?;
         let local_eph_pubkey = EphemeralPublic::mul_base_clamped(local_eph_privkey);
 
         // Compute common shared secret.

--- a/tmkms-p2p/src/msg_traits.rs
+++ b/tmkms-p2p/src/msg_traits.rs
@@ -7,7 +7,7 @@ use std::io::{Read, Write};
 /// Message prefix length to always consume. This also represents the minimum message size.
 ///
 /// This is picked to ensure that the entire length prefix will always fit in this size, namely
-/// we only support up to 1 MiB messages (`MAX_MSG_LEN`), which use 3-byte headers.
+/// we only support up to 1 MiB messages (`MAX_MSG_LEN`), which use max 3-byte length prefixes.
 const PREFIX_LEN: usize = 3;
 
 // NOTE: trait definitions below use a generic parameter on the trait rather than the method to


### PR DESCRIPTION
This is an internal error previously raised in the `handshake` module.

We can use `CryptoError` instead