### PR TITLE
Vendor protos and re-enable Celestia `SignRawBytes*` extension

### DIFF
--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -4,11 +4,11 @@ use crate::{
     chain,
     prelude::*,
     privval::{ConsensusMsg, ConsensusMsgType},
+    proto,
 };
 use abscissa_core::{Command, Runnable};
 use clap::{Parser, Subcommand};
 use cometbft::Vote;
-use cometbft_proto as proto;
 use std::{path::PathBuf, process};
 
 /// `ledger` subcommand

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,8 +1,8 @@
 //! Connections to a validator (TCP or Unix socket)
 
 use self::unix::UnixConnection;
+use crate::proto;
 use cometbft_p2p::{ReadMsg, SecretConnection, WriteMsg};
-use cometbft_proto as proto;
 use std::io;
 
 pub mod tcp;
@@ -10,7 +10,7 @@ pub mod unix;
 
 /// Connections to a validator
 pub trait Connection:
-    ReadMsg<proto::privval::v1beta1::Message> + WriteMsg<proto::privval::v1beta1::Message> + Sync + Send
+    ReadMsg<proto::privval::Message> + WriteMsg<proto::privval::Message> + Sync + Send
 {
 }
 

--- a/src/keyring/signature.rs
+++ b/src/keyring/signature.rs
@@ -1,8 +1,8 @@
 //! Signing signature
 
 pub use super::ed25519;
+use crate::proto;
 pub use k256::ecdsa;
-// use cometbft_proto as proto;
 
 /// Cryptographic signature used for block signing
 pub enum Signature {
@@ -41,12 +41,11 @@ impl From<Signature> for cometbft::Signature {
     }
 }
 
-// TODO(tarcieri): vendor the `SignedRawBytes*` protos
-// impl From<Signature> for proto::privval::v1beta1::SignedRawBytesResponse {
-//     fn from(sig: Signature) -> Self {
-//         proto::privval::v1beta1::SignedRawBytesResponse {
-//             signature: sig.to_vec(),
-//             error: None,
-//         }
-//     }
-// }
+impl From<Signature> for proto::privval::celestia::SignedRawBytesResponse {
+    fn from(sig: Signature) -> Self {
+        proto::privval::celestia::SignedRawBytesResponse {
+            signature: sig.to_vec(),
+            error: None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod key_utils;
 pub mod keyring;
 pub mod prelude;
 pub mod privval;
+pub mod proto;
 pub mod rpc;
 pub mod session;
 

--- a/src/privval.rs
+++ b/src/privval.rs
@@ -1,8 +1,8 @@
 //! Validator private key operations: signing consensus votes and proposals.
 
+use crate::proto;
 use bytes::{Bytes, BytesMut};
 use cometbft::{Error, Proposal, Vote, block, chain, consensus, vote};
-use cometbft_proto as proto;
 use prost::{EncodeError, Message as _};
 
 /// Message codes.

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,0 +1,6 @@
+//! Protobuf definitions.
+
+#![allow(missing_docs)]
+
+pub mod privval;
+pub use cometbft_proto::{consensus, crypto, google, types, v0_38};

--- a/src/proto/privval.rs
+++ b/src/proto/privval.rs
@@ -1,0 +1,14 @@
+//! Private validator connection to a remote signer.
+
+pub mod celestia;
+pub mod message;
+
+pub use cometbft_proto::privval::v1beta1;
+
+/// Message type containing the `celestia` extensions
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Message {
+    #[prost(oneof = "message::Sum", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10")]
+    pub sum: Option<message::Sum>,
+}

--- a/src/proto/privval/celestia.rs
+++ b/src/proto/privval/celestia.rs
@@ -1,0 +1,29 @@
+//! Celestia protobuf extensions
+//!
+//! Contains extensions which aren't part of upstream CometBFT:
+//! <https://github.com/cometbft/tendermint-rs/commit/d7ce755d56826e8c5fbe1d059fb5ab1e2cab7c5b>
+//!
+//! See PR to upstream this functionality here:
+//! <https://github.com/cometbft/cometbft/pull/5138>
+
+use super::v1beta1::RemoteSignerError;
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignRawBytesRequest {
+    #[prost(string, tag = "1")]
+    pub chain_id: String,
+    #[prost(bytes = "vec", tag = "2")]
+    pub raw_bytes: Vec<u8>,
+    #[prost(string, tag = "3")]
+    pub unique_id: String,
+}
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignedRawBytesResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub signature: Vec<u8>,
+    #[prost(message, optional, tag = "2")]
+    pub error: Option<RemoteSignerError>,
+}

--- a/src/proto/privval/message.rs
+++ b/src/proto/privval/message.rs
@@ -1,0 +1,33 @@
+//! Vendored from:
+//! <https://github.com/cometbft/tendermint-rs/commit/d7ce755d56826e8c5fbe1d059fb5ab1e2cab7c5b>
+//!
+//! See `celestia.rs` for more information.
+
+use super::{celestia, v1beta1};
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+pub enum Sum {
+    #[prost(message, tag = "1")]
+    PubKeyRequest(v1beta1::PubKeyRequest),
+    #[prost(message, tag = "2")]
+    PubKeyResponse(v1beta1::PubKeyResponse),
+    #[prost(message, tag = "3")]
+    SignVoteRequest(v1beta1::SignVoteRequest),
+    #[prost(message, tag = "4")]
+    SignedVoteResponse(v1beta1::SignedVoteResponse),
+    #[prost(message, tag = "5")]
+    SignProposalRequest(v1beta1::SignProposalRequest),
+    #[prost(message, tag = "6")]
+    SignedProposalResponse(v1beta1::SignedProposalResponse),
+    #[prost(message, tag = "7")]
+    PingRequest(v1beta1::PingRequest),
+    #[prost(message, tag = "8")]
+    PingResponse(v1beta1::PingResponse),
+
+    // Celestia extensions
+    #[prost(message, tag = "9")]
+    SignRawBytesRequest(celestia::SignRawBytesRequest),
+    #[prost(message, tag = "10")]
+    SignedRawBytesResponse(celestia::SignedRawBytesResponse),
+}


### PR DESCRIPTION
Re-enables support for signing raw bytes using a consensus key, originally added in #969.

That PR originally sourced its protos via git from:

https://github.com/rach-id/tendermint-rs/commits/rachid/generate-latest-v38-protos

To avoid the git dependency, this vendors the relevant protos, until such a time that they can be merged into CometBFT properly, i.e.:

https://github.com/cometbft/cometbft/pull/5138