### PR TITLE
tmkms-p2p: add pass-through `SocketAddr` accessors

### DIFF
--- a/tmkms-p2p/src/async_secret_connection.rs
+++ b/tmkms-p2p/src/async_secret_connection.rs
@@ -9,7 +9,11 @@ use crate::{
 };
 use ed25519_dalek::Signer;
 use prost::Message;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use std::{io, net::SocketAddr};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpStream,
+};
 
 #[cfg(doc)]
 use crate::IdentitySecret;
@@ -102,6 +106,18 @@ impl<Io> AsyncSecretConnection<Io> {
     /// - if the peer's public key is not initialized (library-internal bug)
     pub fn peer_public_key(&self) -> PublicKey {
         self.peer_public_key.expect("remote_pubkey uninitialized")
+    }
+}
+
+impl AsyncSecretConnection<TcpStream> {
+    /// Returns the socket address of the local side of this TCP connection.
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.io.local_addr()
+    }
+
+    /// Returns the socket address of the remote peer of the underlying TCP connection.
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        self.io.peer_addr()
     }
 }
 

--- a/tmkms-p2p/src/secret_connection.rs
+++ b/tmkms-p2p/src/secret_connection.rs
@@ -8,7 +8,10 @@ use crate::{
     traits::{ReadMsg, WriteMsg},
 };
 use prost::Message;
-use std::io::{self, Read, Write};
+use std::{
+    io::{self, Read, Write},
+    net::{SocketAddr, TcpStream},
+};
 
 #[cfg(doc)]
 use crate::IdentitySecret;
@@ -115,6 +118,18 @@ impl<Io> SecretConnection<Io> {
         self.peer_public_key
             .as_ref()
             .expect("remote_pubkey uninitialized")
+    }
+}
+
+impl SecretConnection<TcpStream> {
+    /// Returns the socket address of the local side of this TCP connection.
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.io.local_addr()
+    }
+
+    /// Returns the socket address of the remote peer of the underlying TCP connection.
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        self.io.peer_addr()
     }
 }
 


### PR DESCRIPTION
Passes `local_addr` and `peer_addr` through to the underlying `TcpStream` types, for both `std::io` and `tokio`.