### PR TITLE
tmkms-p2p: rename `*_public_key` accessors, add local accessor

### DIFF
--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -44,7 +44,7 @@ pub fn open_secret_connection(
         Ok(conn) => conn,
         Err(error) => fail!(ProtocolError, format!("{error}")),
     };
-    let actual_peer_id = connection.remote_pubkey().peer_id();
+    let actual_peer_id = connection.peer_public_key().peer_id();
 
     // TODO(tarcieri): move this into `SecretConnection::new`
     if let Some(expected_peer_id) = peer_id {

--- a/src/session.rs
+++ b/src/session.rs
@@ -63,7 +63,7 @@ impl Session {
                         "[{}@{}]: unverified validator peer ID! ({})",
                         &config.chain_id,
                         &config.addr,
-                        conn.remote_pubkey().peer_id()
+                        conn.peer_public_key().peer_id()
                     );
                 }
 

--- a/tmkms-p2p/src/async_secret_connection.rs
+++ b/tmkms-p2p/src/async_secret_connection.rs
@@ -17,8 +17,16 @@ use crate::IdentitySecret;
 /// Encrypted connection between peers in a CometBFT network, implemented using asynchronous I/O
 /// provided by the Tokio async runtime.
 pub struct AsyncSecretConnection<Io> {
+    /// Inner async I/O object this connection type wraps.
     io: Io,
-    remote_pubkey: Option<PublicKey>,
+
+    /// Our identity's Ed25519 public key.
+    local_public_key: PublicKey,
+
+    /// Remote peer's Ed25519 public key.
+    peer_public_key: Option<PublicKey>,
+
+    /// Symmetric cipher state: key + tracking of the current nonce for a given packet sequence.
     cipher_state: CipherState,
 }
 
@@ -40,7 +48,7 @@ impl<Io: AsyncReadExt + AsyncWriteExt + Send + Sync + Unpin> AsyncSecretConnecti
         ed25519::VerifyingKey: for<'a> From<&'a Identity>,
     {
         // Start a handshake process, generating a local ephemeral X25519 public key.
-        let identity_pub_key: PublicKey = ed25519::VerifyingKey::from(identity_key).into();
+        let local_public_key: PublicKey = ed25519::VerifyingKey::from(identity_key).into();
         let (mut initial_state, initial_message) = handshake::InitialState::new();
 
         // Send our ephemeral X25519 public key to the remote peer (unencrypted).
@@ -57,13 +65,14 @@ impl<Io: AsyncReadExt + AsyncWriteExt + Send + Sync + Unpin> AsyncSecretConnecti
 
         let mut sc = Self {
             io,
-            remote_pubkey: None,
+            local_public_key,
+            peer_public_key: None,
             cipher_state,
         };
 
         // Send our identity's Ed25519 public key and signature over the transcript to the peer.
         sc.write_msg(&proto::p2p::AuthSigMessage {
-            pub_key: Some(identity_pub_key.into()),
+            pub_key: Some(local_public_key.into()),
             sig: sig.to_vec(),
         })
         .await?;
@@ -76,16 +85,23 @@ impl<Io: AsyncReadExt + AsyncWriteExt + Send + Sync + Unpin> AsyncSecretConnecti
         let remote_pubkey = challenge.got_signature(auth_sig_msg)?;
 
         // All good!
-        sc.remote_pubkey = Some(remote_pubkey);
+        sc.peer_public_key = Some(remote_pubkey);
         Ok(sc)
     }
+}
 
-    /// Returns the remote pubkey. Panics if there's no key.
+impl<Io> AsyncSecretConnection<Io> {
+    /// Get the local (i.e. our) [`PublicKey`].
+    pub fn local_public_key(&self) -> &PublicKey {
+        &self.local_public_key
+    }
+
+    /// Returns the remote peer's [`PublicKey`].
     ///
     /// # Panics
-    /// - if the remote pubkey is not initialized.
-    pub fn remote_pubkey(&self) -> PublicKey {
-        self.remote_pubkey.expect("remote_pubkey uninitialized")
+    /// - if the peer's public key is not initialized (library-internal bug)
+    pub fn peer_public_key(&self) -> PublicKey {
+        self.peer_public_key.expect("remote_pubkey uninitialized")
     }
 }
 

--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -24,10 +24,11 @@
 //! let tcp_sock = TcpStream::connect("example.com:26656")?;
 //! let mut conn = SecretConnection::new(tcp_sock, &node_identity)?;
 //!
-//! // Verify remote peer ID
-//! conn.remote_pubkey().peer_id().verify(expected_peer_id)?;
+//! // Verify remote peer ID (optional but highly encouraged)
+//! conn.peer_public_key().peer_id().verify(expected_peer_id)?;
 //!
 //! // Read Protobuf message from the remote peer
+//! // (note: you could also write here if initiating a request, see `WriteMsg`)
 //! let msg: ExampleMessage = conn.read_msg()?;
 //! # Ok(())
 //! # }

--- a/tmkms-p2p/tests/async_secret_connection.rs
+++ b/tmkms-p2p/tests/async_secret_connection.rs
@@ -35,7 +35,7 @@ async fn integration_test() {
         .unwrap();
 
     assert_eq!(
-        conn.remote_pubkey().ed25519().unwrap().as_bytes(),
+        conn.peer_public_key().ed25519().unwrap().as_bytes(),
         bob_pk.as_bytes()
     );
 

--- a/tmkms-p2p/tests/secret_connection.rs
+++ b/tmkms-p2p/tests/secret_connection.rs
@@ -36,7 +36,7 @@ proptest! {
         let server_handle = thread::spawn(move || TestServer::run(sock_b, bob_sk, NUM_REQUESTS));
 
         let mut conn = SecretConnection::new(sock_a, &alice_sk).unwrap();
-        assert_eq!(conn.remote_pubkey().ed25519().unwrap().as_bytes(), bob_pk.as_bytes());
+        assert_eq!(conn.peer_public_key().ed25519().unwrap().as_bytes(), bob_pk.as_bytes());
 
         for _ in 0..NUM_REQUESTS {
             conn.write_msg(&PingRequest { msg: example_msg.clone() }).unwrap();


### PR DESCRIPTION
Renames:
- `SecretConnection::remote_pubkey` => `peer_public_key`
- `AsyncSecretConnection::remote_pubkey` => `peer_public_key`

On both types, also adds `local_public_key` to retrieve our local identity key.

These names mirror the `local_addr` and `peer_addr` methods on `TcpStream` (which would also be nice to add).