### PR TITLE
Remove `cosmrs` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,23 +215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
-name = "bip32"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db40d3dfbeab4e031d78c844642fa0caa0b0db11ce1607ac9d2986dff1405c69"
-dependencies = [
- "bs58",
- "hmac",
- "k256",
- "rand_core",
- "ripemd",
- "secp256k1",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,15 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -514,36 +488,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cosmos-sdk-proto"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ac39be7373404accccaede7cc1ec942ccef14f0ca18d209967a756bf1dbb1f"
-dependencies = [
- "prost",
- "tendermint-proto",
-]
-
-[[package]]
-name = "cosmrs"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e74fa7a22930fe0579bef560f2d64b78415d4c47b9dd976c0635136809471d"
-dependencies = [
- "bip32",
- "cosmos-sdk-proto",
- "ecdsa",
- "eyre",
- "k256",
- "rand_core",
- "serde",
- "serde_json",
- "signature",
- "subtle-encoding",
- "tendermint",
- "thiserror",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -2031,24 +1975,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
-dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,7 +2461,6 @@ dependencies = [
  "chrono",
  "clap",
  "cometbft-p2p",
- "cosmrs",
  "ed25519",
  "ed25519-dalek",
  "elliptic-curve",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bytes = "1"
 chrono = "0.4"
 clap = "4"
 cometbft-p2p = "0.2"
-cosmrs = "0.22"
 ed25519 = "2"
 ed25519-dalek = "2"
 elliptic-curve = { version = "0.13", features = ["pkcs8"], optional = true }

--- a/src/keyring/format.rs
+++ b/src/keyring/format.rs
@@ -1,9 +1,14 @@
 //! Chain-specific key configuration
 
-use cosmrs::crypto::PublicKey;
-use serde::Deserialize;
-use subtle_encoding::bech32;
+use serde::{Deserialize, Serialize};
+use subtle_encoding::{base64, bech32};
 use tendermint::TendermintKey;
+
+/// Protobuf [`Any`] type URL for Ed25519 public keys
+const ED25519_TYPE_URL: &str = "/cosmos.crypto.ed25519.PubKey";
+
+/// Protobuf [`Any`] type URL for secp256k1 public keys
+const SECP256K1_TYPE_URL: &str = "/cosmos.crypto.secp256k1.PubKey";
 
 /// Options for how keys for this chain are represented
 #[derive(Clone, Debug, Deserialize)]
@@ -41,11 +46,45 @@ impl Format {
                 }
                 TendermintKey::ConsensusKey(pk) => pk.to_bech32(consensus_key_prefix),
             },
-            Format::CosmosJson => PublicKey::from(*public_key.public_key()).to_json(),
+            Format::CosmosJson => {
+                let pk = match public_key {
+                    TendermintKey::AccountKey(pk) => PublicKeyJson::from(&pk),
+                    TendermintKey::ConsensusKey(pk) => PublicKeyJson::from(&pk),
+                };
+                serde_json::to_string(&pk).expect("JSON serialization error")
+            }
             Format::Hex => match public_key {
                 TendermintKey::AccountKey(pk) => pk.to_hex(),
                 TendermintKey::ConsensusKey(pk) => pk.to_hex(),
             },
         }
+    }
+}
+
+/// Serde encoding type for JSON public keys.
+///
+/// Uses Protobuf JSON encoding conventions.
+#[derive(Deserialize, Serialize)]
+struct PublicKeyJson {
+    /// `@type` field e.g. `/cosmos.crypto.ed25519.PubKey`.
+    #[serde(rename = "@type")]
+    type_url: String,
+
+    /// Key data: standard Base64 encoded with padding.
+    key: String,
+}
+
+impl From<&tendermint::PublicKey> for PublicKeyJson {
+    fn from(public_key: &tendermint::PublicKey) -> PublicKeyJson {
+        let type_url = match public_key {
+            tendermint::PublicKey::Ed25519(_) => ED25519_TYPE_URL,
+            tendermint::PublicKey::Secp256k1(_) => SECP256K1_TYPE_URL,
+            // `tendermint::PublicKey` is `non_exhaustive`
+            _ => unreachable!("unknown pubic key type"),
+        }
+        .to_owned();
+
+        let key = String::from_utf8(base64::encode(public_key.to_bytes())).expect("UTF-8 error");
+        PublicKeyJson { type_url, key }
     }
 }


### PR DESCRIPTION
To unblock the upgrade to `cometbft-rs` (#1124), this removes the only usage of `cosmrs`, which is for formatting Cosmos JSON public keys.