### PR TITLE
tmkms-p2p: refactor handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2054,7 +2054,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2451,7 +2451,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-p2p"
-version = "0.4.1"
+version = "0.5.0-pre"
 dependencies = [
  "aead",
  "chacha20poly1305",
@@ -3093,7 +3093,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tendermint = { version = "0.40", features = ["secp256k1"] }
 tendermint-config = "0.40"
 tendermint-proto = "0.40"
 thiserror = "1"
-tmkms-p2p = "0.4"
+tmkms-p2p = "0.5.0-pre"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -4,7 +4,7 @@ use std::{net::TcpStream, path::PathBuf, time::Duration};
 
 use subtle::ConstantTimeEq;
 use tendermint::node;
-use tmkms_p2p::{PublicKey, SecretConnection};
+use tmkms_p2p::{IdentitySecret, PublicKey, SecretConnection};
 
 use crate::{
     error::{Error, ErrorKind::*},
@@ -32,7 +32,7 @@ pub fn open_secret_connection(
         )
     })?;
 
-    let identity_key = key_utils::load_base64_ed25519_key(identity_key_path)?;
+    let identity_key = IdentitySecret::from(key_utils::load_base64_ed25519_key(identity_key_path)?);
     info!("KMS node ID: {}", PublicKey::from(&identity_key));
 
     let socket = TcpStream::connect(format!("{host}:{port}"))?;
@@ -40,7 +40,7 @@ pub fn open_secret_connection(
     socket.set_read_timeout(Some(timeout))?;
     socket.set_write_timeout(Some(timeout))?;
 
-    let connection = match SecretConnection::new(socket, identity_key.into()) {
+    let connection = match SecretConnection::new(socket, &identity_key) {
         Ok(conn) => conn,
         Err(error) => fail!(ProtocolError, format!("{error}")),
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,14 +13,14 @@ use std::{
 use tempfile::NamedTempFile;
 use tendermint::node;
 use tendermint_proto as proto;
-use tmkms::connection::Connection;
 use tmkms::{
     config::provider::KeyType,
+    connection::Connection,
     connection::unix::UnixConnection,
     keyring::ed25519,
     privval::{SignableMsg, SignedMsgType},
 };
-use tmkms_p2p::{self as p2p, PublicKey, ReadMsg, SecretConnection, WriteMsg};
+use tmkms_p2p::{self as p2p, IdentitySecret, PublicKey, ReadMsg, SecretConnection, WriteMsg};
 
 /// Integration tests for the KMS command-line interface
 mod cli;
@@ -186,12 +186,12 @@ impl KmsProcess {
         match self.socket {
             KmsSocket::TCP(ref sock) => {
                 // we use the same key for both sides:
-                let identity_key = test_ed25519_keypair();
+                let identity_key = IdentitySecret::from(test_ed25519_keypair());
 
                 // Here we reply to the kms with a "remote" ephemeral key, auth signature etc:
                 let socket_cp = sock.try_clone().unwrap();
 
-                KmsConnection::Tcp(SecretConnection::new(socket_cp, identity_key.into()).unwrap())
+                KmsConnection::Tcp(SecretConnection::new(socket_cp, &identity_key).unwrap())
             }
 
             KmsSocket::UNIX(ref sock) => {

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tmkms-p2p"
 description = "Implementation of CometBFT's encrypted P2P protocol"
-version = "0.4.1"
+version = "0.5.0-pre"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms"
@@ -20,7 +20,7 @@ authors = [
 aead = { version = "0.5", default-features = false }
 chacha20poly1305 = { version = "0.10", default-features = false }
 curve25519-dalek = { version = "4", default-features = false, features = ["rand_core"] }
-ed25519-dalek = { version = "2", default-features = false, features = ["alloc", "zeroize"] }
+ed25519-dalek = { version = "2", default-features = false, features = ["alloc", "rand_core", "zeroize"] }
 hkdf = { version = "0.12.3", default-features = false }
 merlin = { version = "3", default-features = false }
 prost = { version = "0.13", default-features = false, features = ["derive", "std"] }

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -10,6 +10,23 @@
     unused_qualifications
 )]
 
+//! # Usage
+//!
+//! ```no_run
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use std::net::TcpStream;
+//! use tmkms_p2p::{SecretConnection, IdentitySecret, rand_core::OsRng};
+//!
+//! let node_identity = IdentitySecret::generate(&mut OsRng);
+//! let tcp_sock = TcpStream::connect("example.com:26656")?;
+//! let conn = SecretConnection::new(tcp_sock, &node_identity)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The [`SecretConnection`] type (`conn`) impls the [`ReadMsg`] and [`WriteMsg`] traits which can
+//! be used to receive and send Protobuf messages which impl the [`prost::Message`] trait.
+
 mod encryption;
 mod error;
 mod handshake;
@@ -26,6 +43,7 @@ pub use crate::{
     public_key::PublicKey,
     secret_connection::SecretConnection,
 };
+pub use rand_core;
 
 /// Secret Connection node identity secret keys.
 ///

--- a/tmkms-p2p/tests/secret_connection.rs
+++ b/tmkms-p2p/tests/secret_connection.rs
@@ -37,7 +37,7 @@ proptest! {
         let (sock_a, sock_b) = UnixStream::pair().unwrap();
         let server_handle = TestServer::run(sock_b, bob_sk);
 
-        let mut conn = SecretConnection::new(sock_a, alice_sk).unwrap();
+        let mut conn = SecretConnection::new(sock_a, &alice_sk).unwrap();
         assert_eq!(conn.remote_pubkey().ed25519().unwrap().as_bytes(), bob_pk.as_bytes());
 
         for _ in 0..NUM_REQUESTS {
@@ -64,7 +64,7 @@ where
     fn run(io: Io, sk: IdentitySecret) -> thread::JoinHandle<()> {
         thread::spawn(move || {
             let mut server = TestServer {
-                conn: SecretConnection::new(io, sk).unwrap(),
+                conn: SecretConnection::new(io, &sk).unwrap(),
             };
 
             for _ in 0..NUM_REQUESTS {


### PR DESCRIPTION
- Avoids taking ownership of the identity secret
- Borrows the identity key in the constructor (breaking change)