### PR TITLE
tmkms-p2p: minor cleanups

### DIFF
--- a/tmkms-p2p/Cargo.toml
+++ b/tmkms-p2p/Cargo.toml
@@ -20,7 +20,7 @@ authors = [
 aead = { version = "0.5", default-features = false }
 base16ct = { version = "0.2", features = ["alloc"] }
 chacha20poly1305 = { version = "0.10", default-features = false }
-curve25519-dalek = { version = "4", default-features = false, features = ["rand_core"] }
+curve25519-dalek = { version = "4", default-features = false, features = ["rand_core", "zeroize"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["alloc", "rand_core", "zeroize"] }
 hkdf = { version = "0.12.3", default-features = false }
 merlin = { version = "3", default-features = false }

--- a/tmkms-p2p/src/test_vectors.rs
+++ b/tmkms-p2p/src/test_vectors.rs
@@ -55,7 +55,3 @@ pub(crate) const ENCRYPTION_KEY1: [u8; 32] =
     hex!("4de5c254243a6a7b52fafd0b0c4db59175975cd435e99b7f758265aaaeeea063");
 pub(crate) const ENCRYPTION_KEY2: [u8; 32] =
     hex!("6083a1a00e5ea92cdc380c55013f3c87d87ade022666fd5aad4ae3a1530d0885");
-
-/// Challenge message derived from the KDF.
-pub(crate) const CHALLENGE: [u8; 32] =
-    hex!("cad18a7a530a6fd6e7f56e372aab9ac9410eb0ab4ca1cee89f5089e58d9e9e3e");


### PR DESCRIPTION
- Enable `zeroize` on `curve25519-dalek` and zeroize DH shared secret
- Store ChaCha20Poly1305 state in a `Box` to avoid copies
- Get rid of legacy challenge from KDF (replaced by Merlin)