### PR TITLE
fix(chain): make consensus state file writes durable with fsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ In particular, there is presently **no double signing defense** in the case
 that multiple KMS instances are running simultaneously and connecting to
 multiple validators on the same network.
 
+The signing state is persisted durably before each signature is produced: the
+state file contents are fsynced, and its parent directory is fsynced after the
+atomic rename, so a crash or power loss cannot revert to an older
+height/round/step. This requires the directory holding `state_file` to be
+readable by the user running `tmkms` and to be on a filesystem that supports
+fsync on a directory handle. Where it is not, signing fails rather than
+proceeding without durable protection.
+
 ## Signing Providers
 
 You **MUST** select one or more signing provider(s) when compiling the KMS,
@@ -44,6 +52,7 @@ instructions on how to build Tendermint KMS).
 The following signing backend providers are presently supported:
 
 #### Hardware Security Modules (recommended)
+
 - [FortanixDSM](./README.fortanixdsm.md) (gated under the `fortanixdsm` cargo feature.
   See [README.fortanixdsm.md](./README.fortanixdsm.md)
 - [YubiHSM2] (gated under the `yubihsm` cargo feature. See [README.yubihsm.md][yubihsm2])
@@ -224,8 +233,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-[//]: # (badges)
-
+[//]: # 'badges'
 [crate-image]: https://img.shields.io/crates/v/tmkms.svg
 [crate-link]: https://crates.io/crates/tmkms
 [build-image]: https://github.com/iqlusioninc/tmkms/actions/workflows/ci.yml/badge.svg
@@ -233,9 +241,7 @@ limitations under the License.
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/tmkms/blob/main/LICENSE
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
-
-[//]: # (links)
-
+[//]: # 'links'
 [CometBFT]: https://cometbft.com/
 [Tendermint]: https://tendermint.com/
 [Cosmos Validators]: https://hub.cosmos.network/main/validators/validator-faq

--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -189,13 +189,7 @@ impl State {
 
         let json = serde_json::to_string(&self.consensus_state)?;
 
-        let state_file_dir = self.state_file_path.parent().unwrap_or_else(|| {
-            panic!("state file cannot be root directory");
-        });
-
-        let mut state_file = NamedTempFile::new_in(state_file_dir)?;
-        state_file.write_all(json.as_bytes())?;
-        state_file.persist(&self.state_file_path)?;
+        atomic_durable_write(&self.state_file_path, json.as_bytes())?;
 
         debug!(
             "successfully wrote new consensus state to {}",
@@ -204,6 +198,40 @@ impl State {
 
         Ok(())
     }
+}
+
+/// Atomically replace the file at `path` with the given contents, durably:
+/// the contents are fsynced before the atomic rename and the parent
+/// directory is fsynced after it, so the replacement survives a crash or
+/// power loss once this function returns.
+fn atomic_durable_write(path: &Path, contents: &[u8]) -> io::Result<()> {
+    // A bare relative filename has an empty parent, which means the current
+    // directory for opening/fsyncing purposes.
+    let dir = match path.parent() {
+        Some(dir) if dir.as_os_str().is_empty() => Path::new("."),
+        Some(dir) => dir,
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "path has no parent directory",
+            ));
+        }
+    };
+
+    let mut file = NamedTempFile::new_in(dir)?;
+    file.write_all(contents)?;
+    // Flush the contents to stable storage before the rename; `persist` alone
+    // only guarantees atomicity, not durability. On Apple targets `sync_all`
+    // issues `fcntl(F_FULLFSYNC)`, which is required for media durability there.
+    file.as_file().sync_all()?;
+    file.persist(path)?;
+
+    // The rename itself is only durable once the parent directory entry is
+    // flushed, which POSIX requires an fsync of the directory for.
+    #[cfg(unix)]
+    fs::File::open(dir)?.sync_all()?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -311,4 +339,64 @@ mod tests {
         state!(1, 1, 2, None),
         state!(1, 1, 2, block_id!(EXAMPLE_BLOCK_ID))
     );
+
+    #[test]
+    fn atomic_durable_write_creates_file_with_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        atomic_durable_write(&path, b"{\"height\":\"1\"}").unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), b"{\"height\":\"1\"}");
+    }
+
+    #[test]
+    fn atomic_durable_write_replaces_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        fs::write(&path, b"old contents").unwrap();
+
+        atomic_durable_write(&path, b"new contents").unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), b"new contents");
+    }
+
+    #[test]
+    fn atomic_durable_write_leaves_no_temp_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        atomic_durable_write(&path, b"contents").unwrap();
+
+        let names: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect();
+        assert_eq!(names, vec!["state.json"]);
+    }
+
+    #[test]
+    fn atomic_durable_write_accepts_bare_relative_path() {
+        struct RemoveOnDrop(&'static str);
+        impl Drop for RemoveOnDrop {
+            fn drop(&mut self) {
+                let _ = fs::remove_file(self.0);
+            }
+        }
+        let path = "atomic_durable_write_bare_relative_test.json";
+        let _cleanup = RemoveOnDrop(path);
+
+        atomic_durable_write(Path::new(path), b"contents").unwrap();
+
+        assert_eq!(fs::read(path).unwrap(), b"contents");
+    }
+
+    #[test]
+    fn atomic_durable_write_errors_when_parent_dir_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing_subdir").join("state.json");
+
+        atomic_durable_write(&path, b"contents")
+            .expect_err("expected error when parent directory does not exist");
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,7 +11,7 @@ use std::{
     os::unix::net::{UnixListener, UnixStream},
     process::{Child, Command},
 };
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 use tmkms::{
     config::provider::KeyType,
     connection::Connection,
@@ -74,6 +74,10 @@ struct KmsProcess {
 
     /// A socket to KMS process
     socket: KmsSocket,
+
+    /// Directory holding this process's double-sign protection state file,
+    /// kept alive (and cleaned up) for the lifetime of the process
+    _state_dir: TempDir,
 }
 
 impl KmsProcess {
@@ -81,7 +85,8 @@ impl KmsProcess {
     pub fn create_tcp(key_type: &KeyType) -> Self {
         // Generate a random port and a config file
         let port: u16 = rand::thread_rng().gen_range(60000..=65535);
-        let config = KmsProcess::create_tcp_config(port, key_type);
+        let state_dir = tempfile::tempdir().unwrap();
+        let config = KmsProcess::create_tcp_config(port, key_type, &state_dir);
 
         // Listen on a random port
         let listener = TcpListener::bind(format!("{}:{}", "127.0.0.1", port)).unwrap();
@@ -93,6 +98,7 @@ impl KmsProcess {
         Self {
             process,
             socket: KmsSocket::TCP(socket),
+            _state_dir: state_dir,
         }
     }
 
@@ -103,7 +109,8 @@ impl KmsProcess {
         let letter: char = rng.gen_range(b'a'..=b'z') as char;
         let number: u32 = rng.gen_range(0..=999999);
         let socket_path = format!("/tmp/tmkms-{letter}{number:06}.sock");
-        let config = KmsProcess::create_unix_config(&socket_path, key_type);
+        let state_dir = tempfile::tempdir().unwrap();
+        let config = KmsProcess::create_unix_config(&socket_path, key_type, &state_dir);
 
         // Start listening for connections via the Unix socket
         let listener = UnixListener::bind(socket_path).unwrap();
@@ -116,14 +123,16 @@ impl KmsProcess {
         Self {
             process,
             socket: KmsSocket::UNIX(socket),
+            _state_dir: state_dir,
         }
     }
 
     /// Create a config file for a TCP KMS and return its path
-    fn create_tcp_config(port: u16, key_type: &KeyType) -> NamedTempFile {
+    fn create_tcp_config(port: u16, key_type: &KeyType, state_dir: &TempDir) -> NamedTempFile {
         let mut config_file = NamedTempFile::new().unwrap();
         let pub_key = test_ed25519_signing_keypair().verifying_key();
         let peer_id = PublicKey::from(pub_key).peer_id();
+        let state_path = state_dir.path().join("state.json").display().to_string();
 
         writeln!(
             config_file,
@@ -131,6 +140,7 @@ impl KmsProcess {
             [[chain]]
             id = "test_chain_id"
             key_format = {{ type = "bech32", account_key_prefix = "cosmospub", consensus_key_prefix = "cosmosvalconspub" }}
+            state_file = "{state_path}"
 
             [[validator]]
             addr = "tcp://{}@127.0.0.1:{}"
@@ -152,15 +162,17 @@ impl KmsProcess {
     }
 
     /// Create a config file for a UNIX KMS and return its path
-    fn create_unix_config(socket_path: &str, key_type: &KeyType) -> NamedTempFile {
+    fn create_unix_config(socket_path: &str, key_type: &KeyType, state_dir: &TempDir) -> NamedTempFile {
         let mut config_file = NamedTempFile::new().unwrap();
         let key_path = signing_key_path(key_type);
+        let state_path = state_dir.path().join("state.json").display().to_string();
         writeln!(
             config_file,
             r#"
             [[chain]]
             id = "test_chain_id"
             key_format = {{ type = "bech32", account_key_prefix = "cosmospub", consensus_key_prefix = "cosmosvalconspub" }}
+            state_file = "{state_path}"
 
             [[validator]]
             addr = "unix://{socket_path}"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -162,7 +162,11 @@ impl KmsProcess {
     }
 
     /// Create a config file for a UNIX KMS and return its path
-    fn create_unix_config(socket_path: &str, key_type: &KeyType, state_dir: &TempDir) -> NamedTempFile {
+    fn create_unix_config(
+        socket_path: &str,
+        key_type: &KeyType,
+        state_dir: &TempDir,
+    ) -> NamedTempFile {
         let mut config_file = NamedTempFile::new().unwrap();
         let key_path = signing_key_path(key_type);
         let state_path = state_dir.path().join("state.json").display().to_string();

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -9,7 +9,11 @@
 #
 # - id: The chain ID for this chain
 # - key_format: How this chain handles serialization. Type may be "bech32", "cosmos-json" or "hex"
-# - state_file (optional): path to where the state of the last signing operation is persisted
+# - state_file (optional): path to where the state of the last signing operation is persisted.
+#   Written durably before each signature: the contents are fsynced and the parent directory is
+#   fsynced after the atomic rename. The directory must therefore be readable by the tmkms user
+#   and live on a filesystem that supports fsync on a directory handle; signing fails closed if
+#   it does not.
 # - state_hook (optional): user-specified command to run on startup to obtain the current height
 #   of this chain. The command should output JSON which looks like the following:
 #   {"latest_block_height": "347290"}


### PR DESCRIPTION
## Summary

The double-signing protection state was persisted with a temp-file + rename that never fsyncs — neither the file contents before the rename nor the parent directory after it. A crash or power loss after a signature has been returned to the validator can therefore revert the state file to an older height/round/step, and on restart the KMS may sign a conflicting vote at the same HRS (equivocation → slashing).

The persist-before-sign ordering in `session.rs` was already correct; this closes the durability half of the guarantee:

- contents are fsynced before the atomic rename, and the parent directory is fsynced after it (the standard durable-replace recipe);
- on macOS this comes out as `fcntl(F_FULLFSYNC)` for free, since Rust's `sync_all()` issues it on Apple targets;
- a bare relative state path (the default when `state_file` is unset — `<chain_id>_priv_validator_state.json`) resolves its parent to the current directory instead of failing.

Reported in gnolang/gno#5915, originating from a security audit of tmkms.

## Changes

- Extract the write into an `atomic_durable_write` helper with fsync of file and directory, plus contract tests — 4ebe132 (https://github.com/aeddi/tmkms/commit/4ebe1328a3ac4edab8979649edb9750f01528a1f)
- Give each KMS process spawned by the integration tests its own `state_file` (they previously all raced on one shared default-path file in the repo root; the slower durable writes turned that latent race into real flakes) — 885f44a (https://github.com/aeddi/tmkms/commit/885f44a43ac9e693007e0929cc86205d98e6445e)

## Testing

- New unit tests cover the helper's contract (create, replace, no stray temp files, bare-relative paths, missing-parent error). The durability property itself isn't observable from an in-process test; the fsync recipe follows the analysis in the linked issue.
- Full suite green; integration suite run 30× consecutively without a failure after the state-file isolation (previously ~50% flaky with the durable writes in place).

Note for reviewers: this adds two fsyncs per signature on the hot path (on macOS, `F_FULLFSYNC`). That's the cost of the state file actually providing its guarantee, but flagging it in case you want it measured on specific deployment targets.