### PR TITLE
tmkms-p2p: add `PeerId` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ name = "tmkms-p2p"
 version = "0.5.0-pre"
 dependencies = [
  "aead",
+ "base16ct",
  "chacha20poly1305",
  "curve25519-dalek",
  "ed25519-dalek",

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -50,7 +50,7 @@ pub fn open_secret_connection(
     if let Some(expected_peer_id) = peer_id {
         if expected_peer_id
             .as_bytes()
-            .ct_eq(&actual_peer_id)
+            .ct_eq(actual_peer_id.as_bytes())
             .unwrap_u8()
             == 0
         {
@@ -60,7 +60,7 @@ pub fn open_secret_connection(
                 host,
                 port,
                 expected_peer_id,
-                node::Id::new(actual_peer_id)
+                actual_peer_id
             );
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,7 +10,7 @@ use crate::{
     rpc::{Request, Response},
 };
 use std::{os::unix::net::UnixStream, time::Instant};
-use tendermint::{TendermintKey, consensus, node};
+use tendermint::{TendermintKey, consensus};
 use tendermint_config::net;
 use tendermint_proto as proto;
 
@@ -63,7 +63,7 @@ impl Session {
                         "[{}@{}]: unverified validator peer ID! ({})",
                         &config.chain_id,
                         &config.addr,
-                        node::Id::new(conn.remote_pubkey().peer_id())
+                        conn.remote_pubkey().peer_id()
                     );
                 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,7 +11,6 @@ use std::{
     process::{Child, Command},
 };
 use tempfile::NamedTempFile;
-use tendermint::node;
 use tendermint_proto as proto;
 use tmkms::{
     config::provider::KeyType,
@@ -146,9 +145,8 @@ impl KmsProcess {
             path = "{}"
             key_type = "{}"
         "#,
-            node::Id::new(peer_id).to_string(), port, signing_key_path(key_type), key_type
-        )
-            .unwrap();
+            peer_id.to_string(), port, signing_key_path(key_type), key_type
+        ).unwrap();
 
         config_file
     }

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -18,6 +18,7 @@ authors = [
 
 [dependencies]
 aead = { version = "0.5", default-features = false }
+base16ct = { version = "0.2", features = ["alloc"] }
 chacha20poly1305 = { version = "0.10", default-features = false }
 curve25519-dalek = { version = "4", default-features = false, features = ["rand_core"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["alloc", "rand_core", "zeroize"] }

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -32,6 +32,7 @@ mod error;
 mod handshake;
 mod kdf;
 mod msg_traits;
+mod peer_id;
 mod proto;
 mod public_key;
 mod secret_connection;
@@ -40,6 +41,7 @@ mod test_vectors;
 pub use crate::{
     error::{CryptoError, Error, Result},
     msg_traits::{ReadMsg, WriteMsg},
+    peer_id::PeerId,
     public_key::PublicKey,
     secret_connection::SecretConnection,
 };
@@ -49,9 +51,6 @@ pub use rand_core;
 ///
 /// Ed25519 is currently the only supported signature algorithm.
 pub type IdentitySecret = ed25519::SigningKey;
-
-/// Secret Connection Peer IDs: 20-byte public key fingerprints.
-pub type PeerId = [u8; 20];
 
 pub(crate) use curve25519_dalek::montgomery::MontgomeryPoint as EphemeralPublic;
 pub(crate) use ed25519_dalek as ed25519;

--- a/tmkms-p2p/src/peer_id.rs
+++ b/tmkms-p2p/src/peer_id.rs
@@ -1,0 +1,88 @@
+//! Secret Connection peer IDs.
+
+use crate::{Error, Result};
+use base16ct::mixed as hex;
+use prost::DecodeError;
+use std::{
+    fmt::{self, Debug, Display},
+    str::FromStr,
+};
+
+/// Secret Connection peer IDs (i.e. key fingerprints)
+// TODO(tarcieri): use `cometbft::node::Id`
+#[allow(clippy::derived_hash_with_manual_eq)]
+#[derive(Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct PeerId(pub [u8; Self::LENGTH]);
+
+impl PeerId {
+    /// Length of a Node ID in bytes
+    pub const LENGTH: usize = 20;
+
+    /// Create a new Node ID from raw bytes
+    pub fn new(bytes: [u8; Self::LENGTH]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the node ID as a byte slice
+    pub fn as_bytes(&self) -> &[u8; Self::LENGTH] {
+        &self.0
+    }
+
+    /// Get an owned ID containing the peer ID.
+    pub fn to_bytes(self) -> [u8; Self::LENGTH] {
+        self.0
+    }
+}
+
+impl AsRef<[u8]> for PeerId {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl Display for PeerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in &self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl Debug for PeerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "node::Id({self})")
+    }
+}
+
+impl From<[u8; PeerId::LENGTH]> for PeerId {
+    fn from(bytes: [u8; PeerId::LENGTH]) -> PeerId {
+        PeerId(bytes)
+    }
+}
+
+impl From<PeerId> for [u8; PeerId::LENGTH] {
+    fn from(peer_id: PeerId) -> Self {
+        peer_id.0
+    }
+}
+
+impl From<&PeerId> for [u8; PeerId::LENGTH] {
+    fn from(peer_id: &PeerId) -> Self {
+        peer_id.0
+    }
+}
+
+/// Decode Node ID from hex
+impl FromStr for PeerId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        // Accept either upper or lower case hex
+        let bytes = hex::decode_vec(s).map_err(|_| DecodeError::new("hex decoding error"))?;
+        bytes
+            .try_into()
+            .map(Self)
+            .map_err(|_| DecodeError::new("invalid peer ID length").into())
+    }
+}

--- a/tmkms-p2p/src/public_key.rs
+++ b/tmkms-p2p/src/public_key.rs
@@ -38,7 +38,7 @@ impl PublicKey {
         match self {
             Self::Ed25519(pk) => {
                 let digest = Sha256::digest(pk.as_bytes());
-                digest[..20].try_into().expect("should be 20 bytes")
+                PeerId(digest[..20].try_into().expect("should be 20 bytes"))
             }
         }
     }
@@ -65,9 +65,16 @@ impl PublicKey {
 
 impl Display for PublicKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for byte in self.peer_id() {
-            write!(f, "{byte:02x}")?;
+        match self {
+            Self::Ed25519(ed25519_key) => {
+                write!(f, "PublicKey::Ed25519(")?;
+                for byte in ed25519_key.to_bytes() {
+                    write!(f, "{byte:02x}")?;
+                }
+                write!(f, ")")?;
+            }
         }
+
         Ok(())
     }
 }

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -16,6 +16,13 @@ use crate::IdentitySecret;
 
 /// Encrypted connection between peers in a CometBFT network.
 ///
+/// ## Sending and receiving messages
+///
+/// The [`SecretConnection`] type implements a message-oriented interface which can send and receive
+/// Protobuf-encoded messages that impl the [`prost::Message`] trait.
+///
+/// The [`ReadMsg`] and [`WriteMsg`] traits can be used for sending/receiving Protobuf messages.
+///
 /// ## Connection integrity and failures
 ///
 /// Due to the underlying encryption mechanism (currently [RFC 8439]), when a
@@ -40,6 +47,7 @@ impl<Io: Read + Write + Send + Sync> SecretConnection<Io> {
     /// - if sharing of the pubkey fails
     /// - if sharing of the signature fails
     /// - if receiving the signature fails
+    /// - if verifying the signature fails
     pub fn new<Identity>(mut io: Io, identity_key: &Identity) -> Result<Self>
     where
         Identity: Signer<ed25519::Signature>,


### PR DESCRIPTION
Adds a temporary replacement for `cometbft::node::Id` until a crate release of the `cometbft` crate is available.

It's a newtype for `[u8; 20]` which can handle hex encoding/decoding.