### PR TITLE
tmkms-p2p: basic peer verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms-p2p"
-version = "0.5.0"
+version = "0.6.0-pre"
 dependencies = [
  "aead",
  "base16ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tendermint = { version = "0.40", features = ["secp256k1"] }
 tendermint-config = "0.40"
 tendermint-proto = "0.40"
 thiserror = "1"
-tmkms-p2p = "0.5"
+tmkms-p2p = "=0.6.0-pre"
 url = { version = "2.2.2", features = ["serde"], optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 wait-timeout = "0.2"

--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tmkms-p2p"
 description = "Implementation of CometBFT's encrypted P2P protocol"
-version = "0.5.0"
+version = "0.6.0-pre"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/iqlusioninc/tmkms"

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -16,12 +16,18 @@
 //! ```no_run
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # type ExampleMessage = String; // example that impls `prost::Message`
+//! # let expected_peer_id = tmkms_p2p::PeerId(Default::default());
 //! use std::net::TcpStream;
 //! use tmkms_p2p::{SecretConnection, IdentitySecret, ReadMsg, rand_core::OsRng};
 //!
 //! let node_identity = IdentitySecret::generate(&mut OsRng);
 //! let tcp_sock = TcpStream::connect("example.com:26656")?;
 //! let mut conn = SecretConnection::new(tcp_sock, &node_identity)?;
+//!
+//! // Verify remote peer ID
+//! conn.remote_pubkey().peer_id().verify(expected_peer_id)?;
+//!
+//! // Read Protobuf message from the remote peer
 //! let msg: ExampleMessage = conn.read_msg()?;
 //! # Ok(())
 //! # }
@@ -43,7 +49,7 @@ mod test_vectors;
 mod traits;
 
 pub use crate::{
-    error::{CryptoError, Error, Result},
+    error::{CryptoError, Error, Result, VerifyPeerError},
     peer_id::PeerId,
     public_key::PublicKey,
     secret_connection::SecretConnection,


### PR DESCRIPTION
Shows how to verify that the remote peer ID matches some expected value.

Adds this to the basic usage documentation.