### PR TITLE
tmkms-p2p: async trait ergonomics

### DIFF
--- a/tmkms-p2p/tests/async_secret_connection.rs
+++ b/tmkms-p2p/tests/async_secret_connection.rs
@@ -42,7 +42,7 @@ async fn integration_test() {
     for _ in 0..NUM_REQUESTS {
         let example_msg = example_msg();
 
-        conn.write_msg(&PingRequest {
+        conn.write_msg(PingRequest {
             msg: example_msg.clone(),
         })
         .await


### PR DESCRIPTION
- Make turbofish possible
- Have `write_msg` take ownership