### PR TITLE
tmkms-p2p v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-p2p"
-version = "0.5.0-pre"
+version = "0.5.0"
 dependencies = [
  "aead",
  "base16ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tendermint = { version = "0.40", features = ["secp256k1"] }
 tendermint-config = "0.40"
 tendermint-proto = "0.40"
 thiserror = "1"
-tmkms-p2p = "0.5.0-pre"
+tmkms-p2p = "0.5"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"

--- a/tmkms-p2p/CHANGELOG.md
+++ b/tmkms-p2p/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.0 (2025-08-23)
+### Changed
+- `SecretConnection::new` now borrows the `IdentitySecret` (#1063)
+- `PeerId` is now a newtype for `[u8; 20]` (#1064)
+
 ## 0.4.1 (2025-08-23)
 ### Changed
 - Rewrite and simplify internal buffering (#1061)

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tmkms-p2p"
 description = "Implementation of CometBFT's encrypted P2P protocol"
-version = "0.5.0-pre"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms"
@@ -29,7 +29,6 @@ rand_core = { version = "0.6", default-features = false, features = ["std"] }
 sha2 = { version = "0.10", default-features = false }
 subtle = { version = "2", default-features = false }
 zeroize = { version = "1", default-features = false }
-proptest = "1.6.0"
 
 [dev-dependencies]
 hex-literal = "1"


### PR DESCRIPTION
### Changed
- `SecretConnection::new` now borrows the `IdentitySecret` (#1063)
- `PeerId` is now a newtype for `[u8; 20]` (#1064)