### PR TITLE
Add `protocol_version = "v0.38"`

### DIFF
--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -34,10 +34,15 @@ pub struct ValidatorConfig {
 }
 
 /// Protocol version (based on the Tendermint version)
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum ProtocolVersion {
-    /// Tendermint v0.34 and newer.
+    /// Tendermint v0.38
+    #[default]
+    #[serde(rename = "v0.38")]
+    V0_38,
+
+    /// Legacy: Tendermint v0.34
     #[serde(rename = "v0.34")]
     V0_34,
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     chain::{self, Chain, state::StateErrorKind},
-    config::ValidatorConfig,
+    config::{ValidatorConfig, validator::ProtocolVersion},
     connection::{Connection, tcp, unix::UnixConnection},
     error::{Error, ErrorKind::*},
     prelude::*,
@@ -27,9 +27,9 @@ pub struct Session {
 impl Session {
     /// Open a session using the given validator configuration
     pub fn open(config: ValidatorConfig) -> Result<Self, Error> {
-        if config.protocol_version.is_some() {
+        if config.protocol_version == Some(ProtocolVersion::V0_34) {
             warn!(
-                "[{}]: deprecated `protocol_version` field in config! Will be a hard error in next release",
+                "[{}]: deprecated `protocol_version` v0.34 (update to v0.38)! Will be a hard error in next release",
                 &config.chain_id,
             );
         }

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -37,6 +37,7 @@ addr = "tcp://f88883b673fc69d7869cab098de3bafc2ff76eb8@example1.example.com:2665
 chain_id = "cosmoshub-3"
 reconnect = true # true is the default
 secret_key = "path/to/secret_connection.key"
+protocol_version = "v0.38"
 # max_height = "500000"
 
 ## Signing provider configuration
@@ -68,17 +69,3 @@ path = "path/to/consensus-ed25519.key" # generate using `tmkms softsign keygen -
 #chain_ids = ["irishub"]
 #key_type = "account"
 #path = "path/to/account-secp256k1.key" # generate using `tmkms softsign keygen -t account account-secp256k1.key`
-
-## (Optional) Transaction signer configuration
-
-# example transaction signer: sign StdTx-strucutred transactions with a KMS-managed key
-# [[tx_signer]]
-# chain_id = "irishub"
-# schema = "iris_tx_schema.toml" # See example TERRA_SCHEMA at https://docs.rs/stdtx#usage
-# account_number = 101072
-# account_address = "iap1qqqsyqcyq5rqwzqfpg9scrgwpugpzysnfxh53h" # must be in the keyring for this chain
-# acl = { msg_type = ["oracle/MsgExchangeRatePrevote", "oracle/MsgExchangeRateVote"] }
-# poll_interval = { blocks = 5 }
-# source = { protocol = "jsonrpc", uri = "http://127.0.0.1:23456" }
-# rpc = { addr = "tcp://127.0.0.1:26657" }
-# seq_file = "irishub-account-seq.json"


### PR DESCRIPTION
We'll need to migrate to CometBFT V1 at some point, which contains breaking changes.

Rather than getting rid of the `protocol_version` field under `[validator]`, it can instead be repurposed to assist in the migration.

First we need to get people to update it to `v0.38`, which is the proto version we source from (iq-)`cometbft-rs`.

After that we can add support for `v1`, and eventually make it the default.