### PR TITLE
tmkms-p2p: add `AsyncSecretConnection::split`

### DIFF
--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -60,7 +60,7 @@ pub use rand_core;
 
 #[cfg(feature = "async")]
 pub use crate::{
-    async_secret_connection::AsyncSecretConnection,
+    async_secret_connection::{AsyncMsgReader, AsyncMsgWriter, AsyncSecretConnection},
     traits::{AsyncReadMsg, AsyncWriteMsg},
 };
 


### PR DESCRIPTION
Support for splitting into independently owned `AsyncMsgReader` and `AsyncMsgWriter`, making it possible to do simultaneous reads/writes