### PR TITLE
Use `iq-cometbft` crate releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,15 +222,6 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -419,7 +410,7 @@ checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
  "cipher",
  "dbl",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -442,48 +433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "cometbft"
-version = "0.1.0-alpha.2"
-source = "git+https://github.com/cometbft/cometbft-rs.git?rev=71af716216216cfdc150cacef5ceae3610a5824b#71af716216216cfdc150cacef5ceae3610a5824b"
-dependencies = [
- "bytes",
- "cometbft-proto",
- "digest 0.10.7",
- "ed25519",
- "ed25519-consensus",
- "flex-error",
- "futures",
- "k256",
- "num-traits",
- "once_cell",
- "prost",
- "ripemd",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2 0.10.9",
- "signature",
- "subtle",
- "subtle-encoding",
- "time",
- "zeroize",
-]
-
-[[package]]
-name = "cometbft-config"
-version = "0.1.0-alpha.2"
-source = "git+https://github.com/cometbft/cometbft-rs.git?rev=71af716216216cfdc150cacef5ceae3610a5824b#71af716216216cfdc150cacef5ceae3610a5824b"
-dependencies = [
- "cometbft",
- "flex-error",
- "serde",
- "serde_json",
- "toml",
- "url 2.5.7",
-]
-
-[[package]]
 name = "cometbft-p2p"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,23 +447,9 @@ dependencies = [
  "merlin",
  "prost",
  "rand_core",
- "sha2 0.10.9",
+ "sha2",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "cometbft-proto"
-version = "0.1.0-alpha.2"
-source = "git+https://github.com/cometbft/cometbft-rs.git?rev=71af716216216cfdc150cacef5ceae3610a5824b#71af716216216cfdc150cacef5ceae3610a5824b"
-dependencies = [
- "bytes",
- "flex-error",
- "prost",
- "serde",
- "serde_bytes",
- "subtle-encoding",
- "time",
 ]
 
 [[package]]
@@ -589,7 +524,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "rand_core",
  "rustc_version",
@@ -606,19 +541,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core",
- "subtle-ng",
- "zeroize",
 ]
 
 [[package]]
@@ -652,20 +574,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -689,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -707,19 +620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-consensus"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
-dependencies = [
- "curve25519-dalek-ng",
- "hex 0.4.3",
- "rand_core",
- "sha2 0.9.9",
- "zeroize",
-]
-
-[[package]]
 name = "ed25519-dalek"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,7 +629,7 @@ dependencies = [
  "ed25519",
  "rand_core",
  "serde",
- "sha2 0.10.9",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -748,7 +648,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -772,7 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1069,12 +969,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hidapi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,7 +990,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "rand_core",
- "sha2 0.10.9",
+ "sha2",
  "zeroize",
 ]
 
@@ -1115,7 +1009,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1350,6 +1244,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "iq-cometbft"
+version = "0.1.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653e45fc95283936c315f2cbc6ed72dad55f8f5ca457cbcaf61b757a314df030"
+dependencies = [
+ "bytes",
+ "digest",
+ "ed25519",
+ "ed25519-dalek",
+ "flex-error",
+ "futures",
+ "iq-cometbft-proto",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "ripemd",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "iq-cometbft-config"
+version = "0.1.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049182ea12174a679a2bfee8925a34c3e9debb7ed3586c4f120ed5bc731da0fb"
+dependencies = [
+ "flex-error",
+ "iq-cometbft",
+ "serde",
+ "serde_json",
+ "toml",
+ "url 2.5.7",
+]
+
+[[package]]
+name = "iq-cometbft-proto"
+version = "0.1.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbbf54c677e57581b666f2cecfea937d1590762c36f2ed952bbcc5e68a0e4463"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "prost",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,7 +1343,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.9",
+ "sha2",
  "signature",
 ]
 
@@ -1417,7 +1370,7 @@ checksum = "6c9a2f47929b010a64a4bf9cdfe03b0d02175d44db0b91e16283f5a4a731d52c"
 dependencies = [
  "byteorder",
  "cfg-if 0.1.10",
- "hex 0.3.2",
+ "hex",
  "hidapi",
  "lazy_static",
  "libc",
@@ -1660,7 +1613,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1672,7 +1625,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1687,7 +1640,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "hmac",
 ]
 
@@ -1903,7 +1856,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1962,7 +1915,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2142,20 +2095,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -2166,7 +2106,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2190,7 +2130,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core",
  "signature_derive",
 ]
@@ -2281,12 +2221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,7 +2275,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2459,10 +2393,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "cometbft",
- "cometbft-config",
  "cometbft-p2p",
- "cometbft-proto",
  "ed25519",
  "ed25519-dalek",
  "elliptic-curve",
@@ -2470,6 +2401,9 @@ dependencies = [
  "getrandom 0.2.16",
  "hkd32",
  "hkdf",
+ "iq-cometbft",
+ "iq-cometbft-config",
+ "iq-cometbft-proto",
  "k256",
  "ledger",
  "once_cell",
@@ -2480,7 +2414,7 @@ dependencies = [
  "sdkms",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "signature",
  "subtle",
  "subtle-encoding",
@@ -2878,7 +2812,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3170,7 +3104,7 @@ dependencies = [
  "cbc",
  "ccm",
  "cmac",
- "digest 0.10.7",
+ "digest",
  "ecdsa",
  "ed25519",
  "ed25519-dalek",
@@ -3184,7 +3118,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2",
  "signature",
  "subtle",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ abscissa_core = "0.8"
 bytes = "1"
 chrono = "0.4"
 clap = "4"
-cometbft = { git = "https://github.com/cometbft/cometbft-rs.git", rev = "71af716216216cfdc150cacef5ceae3610a5824b", features = ["secp256k1"] }
-cometbft-config = { git = "https://github.com/cometbft/cometbft-rs.git", rev = "71af716216216cfdc150cacef5ceae3610a5824b" }
-cometbft-proto = { git = "https://github.com/cometbft/cometbft-rs.git", rev = "71af716216216cfdc150cacef5ceae3610a5824b" }
+cometbft = { package = "iq-cometbft", version = "=0.1.0-pre.1", features = ["secp256k1"] }
+cometbft-config = { package = "iq-cometbft-config", version = "=0.1.0-pre.1" }
+cometbft-proto = { package = "iq-cometbft-proto", version = "=0.1.0-pre.0" }
 cometbft-p2p = "0.2"
 ed25519 = "2"
 ed25519-dalek = "2"


### PR DESCRIPTION
To make TMKMS releasable, this uses forks of cometbft-rs which have been released to crates.io