### PR TITLE
Silence `generic-array` deprecation warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",

--- a/src/commands/yubihsm/keys/list.rs
+++ b/src/commands/yubihsm/keys/list.rs
@@ -3,9 +3,11 @@
 use crate::{Map, chain, keyring, prelude::*};
 use abscissa_core::Command;
 use clap::Parser;
-use k256::elliptic_curve::generic_array::GenericArray;
 use std::{path::PathBuf, process};
 use tendermint::{PublicKey, TendermintKey};
+
+#[allow(deprecated)]
+use k256::elliptic_curve::generic_array::GenericArray;
 
 /// The `yubihsm keys list` subcommand
 #[derive(Command, Debug, Default, Parser)]
@@ -123,12 +125,12 @@ fn display_key_info(
 
     let tendermint_key = match public_key.algorithm {
         yubihsm::asymmetric::Algorithm::EcK256 => {
+            #[allow(deprecated)]
+            let pk = GenericArray::from_slice(public_key.as_ref());
+
             // The YubiHSM2 returns the uncompressed public key, so for
             // compatibility with Tendermint, we have to compress it first
-            let compressed_pubkey = k256::EncodedPoint::from_untagged_bytes(
-                GenericArray::from_slice(public_key.as_ref()),
-            )
-            .compress();
+            let compressed_pubkey = k256::EncodedPoint::from_untagged_bytes(pk).compress();
 
             TendermintKey::AccountKey(
                 PublicKey::from_raw_secp256k1(compressed_pubkey.as_ref()).unwrap(),


### PR DESCRIPTION
The real upgrade will be to `hybrid-array` with the next RustCrypto crate releases