### PR TITLE
tmkms-p2p: make `MAX_MSG_LEN` public

### DIFF
--- a/tmkms-p2p/src/handshake.rs
+++ b/tmkms-p2p/src/handshake.rs
@@ -1,13 +1,12 @@
 //! Secret Connection handshakes.
 //!
 //! Performs an authenticated key exchange, first using ephemeral X25519 D-H to establish a shared
-//! symmetric key, using [Merlin] to compute a signature over the handshake, then signing the result
+//! symmetric key, using Merlin to compute a signature over the handshake, then signing the result
 //! using Ed25519, providing the signature in the handshake response message.
 //!
-//! For more information, see the [sepcification].
+//! For more information, see the specification:
 //!
-//! [Merlin]:
-//! [specification]: https://github.com/cometbft/cometbft/blob/015f455/spec/p2p/legacy-docs/peer.md#authenticated-encryption-handshake
+//! <https://github.com/cometbft/cometbft/blob/015f455/spec/p2p/legacy-docs/peer.md#authenticated-encryption-handshake>
 
 use crate::{
     CryptoError, EphemeralPublic, PublicKey, Result,

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -28,6 +28,8 @@ pub use crate::{
 };
 
 /// Secret Connection node identity secret keys.
+///
+/// Ed25519 is currently the only supported signature algorithm.
 pub type IdentitySecret = ed25519::SigningKey;
 
 /// Secret Connection Peer IDs: 20-byte public key fingerprints.
@@ -36,11 +38,10 @@ pub type PeerId = [u8; 20];
 pub(crate) use curve25519_dalek::montgomery::MontgomeryPoint as EphemeralPublic;
 pub(crate) use ed25519_dalek as ed25519;
 
-/// Limit (in bytes) on the maximum size of a length delimited message (e.g. Protobuf), where the
-/// message potentially spans multiple encrypted frames.
+/// Message size limit which applies to length-delimited messages read via the [`ReadMsg`] trait.
 ///
-/// It ensures we won't allocate excessively large buffers when consuming incoming requests.
-pub(crate) const MAX_MSG_LEN: usize = 1_048_576; // 1 MiB
+/// Ensures we won't allocate excessively large buffers when consuming incoming requests.
+pub const MAX_MSG_LEN: usize = 1_048_576; // 1 MiB
 
 /// Maximum size of a message frame
 pub(crate) const FRAME_MAX_SIZE: usize = 1024;


### PR DESCRIPTION
Should help diagnose `Error::MessageSize` if it comes up.