### PR TITLE
Use ed25519-dalek's ExpandedSecretKeys 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap = "4"
 cometbft-p2p = "0.2"
 cosmrs = "0.22"
 ed25519 = "2"
-ed25519-dalek = "2"
+ed25519-dalek = { version = "2", features = ["hazmat"] }
 elliptic-curve = { version = "0.13", features = ["pkcs8"], optional = true }
 eyre = "0.6"
 getrandom = "0.2"

--- a/src/commands/softsign/keygen.rs
+++ b/src/commands/softsign/keygen.rs
@@ -1,6 +1,6 @@
 //! `tmkms softsign keygen` subcommand
 
-use crate::{key_utils, keyring::ed25519, prelude::*};
+use crate::{key_utils, prelude::*};
 use abscissa_core::Command;
 use clap::Parser;
 use k256::ecdsa;
@@ -70,7 +70,7 @@ fn generate_secp256k1_key(output_path: &Path) {
 fn generate_ed25519_key(output_path: &Path) {
     let mut sk_bytes = [0u8; 32];
     OsRng.fill_bytes(&mut sk_bytes);
-    let sk = ed25519::SigningKey::from(sk_bytes);
+    let sk = ed25519_dalek::SigningKey::from(sk_bytes);
 
     key_utils::write_base64_secret(output_path, sk.as_bytes()).unwrap_or_else(|e| {
         status_err!("{}", e);

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -32,7 +32,7 @@ pub fn open_secret_connection(
         )
     })?;
 
-    let identity_key = IdentitySecret::from(key_utils::load_base64_ed25519_key(identity_key_path)?);
+    let identity_key = IdentitySecret::from(key_utils::load_identity_key(identity_key_path)?);
     info!("KMS node ID: {}", PublicKey::from(&identity_key));
 
     let socket = TcpStream::connect(format!("{host}:{port}"))?;

--- a/src/keyring/ed25519/signing_key.rs
+++ b/src/keyring/ed25519/signing_key.rs
@@ -1,50 +1,82 @@
 use super::{Signature, VerifyingKey};
 use crate::error::{Error, ErrorKind};
+use sha2::Sha512;
 use signature::Signer;
 
-/// Signing key serialized as bytes.
-type SigningKeyBytes = [u8; SigningKey::BYTE_SIZE];
+const COMBINED_KEY_LENGTH: usize =
+    ed25519_dalek::EXPANDED_SECRET_KEY_LENGTH + ed25519_dalek::PUBLIC_KEY_LENGTH;
 
 /// Ed25519 signing key.
-#[derive(Clone, Debug)]
-pub struct SigningKey(ed25519_dalek::SigningKey);
+#[derive(Debug)]
+pub struct SigningKey(ed25519_dalek::hazmat::ExpandedSecretKey);
 
 impl SigningKey {
     /// Size of an encoded Ed25519 signing key in bytes.
     pub const BYTE_SIZE: usize = 32;
 
-    /// Borrow the serialized signing key as bytes.
-    pub fn as_bytes(&self) -> &SigningKeyBytes {
-        self.0.as_bytes()
-    }
-
     /// Get the verifying key for this signing key.
     pub fn verifying_key(&self) -> VerifyingKey {
-        VerifyingKey(self.0.verifying_key())
+        let public_key = ed25519_dalek::VerifyingKey::from(&self.0);
+        VerifyingKey(public_key)
     }
 }
 
-impl From<SigningKeyBytes> for SigningKey {
-    fn from(bytes: SigningKeyBytes) -> Self {
-        Self(bytes.into())
+impl Signer<Signature> for SigningKey {
+    fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
+        let signature =
+            ed25519_dalek::hazmat::raw_sign::<Sha512>(&self.0, msg, &self.verifying_key().0);
+        Ok(signature.to_bytes().into())
     }
 }
 
-impl From<SigningKey> for ed25519_dalek::SigningKey {
-    fn from(signing_key: SigningKey) -> ed25519_dalek::SigningKey {
-        signing_key.0
+impl TryFrom<&[u8]> for SigningKey {
+    type Error = Error;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Error> {
+        match slice.len() {
+            ed25519_dalek::SECRET_KEY_LENGTH => {
+                let secret_key =
+                    ed25519_dalek::SecretKey::try_from(slice).map_err(|_| ErrorKind::InvalidKey)?;
+                let expanded_key = ed25519_dalek::hazmat::ExpandedSecretKey::from(&secret_key);
+                Ok(Self(expanded_key))
+            }
+
+            // big-endian encoded, prehashed key
+            ed25519_dalek::EXPANDED_SECRET_KEY_LENGTH => {
+                let expanded_key = ed25519_dalek::hazmat::ExpandedSecretKey::from_bytes(
+                    slice.try_into().map_err(|_| ErrorKind::InvalidKey)?,
+                );
+
+                Ok(Self(expanded_key))
+            }
+
+            // little-endian encoded, prehashed key, exported from YubiHSM
+            COMBINED_KEY_LENGTH => {
+                let mut key_bytes: [u8; ed25519_dalek::EXPANDED_SECRET_KEY_LENGTH] = slice
+                    [..ed25519_dalek::EXPANDED_SECRET_KEY_LENGTH]
+                    .try_into()
+                    .map_err(|_| ErrorKind::InvalidKey)?;
+
+                key_bytes[..ed25519_dalek::SECRET_KEY_LENGTH].reverse();
+
+                let expanded_key = ed25519_dalek::hazmat::ExpandedSecretKey::from_bytes(&key_bytes);
+
+                Ok(Self(expanded_key))
+            }
+
+            other_len => Err(ErrorKind::InvalidKey
+                .context(format!(
+                    "invalid Ed25519 key size: expected 32, 64, or 96, but got {}",
+                    other_len
+                ))
+                .into()),
+        }
     }
 }
 
 impl From<&SigningKey> for cometbft_p2p::PublicKey {
     fn from(signing_key: &SigningKey) -> cometbft_p2p::PublicKey {
-        Self::from(&signing_key.0)
-    }
-}
-
-impl From<ed25519_dalek::SigningKey> for SigningKey {
-    fn from(signing_key: ed25519_dalek::SigningKey) -> SigningKey {
-        SigningKey(signing_key)
+        signing_key.verifying_key().into()
     }
 }
 
@@ -54,22 +86,5 @@ impl From<tendermint::private_key::Ed25519> for SigningKey {
             .as_bytes()
             .try_into()
             .expect("invalid Ed25519 signing key")
-    }
-}
-
-impl Signer<Signature> for SigningKey {
-    fn try_sign(&self, msg: &[u8]) -> signature::Result<Signature> {
-        Ok(self.0.sign(msg).to_bytes().into())
-    }
-}
-
-impl TryFrom<&[u8]> for SigningKey {
-    type Error = Error;
-
-    fn try_from(slice: &[u8]) -> Result<Self, Error> {
-        slice
-            .try_into()
-            .map(Self)
-            .map_err(|_| ErrorKind::InvalidKey.into())
     }
 }

--- a/src/keyring/providers/softsign.rs
+++ b/src/keyring/providers/softsign.rs
@@ -81,7 +81,7 @@ fn load_ed25519_key(config: &SoftsignConfig) -> Result<ed25519::SigningKey, Erro
     let key_format = config.key_format.as_ref().cloned().unwrap_or_default();
 
     match key_format {
-        KeyFormat::Base64 => key_utils::load_base64_ed25519_key(&config.path),
+        KeyFormat::Base64 => key_utils::load_signing_key(&config.path),
         KeyFormat::Json => {
             let private_key = PrivValidatorKey::load_json_file(&config.path)
                 .map_err(|e| {


### PR DESCRIPTION
another stab at using the prehashed, expanded secret keys.
I tried to take: https://github.com/iqlusioninc/tmkms/pull/978#discussion_r2274564785 into the account, so now it's using the ExpandedSecretKey across the board, trying to guess the type/encoding based on the supplied keylength.

One thing to note is that I split loading signing keys and identity keys, keeping this coupled would require some changes to the p2p crate, which I wanted to avoid. 

previous prs:
- https://github.com/iqlusioninc/tmkms/pull/891
- https://github.com/iqlusioninc/tmkms/pull/742
- https://github.com/iqlusioninc/tmkms/pull/978