### PR TITLE
tmkms-p2p: add `SecretReader` and `SecretWriter`

### DIFF
--- a/tmkms-p2p/src/lib.rs
+++ b/tmkms-p2p/src/lib.rs
@@ -53,14 +53,14 @@ pub use crate::{
     error::{CryptoError, Error, Result, VerifyPeerError},
     peer_id::PeerId,
     public_key::PublicKey,
-    secret_connection::SecretConnection,
-    traits::{ReadMsg, WriteMsg},
+    secret_connection::{SecretConnection, SecretReader, SecretWriter},
+    traits::{ReadMsg, TryCloneIo, WriteMsg},
 };
 pub use rand_core;
 
 #[cfg(feature = "async")]
 pub use crate::{
-    async_secret_connection::{AsyncMsgReader, AsyncMsgWriter, AsyncSecretConnection},
+    async_secret_connection::{AsyncSecretConnection, AsyncSecretReader, AsyncSecretWriter},
     traits::{AsyncReadMsg, AsyncWriteMsg},
 };
 

--- a/tmkms-p2p/src/traits.rs
+++ b/tmkms-p2p/src/traits.rs
@@ -2,16 +2,33 @@
 
 use crate::{Error, MAX_MSG_LEN, Result, proto};
 use prost::Message;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 
 #[cfg(feature = "async")]
 use std::future::Future;
 
-/// Message prefix length to always consume. This also represents the minimum message size.
-///
-/// This is picked to ensure that the entire length prefix will always fit in this size, namely
-/// we only support up to 1 MiB messages (`MAX_MSG_LEN`), which use max 3-byte length prefixes.
-const PREFIX_LEN: usize = 3;
+// NOTE: async trait definitions below opt to place the `M` parameter on the trait to make it
+// possible to turbofish the result message, which is helpful when dealing with an `impl Future`
+// output where it may be difficult to notate the return type. The use of RPIT means the trait
+// can't be dyn compatible / object safe anyway.
+
+/// Read the given Protobuf message from the underlying I/O object (async).
+#[cfg(feature = "async")]
+pub trait AsyncReadMsg {
+    /// Read from the underlying I/O object, decrypting the data and decoding it into the given
+    /// Protobuf message.
+    fn read_msg<M: Message + Default>(&mut self) -> impl Future<Output = Result<M>> + Send + Sync;
+}
+
+/// Write the given Protobuf message to the underlying I/O object (async).
+#[cfg(feature = "async")]
+pub trait AsyncWriteMsg {
+    /// Encode the given Protobuf as bytes, encrypted it, and write the ciphertext to the underlying
+    /// I/O object.
+    ///
+    /// Deliberately takes ownership of the message to send to simplify writing async code.
+    fn write_msg<M: Message>(&mut self, msg: M) -> impl Future<Output = Result<()>> + Send + Sync;
+}
 
 // NOTE: trait definitions below use a generic `M` parameter on the trait rather than the method to
 // support dyn compatibility / object safety.
@@ -32,31 +49,15 @@ pub trait WriteMsg<M: Message> {
     fn write_msg(&mut self, msg: &M) -> Result<()>;
 }
 
-// NOTE: async trait definitions below opt to place the `M` parameter on the trait to make it
-// possible to turbofish the result message, which is helpful when dealing with an `impl Future`
-// output where it may be difficult to notate the return type. The use of RPIT means the trait
-// can't be dyn compatible / object safe anyway.
-
-/// Read the given Protobuf message from the underlying I/O object (async).
-#[cfg(feature = "async")]
-pub trait AsyncReadMsg {
-    /// Read from the underlying I/O object, decoding (and if necessary decrypting) the data
-    /// to the given Protobuf message.
-    fn read_msg<M: Message + Default>(&mut self) -> impl Future<Output = Result<M>> + Send + Sync;
-}
-
-/// Write the given Protobuf message to the underlying I/O object (async).
-#[cfg(feature = "async")]
-pub trait AsyncWriteMsg {
-    /// Encode the given Protobuf as bytes and write them to the underlying I/O object
-    /// (and encrypting if necessary).
-    ///
-    /// Deliberately takes ownership of the message to send to simplify writing async code.
-    fn write_msg<M: Message>(&mut self, msg: M) -> impl Future<Output = Result<()>> + Send + Sync;
-}
-
 impl<M: Message + Default, Io: Read> ReadMsg<M> for Io {
     fn read_msg(&mut self) -> Result<M> {
+        /// Message prefix length to always consume. This also represents the minimum message size.
+        ///
+        /// This is picked to ensure that the entire length prefix will always fit in this size,
+        /// namely  we only support up to 1 MiB messages (`MAX_MSG_LEN`), which use max 3-byte
+        /// length prefixes.
+        const PREFIX_LEN: usize = 3;
+
         let mut prefix = [0u8; PREFIX_LEN];
         self.read_exact(&mut prefix)?;
 
@@ -80,6 +81,24 @@ impl<M: Message, Io: Write> WriteMsg<M> for Io {
     fn write_msg(&mut self, msg: &M) -> Result<()> {
         let bytes = msg.encode_length_delimited_to_vec();
         Ok(self.write_all(&bytes)?)
+    }
+}
+
+/// Attempt to clone an I/O object, returning an `io::Result`.
+pub trait TryCloneIo: Sized {
+    /// Try to clone the given I/O object.
+    fn try_clone(&self) -> io::Result<Self>;
+}
+
+impl TryCloneIo for std::net::TcpStream {
+    fn try_clone(&self) -> io::Result<Self> {
+        self.try_clone()
+    }
+}
+
+impl TryCloneIo for std::os::unix::net::UnixStream {
+    fn try_clone(&self) -> io::Result<Self> {
+        self.try_clone()
     }
 }
 

--- a/tmkms-p2p/tests/common/mod.rs
+++ b/tmkms-p2p/tests/common/mod.rs
@@ -2,7 +2,7 @@
 
 use prost::Message;
 use std::io::{Read, Write};
-use tmkms_p2p::{IdentitySecret, ReadMsg, SecretConnection, WriteMsg};
+use tmkms_p2p::{IdentitySecret, ReadMsg, SecretConnection, TryCloneIo, WriteMsg};
 
 /// Test server used for exercising `SecretConnection`.
 /// Implements basic ping/pong functionality
@@ -12,7 +12,7 @@ pub struct TestServer<Io> {
 
 impl<Io> TestServer<Io>
 where
-    Io: Read + Write + Send + Sync + 'static,
+    Io: Read + Write + Send + Sync + TryCloneIo + 'static,
 {
     pub fn run(io: Io, sk: IdentitySecret, num_requests: usize) {
         let mut server = TestServer {


### PR DESCRIPTION
Also adds `SecretConnection::split` for obtaining them.

Mirrors the implementation of `AsyncSecretConnection`.