### PR TITLE
tmkms-p2p: extract `Frame` type

### DIFF
--- a/tmkms-p2p/src/encryption/frame.rs
+++ b/tmkms-p2p/src/encryption/frame.rs
@@ -1,0 +1,119 @@
+//! Secret Connection message frames.
+
+use super::Tag;
+use crate::CryptoError;
+use std::io::{self, Read, Write};
+
+/// 4 + 1024 == 1028 total frame size
+const LENGTH_PREFIX_SIZE: usize = 4;
+pub(super) const TOTAL_FRAME_SIZE: usize = Frame::MAX_SIZE + LENGTH_PREFIX_SIZE;
+
+/// Total size of frame including ChaCha20Poly1305 tag.
+pub(super) const TAGGED_FRAME_SIZE: usize = TOTAL_FRAME_SIZE + size_of::<Tag>();
+
+/// Frames are the fundamental "packets" of Secret Connection.
+///
+/// They are fixed-length and sent in sequence. However, when decrypted they have a leading length
+/// prefix which can be used to encode shorter messages (this is ostensibly to try to hide length
+/// sidechannels about what messages are being sent).
+pub(crate) struct Frame {
+    /// We always represent frames as being of fixed length. When frames are plaintext the length
+    /// of the message is encoded in the leading 4 bytes.
+    pub(super) bytes: [u8; TAGGED_FRAME_SIZE],
+
+    /// Flag to indicate whether the frame is plaintext or encrypted.
+    pub(super) encrypted: bool,
+}
+
+impl Frame {
+    /// Maximum size of a plaintext message frame.
+    pub(crate) const MAX_SIZE: usize = 1024;
+
+    /// Create a new plaintext frame from the given bytes.
+    pub(crate) fn plaintext(slice: &[u8]) -> Result<Self, CryptoError> {
+        let len: u32 = match slice.len().try_into() {
+            Ok(len) if slice.len() <= Frame::MAX_SIZE => len,
+            _ => return Err(CryptoError::ENCRYPTION),
+        };
+
+        let mut bytes = [0u8; TAGGED_FRAME_SIZE];
+        let (length_prefix, pt) = bytes.split_at_mut(LENGTH_PREFIX_SIZE);
+        length_prefix.copy_from_slice(&len.to_le_bytes());
+        pt[..slice.len()].copy_from_slice(slice);
+
+        Ok(Self {
+            bytes,
+            encrypted: false,
+        })
+    }
+
+    /// Create a ciphertext frame from the given buffer.
+    #[inline]
+    pub(crate) fn ciphertext(bytes: [u8; TAGGED_FRAME_SIZE]) -> Self {
+        Self {
+            bytes,
+            encrypted: true,
+        }
+    }
+
+    /// Read a ciphertext frame from the network.
+    pub(crate) fn read<R: Read>(reader: &mut R) -> Result<Self, io::Error> {
+        let mut bytes = [0u8; TAGGED_FRAME_SIZE];
+        reader.read_exact(&mut bytes)?;
+        Ok(Self::ciphertext(bytes))
+    }
+
+    /// Write a ciphertext frame to the network.
+    pub(crate) fn write<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
+        if !self.encrypted {
+            return Err(io::Error::other("refusing to write plaintext to network"));
+        }
+
+        writer.write_all(&self.bytes)
+    }
+
+    /// Length of the frame.
+    ///
+    /// # Panics
+    /// - if called on a ciphertext frame
+    pub(crate) fn len(&self) -> usize {
+        debug_assert!(!self.encrypted, "should only be called on plaintext frames");
+
+        let n = self.length_prefix();
+        debug_assert!(
+            n <= Frame::MAX_SIZE,
+            "constructor failed to ensure frame size"
+        );
+        n
+    }
+
+    /// Get the frame's contents as a byte slice.
+    ///
+    /// # Panics
+    /// - if called on a ciphertext frame
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        debug_assert!(!self.encrypted, "should only be called on plaintext frames");
+        &self.bytes[LENGTH_PREFIX_SIZE..(LENGTH_PREFIX_SIZE + self.len())]
+    }
+
+    /// Parse the tag of the frame.
+    pub(super) fn tag(&self) -> Tag {
+        debug_assert!(self.encrypted, "should only be called on ciphertext frames");
+        Tag::clone_from_slice(&self.bytes[TOTAL_FRAME_SIZE..])
+    }
+
+    /// Parse the length prefix. Doesn't ensure length is less than `Frame::MAX_SIZE`.
+    pub(super) fn length_prefix(&self) -> usize {
+        let prefix = self.bytes[..LENGTH_PREFIX_SIZE]
+            .try_into()
+            .expect("length prefix should exist");
+        let len = u32::from_le_bytes(prefix);
+        len.try_into().expect("length should be valid usize")
+    }
+}
+
+impl AsRef<[u8]> for Frame {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}

--- a/tmkms-p2p/src/encryption/nonce.rs
+++ b/tmkms-p2p/src/encryption/nonce.rs
@@ -1,0 +1,29 @@
+/// `SecretConnection` nonces (i.e. `ChaCha20` nonces)
+pub(super) struct Nonce(chacha20poly1305::Nonce);
+
+impl Nonce {
+    /// Get the initial all-zero nonce. This must only be used once and then incremented!
+    pub(super) fn initial() -> Self {
+        Self(chacha20poly1305::Nonce::default())
+    }
+
+    /// Increment the nonce's counter by 1
+    ///
+    /// # Panics
+    /// - if the counter overflows
+    /// - if the nonce is not 12 bytes long
+    pub(super) fn increment(&mut self) {
+        let mut counter: u64 = u64::from_le_bytes(self.0[4..].try_into().expect("framing failed"));
+        counter = counter
+            .checked_add(1)
+            .expect("overflow in counter addition");
+
+        self.0[4..].copy_from_slice(&counter.to_le_bytes());
+    }
+}
+
+impl AsRef<chacha20poly1305::Nonce> for Nonce {
+    fn as_ref(&self) -> &chacha20poly1305::Nonce {
+        &self.0
+    }
+}

--- a/tmkms-p2p/src/error.rs
+++ b/tmkms-p2p/src/error.rs
@@ -46,7 +46,12 @@ impl std::error::Error for Error {
     }
 }
 
-// TODO(tarcieri): avoid leaking `prost::DecodeError` in public API?
+impl From<ed25519_dalek::ed25519::Error> for Error {
+    fn from(err: ed25519_dalek::ed25519::Error) -> Self {
+        CryptoError::from(err).into()
+    }
+}
+
 impl From<prost::DecodeError> for Error {
     fn from(e: prost::DecodeError) -> Self {
         Self::Decode(e)
@@ -86,19 +91,25 @@ impl Display for CryptoError {
     }
 }
 
+impl std::error::Error for CryptoError {}
+
 impl From<CryptoError> for Error {
     fn from(err: CryptoError) -> Self {
         Error::Crypto(err)
     }
 }
 
-impl From<ed25519_dalek::ed25519::Error> for Error {
-    fn from(_: ed25519_dalek::ed25519::Error) -> Self {
-        CryptoError::SIGNATURE.into()
+impl From<aead::Error> for CryptoError {
+    fn from(_: aead::Error) -> Self {
+        CryptoError::ENCRYPTION
     }
 }
 
-impl std::error::Error for CryptoError {}
+impl From<ed25519_dalek::ed25519::Error> for CryptoError {
+    fn from(_: ed25519_dalek::ed25519::Error) -> Self {
+        CryptoError::SIGNATURE
+    }
+}
 
 /// Hidden inner type for tracking what type of cryptographic error occurred.
 #[derive(Debug)]

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -42,25 +42,3 @@ pub(crate) use ed25519_dalek as ed25519;
 ///
 /// Ensures we won't allocate excessively large buffers when consuming incoming requests.
 pub const MAX_MSG_LEN: usize = 1_048_576; // 1 MiB
-
-/// Maximum size of a message frame
-pub(crate) const FRAME_MAX_SIZE: usize = 1024;
-
-/// 4 + 1024 == 1028 total frame size
-pub(crate) const LENGTH_PREFIX_SIZE: usize = 4;
-pub(crate) const TOTAL_FRAME_SIZE: usize = FRAME_MAX_SIZE + LENGTH_PREFIX_SIZE;
-
-/// Size of the `ChaCha20Poly1305` MAC tag
-pub(crate) const TAG_SIZE: usize = 16;
-pub(crate) const TAGGED_FRAME_SIZE: usize = TOTAL_FRAME_SIZE + TAG_SIZE;
-
-/// Decode the total length of a length-delimited Protobuf or other LEB128-prefixed message,
-/// including the length of the length prefix itself (which is variable-sized).
-fn decode_length_delimiter_inclusive(frame: &[u8]) -> Result<usize> {
-    // TODO(tarcieri): would this fail on non-canonical LEB128, e.g. with leading zeros?
-    let len = prost::decode_length_delimiter(frame)?;
-    let length_delimiter_len = prost::length_delimiter_len(len);
-    length_delimiter_len
-        .checked_add(len)
-        .ok_or_else(|| prost::DecodeError::new("length overflow").into())
-}


### PR DESCRIPTION
- Extracts a type for Secret Connection's frames
- Reimplements encryption using frame-based payloads
- Replace all the old receive buffering and sending logic

Note: one test vector had to be regenerated because the original code that generated it reused a buffer, so it contained the ciphertext of the previous message in the "padding".

This was spotted thanks to the new `Frame` type, which always initializes the "padding" with zeros.