### PR TITLE
tmkms-p2p v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2054,7 +2054,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2451,7 +2451,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-p2p"
-version = "0.4.0-pre"
+version = "0.4.0"
 dependencies = [
  "aead",
  "chacha20poly1305",
@@ -3093,7 +3093,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tendermint = { version = "0.40", features = ["secp256k1"] }
 tendermint-config = "0.40"
 tendermint-proto = "0.40"
 thiserror = "1"
-tmkms-p2p = "=0.4.0-pre"
+tmkms-p2p = "0.4"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"

--- a/tmkms-p2p/CHANGELOG.md
+++ b/tmkms-p2p/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.0 (2025-08-22)
+### Added
+- `MAX_MSG_LEN` constant (#1053)
+
+### Changed
+- Drop `tendermint-proto` dependency (#1047)
+- Move `ReadMsg`/`WriteMsg` generic to trait (#1050)
+
+### Removed
+- `Error::BufferOverflow` (#1051)
+- `Error::Internal` (#1052)
+- `SecretConnection::split` (#1054)
+- Explicit low order point check (#1055)
+
 ## 0.3.0 (2025-08-20)
 ### Added
 - Re-export `IdentitySecret` (#1032)

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tmkms-p2p"
 description = "Implementation of CometBFT's encrypted P2P protocol"
-version = "0.4.0-pre"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms"


### PR DESCRIPTION
### Added
- `MAX_MSG_LEN` constant (#1053)

### Changed
- Drop `tendermint-proto` dependency (#1047)
- Move `ReadMsg`/`WriteMsg` generic to trait (#1050)

### Removed
- `Error::BufferOverflow` (#1051)
- `Error::Internal` (#1052)
- `SecretConnection::split` (#1054)
- Explicit low order point check (#1055)